### PR TITLE
Unhandled exception if previous source map is missing sourcesContent

### DIFF
--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -107,7 +107,9 @@ export default class MapGenerator {
 
             if ( this.mapOpts.sourcesContent === false ) {
                 map = new mozilla.SourceMapConsumer(prev.text);
-                map.sourcesContent = map.sourcesContent.map( i => null );
+                if ( map.sourcesContent ) {
+                    map.sourcesContent = map.sourcesContent.map( i => null );
+                }
             } else {
                 map = prev.consumer();
             }


### PR DESCRIPTION
Hello postcss developers,

I came across an issue using Autoprefixer on CSS files with source maps generated by Less.js which caused an unhandled `TypeError: Cannot call method 'map' of null` to be thrown.  The issue can be reproduced using the following code (with autoprefixer-core 5.1.7 and less 2.4.0):

```javascript
less.render(".flexy { display: flex; }", {sourceMap: {}})
  .then(function(lessOutput) {
    var autoprefixerOutput = autoprefixer().process(
        lessOutput.css,
        {
          map: {
            prev: lessOutput.map,
            sourcesContent: false
          }
        }
    );

    try {
      console.log(autoprefixerOutput.css);
    } catch (err) {
      console.error(err);
      console.error(err.stack);
    }
  });
```

The issue appears to be that when the `sourcesContent` option is `false`, the attempt to remove any source content from the previous source map does not consider the case that `sourcesContent` may be `null`.  This PR just adds a null check, which maintains the same lack of a `sourcesContent` property in the output source map.

I hope you find it useful,
Kevin