### PR TITLE
Fix postcss-color-* references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,26 +58,27 @@ Sponsored by [Evil Martians](http://evilmartians.com/).
 
 ### Plugins
 
-* [postcss-calc] to reduce `calc()` usage
-  (recommanded with `postcss-custom-properties`).
-* [postcss-color] to transform latest W3C CSS color module syntax
-  to more compatible CSS.
-* [postcss-color-gray] to transform `gray()` function 
-  to more compatible CSS.
+* [postcss-calc] to reduce `calc()` usage (recommanded with `postcss-custom-properties`).
+* [postcss-color-function] to transform W3C CSS `color()` function to more compatible CSS.
+* [postcss-color-gray] to transform W3C CSS `gray()` function to more compatible CSS.
+* [postcss-color-hex-alpha] to transform W3C CSS RGBA hexadecimal notations (#RRGGBBAA or #RGBA) to more compatible CSS.
+* [postcss-color-hwb] to transform W3C CSS hwb() function to more compatible CSS.
+* [postcss-color-rebeccapurple] to transform W3C CSS rebeccapurple color to more compatible CSS.
 * [postcss-import] to transform @import rules by inlining content.
-* [postcss-custom-media] to transform W3C CSS Custom Media Queries
-  to more compatible CSS.
-* [postcss-custom-properties] to transform W3C CSS Custom Properties
-  for cascading variables to more compatible CSS.
+* [postcss-custom-media] to transform W3C CSS Custom Media Queries to more compatible CSS.
+* [postcss-custom-properties] to transform W3C CSS Custom Properties for cascading variables to more compatible CSS.
 * [postcss-url] to rebase or inline on `url()`.
 
-[postcss-calc]:              https://github.com/postcss/postcss-calc
-[postcss-color]:             https://github.com/postcss/postcss-color
-[postcss-color-gray]:        https://github.com/postcss/postcss-color-gray
-[postcss-import]:            https://github.com/postcss/postcss-import
-[postcss-custom-media]:      https://github.com/postcss/postcss-custom-media
-[postcss-custom-properties]: https://github.com/postcss/postcss-custom-properties
-[postcss-url]:               https://github.com/postcss/postcss-url
+[postcss-calc]:                 https://github.com/postcss/postcss-calc
+[postcss-color-function]:       https://github.com/postcss/postcss-color-function
+[postcss-color-gray]:           https://github.com/postcss/postcss-color-gray
+[postcss-color-hex]:            https://github.com/postcss/postcss-color-hex
+[postcss-color-hwb]:            https://github.com/postcss/postcss-color-hwb
+[postcss-color-rebeccapurple]:  https://github.com/postcss/postcss-color-rebeccapurple
+[postcss-import]:               https://github.com/postcss/postcss-import
+[postcss-custom-media]:         https://github.com/postcss/postcss-custom-media
+[postcss-custom-properties]:    https://github.com/postcss/postcss-custom-properties
+[postcss-url]:                  https://github.com/postcss/postcss-url
 
 
 ## Quick Example


### PR DESCRIPTION
Update & fix references to postcss-color (this plugin is deprecated & has been exploded into *-(function|hwb|hex-alpha|rebeccapurple).
Also I've keep plugins on one line, even if some lines lengths are greater than 80 chars. Easier to maintain imo.
