### PR TITLE
Sometimes, prev.mappings can be an empty string

### DIFF
--- a/lib/previous-map.js
+++ b/lib/previous-map.js
@@ -76,7 +76,7 @@ class PreviousMap {
                     .fromSourceMap(prev).toString();
             } else if ( prev instanceof mozilla.SourceMapGenerator ) {
                 return prev.toString();
-            } else if ( typeof(prev) == 'object' && prev.mappings ) {
+            } else if ( typeof(prev) == 'object' && (typeof(prev.mappings) == 'string') ) {
                 return JSON.stringify(prev);
             } else {
                 throw new Error('Unsupported previous source map format: ' +


### PR DESCRIPTION
Better to check that `prev.mappings` is a string than check that `prev.mappings` is not _false_.
