### PR TITLE
Fix: `options.annotation` should be relative to `options.to`

### DIFF
--- a/lib/map-generator.coffee
+++ b/lib/map-generator.coffee
@@ -107,12 +107,9 @@ class MapGenerator
 
   # Return path relative from output CSS file
   relative: (file) ->
-    from = if typeof(@mapOpts.annotation) == 'string'
-      path.dirname(@mapOpts.annotation)
-    else if @opts.to
-      path.dirname(@opts.to)
-    else
-      '.'
+    from = if @opts.to then path.dirname(@opts.to) else '.'
+    if typeof(@mapOpts.annotation) == 'string'
+      from = path.dirname(path.resolve(from, @mapOpts.annotation))
     file = path.relative(from, file)
     file = file.replace('\\', '/') if path.sep == '\\'
     file

--- a/test/map.coffee
+++ b/test/map.coffee
@@ -110,18 +110,25 @@ describe 'source maps', ->
 
     step2.css.should.eql(css)
 
-  it 'uses user path in annotation', ->
+  it 'uses user path in annotation, relative to `options.to`', ->
+    # source/
+    #   a.css
+    # build/
+    #   b.css
+    #   maps/
+    #     b.map
+    #
     result = postcss().process 'a { }',
-      from: 'a.css'
-      to:   'b.css'
+      from: 'source/a.css'
+      to:   'build/b.css'
       map:
-        annotation: 'build/b.map'
+        annotation: 'maps/b.map'
 
-    result.css.should.eql "a { }\n/*# sourceMappingURL=build/b.map */"
+    result.css.should.eql "a { }\n/*# sourceMappingURL=maps/b.map */"
 
     map = consumer(result.map)
     map.file.should.eql('../b.css')
-    map.originalPositionFor(line: 1, column: 0).source.should.eql '../a.css'
+    map.originalPositionFor(line: 1, column: 0).source.should.eql '../../source/a.css'
 
   it 'generates inline map', ->
     css = 'a { }'


### PR DESCRIPTION
If `options.annotation` is set to a path, that string is inserted
after "sourceMappingURL=". That means that the path will be relative to
the output CSS file -- in other words, relative to `options.to`.
