### PR TITLE
Safer way for PostCSS to consume PostCSS object as plugin

### DIFF
--- a/lib/postcss.js
+++ b/lib/postcss.js
@@ -14,7 +14,7 @@ class PostCSS {
     // Add another function to CSS processors
     use(processor) {
         processor = this.normalize(processor);
-        if ( processor instanceof PostCSS) {
+        if (processor instanceof PostCSS || (typeof processor === "object" && Array.isArray(processor.processors))) {
             this.processors = this.processors.concat(processor.processors);
         } else {
             this.processors.push(processor);


### PR DESCRIPTION
Because project like grunt are doing some shitty cloning for option,
the test ìnstanceof PostCSS`can return false, even if the object has
been cloned from a PostCSS instance.
To avoid this, we need to tolerate object that have array`processors`.

Ref https://github.com/nDmitry/grunt-postcss/issues/8
