### PR TITLE
Parse spaces & comments inside important. Fixes #253.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -229,7 +229,17 @@ export default class Parser {
                 string = this.spacesFromEnd(tokens) + string;
                 if ( string !== ' !important' ) node._important = string;
                 break;
-            } else if ( token[0] !== 'space' && token[0] !== 'comment' ) {
+            } else if (token[1] === 'important') {
+                let tokensCache = tokens.slice(0);
+                let important = this.stringTo(tokensCache, i, '!');
+                if (important.trim().indexOf('!') === 0) {
+                    node.important = true;
+                    node._important = important;
+                    tokens = tokensCache.slice(0);
+                }
+            }
+
+            if ( token[0] !== 'space' && token[0] !== 'comment' ) {
                 break;
             }
         }
@@ -462,6 +472,16 @@ export default class Parser {
             result += tokens[i][1];
         }
         tokens.splice(from, tokens.length - from);
+        return result;
+    }
+
+    stringTo(tokens, from, to) {
+        let result = '';
+
+        for ( let i = from; i > 0; i-- ) {
+            if (result.trim().indexOf(to) === 0 && tokens[i][0] !== 'space') break;
+            result = tokens.pop()[1] + result;
+        }
         return result;
     }
 }

--- a/test/cases/important.css
+++ b/test/cases/important.css
@@ -2,3 +2,12 @@ a {
     width: 1px!important;
     color: black  !important ;
 }
+
+p {
+    prop: important;
+    color: red important;
+    margin: 10px      !      important;
+    padding: 20px     !  /* test */   important;
+    width: 100px ! /*! test */ important;
+    height: 100px /*! test */ important;
+}

--- a/test/cases/important.json
+++ b/test/cases/important.json
@@ -12,7 +12,7 @@
                             "column": 5
                         },
                         "input": {
-                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n",
+                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
                             "safe": false,
                             "file": "/important.css",
                             "from": "/important.css"
@@ -37,7 +37,7 @@
                             "column": 5
                         },
                         "input": {
-                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n",
+                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
                             "safe": false,
                             "file": "/important.css",
                             "from": "/important.css"
@@ -61,7 +61,7 @@
                     "column": 1
                 },
                 "input": {
-                    "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n",
+                    "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
                     "safe": false,
                     "file": "/important.css",
                     "from": "/important.css"
@@ -76,11 +76,185 @@
             "selector": "a",
             "semicolon": true,
             "after": "\n"
+        },
+        {
+            "type": "rule",
+            "nodes": [
+                {
+                    "type": "decl",
+                    "source": {
+                        "start": {
+                            "line": 7,
+                            "column": 5
+                        },
+                        "input": {
+                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
+                            "safe": false,
+                            "file": "/important.css",
+                            "from": "/important.css"
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 20
+                        }
+                    },
+                    "before": "\n    ",
+                    "prop": "prop",
+                    "between": ": ",
+                    "value": "important"
+                },
+                {
+                    "type": "decl",
+                    "source": {
+                        "start": {
+                            "line": 8,
+                            "column": 5
+                        },
+                        "input": {
+                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
+                            "safe": false,
+                            "file": "/important.css",
+                            "from": "/important.css"
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 25
+                        }
+                    },
+                    "before": "\n    ",
+                    "prop": "color",
+                    "between": ": ",
+                    "value": "red important"
+                },
+                {
+                    "type": "decl",
+                    "source": {
+                        "start": {
+                            "line": 9,
+                            "column": 5
+                        },
+                        "input": {
+                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
+                            "safe": false,
+                            "file": "/important.css",
+                            "from": "/important.css"
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 39
+                        }
+                    },
+                    "before": "\n    ",
+                    "prop": "margin",
+                    "between": ": ",
+                    "important": true,
+                    "_important": "      !      important",
+                    "value": "10px"
+                },
+                {
+                    "type": "decl",
+                    "source": {
+                        "start": {
+                            "line": 10,
+                            "column": 5
+                        },
+                        "input": {
+                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
+                            "safe": false,
+                            "file": "/important.css",
+                            "from": "/important.css"
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 48
+                        }
+                    },
+                    "before": "\n    ",
+                    "prop": "padding",
+                    "between": ": ",
+                    "important": true,
+                    "_important": "     !  /* test */   important",
+                    "value": "20px"
+                },
+                {
+                    "type": "decl",
+                    "source": {
+                        "start": {
+                            "line": 11,
+                            "column": 5
+                        },
+                        "input": {
+                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
+                            "safe": false,
+                            "file": "/important.css",
+                            "from": "/important.css"
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 41
+                        }
+                    },
+                    "before": "\n    ",
+                    "prop": "width",
+                    "between": ": ",
+                    "important": true,
+                    "_important": " ! /*! test */ important",
+                    "value": "100px"
+                },
+                {
+                    "type": "decl",
+                    "source": {
+                        "start": {
+                            "line": 12,
+                            "column": 5
+                        },
+                        "input": {
+                            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
+                            "safe": false,
+                            "file": "/important.css",
+                            "from": "/important.css"
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 40
+                        }
+                    },
+                    "before": "\n    ",
+                    "prop": "height",
+                    "between": ": ",
+                    "_value": {
+                        "value": "100px  important",
+                        "raw": "100px /*! test */ important"
+                    },
+                    "value": "100px  important"
+                }
+            ],
+            "source": {
+                "start": {
+                    "line": 6,
+                    "column": 1
+                },
+                "input": {
+                    "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
+                    "safe": false,
+                    "file": "/important.css",
+                    "from": "/important.css"
+                },
+                "end": {
+                    "line": 13,
+                    "column": 1
+                }
+            },
+            "before": "\n\n",
+            "between": " ",
+            "selector": "p",
+            "semicolon": true,
+            "after": "\n"
         }
     ],
     "source": {
         "input": {
-            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n",
+            "css": "a {\n    width: 1px!important;\n    color: black  !important ;\n}\n\np {\n    prop: important;\n    color: red important;\n    margin: 10px      !      important;\n    padding: 20px     !  /* test */   important;\n    width: 100px ! /*! test */ important;\n    height: 100px /*! test */ important;\n}\n",
             "safe": false,
             "file": "/important.css",
             "from": "/important.css"


### PR DESCRIPTION
So now we can parse a declaration such as this correctly:

```css
h1 {
    color: black      !    /* test comment */   important;
}
```