### PR TITLE
Add postcss-color-gray to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Sponsored by [Evil Martians](http://evilmartians.com/).
   (recommanded with `postcss-custom-properties`).
 * [postcss-color] to transform latest W3C CSS color module syntax
   to more compatible CSS.
+* [postcss-color-gray] to transform `gray()` function 
+  to more compatible CSS.
 * [postcss-import] to transform @import rules by inlining content.
 * [postcss-custom-media] to transform W3C CSS Custom Media Queries
   to more compatible CSS.
@@ -71,6 +73,7 @@ Sponsored by [Evil Martians](http://evilmartians.com/).
 
 [postcss-calc]:              https://github.com/postcss/postcss-calc
 [postcss-color]:             https://github.com/postcss/postcss-color
+[postcss-color-gray]:        https://github.com/postcss/postcss-color-gray
 [postcss-import]:            https://github.com/postcss/postcss-import
 [postcss-custom-media]:      https://github.com/postcss/postcss-custom-media
 [postcss-custom-properties]: https://github.com/postcss/postcss-custom-properties


### PR DESCRIPTION
I created [postcss-color-gray](https://github.com/shinnn/postcss-color-gray) plugin which transforms CSS4 [gray()](http://dev.w3.org/csswg/css-color/#grays) function to more compatible CSS.

It's OK to move the repo to this accout like other postcss-color-\* plugins :)
