### PR TITLE
Add postcss-single-charset plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Weibo account: [postcss].
 * [postcss-data-packer] to move an embedded data into a separate file.
 * [postcss-color-palette] to transform CSS2 color keywords to a custom palette.
 * [postcss-color-hex] to transform rgb() and rgba() to hex.
+* [postcss-single-charset] to pop first `@charset` rule.
 
 [postcss-calc]:                 https://github.com/postcss/postcss-calc
 [postcss-color-function]:       https://github.com/postcss/postcss-color-function
@@ -118,6 +119,7 @@ Weibo account: [postcss].
 [postcss-data-packer]:          https://github.com/Ser-Gen/postcss-data-packer
 [postcss-color-palette]:        https://github.com/zaim/postcss-color-palette
 [postcss-color-hex]:            https://github.com/TrySound/postcss-color-hex
+[postcss-single-charset]:       https://github.com/hail2u/postcss-single-charset
 
 ## Quick Example
 


### PR DESCRIPTION
[postcss-single-charset][1] is for popping first `@charset` rule to the top of CSS file. This plugin is for fixing wrong `@charset` rule position after concatenate CSS files.

[1]: https://github.com/hail2u/postcss-single-charset