### PR TITLE
Sets prev to false when it is 'falsy'

### DIFF
--- a/lib/previous-map.js
+++ b/lib/previous-map.js
@@ -58,6 +58,8 @@ export default class PreviousMap {
 
     // Load previous map
     loadMap(file, prev) {
+
+        prev = prev || false;
         if ( prev === false ) return;
 
         if ( prev ) {


### PR DESCRIPTION
When using gulp-autoprefixer, I somehow managed to get a corrupt sourcemap (or something), when switching between branches which, when reaching to the line 61 (current master state)

```javascript
if ( prev === false ) return;
```

prev was _undefined_, which then would try to _JSON.parse_ it and would throw a SyntaxError saying:

```
SyntaxError: unexpected token /
```

... Problem was solved by removing the node_modules package and re-do ```npm install```... which suggests, at least, a cache problem.