### PR TITLE
Add standalone build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 
 origin.css
 fail.css
+postcss.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,9 @@ var fs   = require('fs-extra');
 // Build
 
 gulp.task('build:clean', function (done) {
-    fs.remove(__dirname + '/build', done);
+    fs.remove(__dirname + '/postcss.js', function () {
+        fs.remove(__dirname + '/build', done);
+    });
 });
 
 gulp.task('build:lib', ['build:clean'], function () {
@@ -39,6 +41,25 @@ gulp.task('build:package', ['build:clean'], function () {
 });
 
 gulp.task('build', ['build:lib', 'build:docs', 'build:package']);
+
+gulp.task('standalone', ['build:lib'], function (done) {
+    var builder    = require('browserify')({
+        basedir:     __dirname + '/build/',
+        standalone: 'postcss'
+    });
+    builder.add('./lib/postcss.js');
+
+    var output = fs.createWriteStream(__dirname + '/postcss.js');
+    builder.bundle(function (error, build) {
+        if ( error ) {
+            process.stderr.write(error.toString() + "\n");
+            process.exit(1);
+        }
+
+        fs.removeSync(__dirname + '/build/');
+        fs.writeFile(__dirname + '/postcss.js', build, done);
+    });
+});
 
 // Lint
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "jshint-stylish":         "1.0.0",
         "gulp-jshint":            "1.9.2",
         "gonzales-pe":            "3.0.0-26",
+        "browserify":             "8.1.3",
         "gulp-babel":             "4.0.0",
         "gulp-bench":             "1.1.0",
         "gulp-mocha":             "2.0.0",


### PR DESCRIPTION
This adds a standalone build much like what is present in [postcss/autoprefixer-core][apc]. This will allow us to more easily integrate postcss support into [OpenNTF/JavascriptAggregator][jaggr].

My employer wishes to express that this is intended for release under the MIT license. :shipit: 

[apc]: https://github.com/postcss/autoprefixer-core "autoprefixer-core"
[jaggr]: https://github.com/OpenNTF/JavascriptAggregator "JavascriptAggregator"