### PR TITLE
Fix relative paths from previous source maps

### DIFF
--- a/lib/map-generator.coffee
+++ b/lib/map-generator.coffee
@@ -56,7 +56,8 @@ class MapGenerator
   # Apply source map from previous compilation step (like Sass)
   applyPrevMaps: ->
     for prev in @previous()
-      from = @relative(prev.file)
+      from = prev.file
+      relativeTo = prev.sourcesRelativeTo || path.dirname(from)
 
       if @mapOpts.sourcesContent == false
         map = new mozilla.SourceMapConsumer(prev.text)
@@ -64,7 +65,7 @@ class MapGenerator
       else
         map = prev.consumer()
 
-      @map.applySourceMap(map, from, from.replace(/(^|\/)[^\/]+$/, ''))
+      @map.applySourceMap(map, @relative(from), @relative(relativeTo))
 
   # Should we add annotation comment
   isAnnotation: ->

--- a/lib/previous-map.coffee
+++ b/lib/previous-map.coffee
@@ -73,6 +73,7 @@ class PreviousMap
     else if @annotation
       map = @annotation.replace('# sourceMappingURL=', '')
       map = path.join(path.dirname(@file), map) if @file
+      @sourcesRelativeTo = path.dirname(map)
       fs.readFileSync(map).toString() if fs.existsSync?(map)
 
 module.exports = PreviousMap

--- a/test/map.coffee
+++ b/test/map.coffee
@@ -251,6 +251,42 @@ describe 'source maps', ->
     consumer(step3.map)
       .originalPositionFor(line: 1, column: 0).source.should.eql '../../a.css'
 
+  it 'uses map from subdir - inlined', ->
+    step1 = @doubler.process 'a { }',
+      from: 'a.css'
+      to:   'out/b.css'
+      map:
+        inline: true
+
+    step2 = @doubler.process step1.css,
+      from: 'out/b.css'
+      to:   'out/two/c.css'
+      map:
+        inline: false
+
+    consumer(step2.map)
+      .originalPositionFor(line: 1, column: 0).source.should.eql '../../a.css'
+
+  it 'uses map from subdir - written as a file', ->
+    step1 = @doubler.process 'a { }',
+      from: 'source/a.css'
+      to:   'one/b.css'
+      map:
+        annotation: 'maps/b.css.map'
+
+    consumer(step1.map)
+      .originalPositionFor(line: 1, column: 0).source.should.eql '../../source/a.css'
+
+    fs.outputFileSync(@dir + '/one/maps/b.css.map', step1.map)
+
+    step2 = @doubler.process step1.css,
+      from: @dir + '/one/b.css'
+      to:   @dir + '/two/c.css'
+      map:  true
+
+    consumer(step2.map)
+      .originalPositionFor(line: 1, column: 0).source.should.eql '../source/a.css'
+
   it 'works with different types of maps', ->
     step1 = @doubler.process('a { }', from: 'a.css', to: 'b.css', map: true)
 


### PR DESCRIPTION
Before, all previous source maps were assumed to be located inside or
next its corresponding file. However, it could be saved in a different
directory. If so, all relative source paths in the previous source maps
must be rewritten according to _that_ directory.
