### PR TITLE
6to5 -> babel in build:package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,8 +33,8 @@ gulp.task('build:package', ['build:clean'], function () {
     gulp.src('./package.json')
         .pipe(editor(function (json) {
             json.main = 'lib/postcss';
-            json.devDependencies['babel'] = json.dependencies['babel'];
-            delete json.dependencies['babel'];
+            json.devDependencies.babel = json.dependencies.babel;
+            delete json.dependencies.babel;
             return json;
         }))
         .pipe(gulp.dest('build'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,8 +33,8 @@ gulp.task('build:package', ['build:clean'], function () {
     gulp.src('./package.json')
         .pipe(editor(function (json) {
             json.main = 'lib/postcss';
-            json.devDependencies['6to5'] = json.dependencies['6to5'];
-            delete json.dependencies['6to5'];
+            json.devDependencies['babel'] = json.dependencies['babel'];
+            delete json.dependencies['babel'];
             return json;
         }))
         .pipe(gulp.dest('build'));


### PR DESCRIPTION
Update the build gulp task to reflect 6to5's new name so it doesn't get pulled as dep in npm installs.