### PR TITLE
Clarify how to import `vendor` module

### DIFF
--- a/API.md
+++ b/API.md
@@ -246,6 +246,10 @@ if ( result.map ) {
 
 Contains helpers for working with vendor prefixes.
 
+```js
+var vendor = require('postcss/lib/vendor');
+```
+
 ### `vendor.prefix(string)`
 
 Returns the vendor prefix extracted from an input string.


### PR DESCRIPTION
As far as I know, `vendor` module should import before using it.