### PR TITLE
Fix typos in example of eachInclude inside README

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ Because CSS have nested structure, PostCSS also contains recursive iterator
 
 ```js
 root.eachInside(function (node, i) {
-    console.log(node.type ' inside ' + parent.type);
+    console.log(node.type + ' inside ' + node.parent.type);
 });
 ```
 


### PR DESCRIPTION
Hello,

I have fixed a couple of typos in example of eachInclude inside `README.md` (issue #38).

Best regards,
Denis
