### PR TITLE
Helpful error message for when adding to containers

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -411,6 +411,9 @@ export default class Container extends Node {
             } else if ( nodes.type ) {
                 nodes = [nodes];
             } else if ( nodes.prop ) {
+                if (nodes.value === undefined) {
+                    throw this.error("Could not construct declaration; 'value' field unspecified.");
+                }
                 nodes = [new Declaration(nodes)];
             } else if ( nodes.selector ) {
                 import Rule from './rule';
@@ -420,6 +423,8 @@ export default class Container extends Node {
                 nodes = [new AtRule(nodes)];
             } else if ( nodes.text ) {
                 nodes = [new Comment(nodes)];
+            } else {
+                throw this.error("Could not infer node type. Try checking your field names?");
             }
         }
 

--- a/test/container.js
+++ b/test/container.js
@@ -3,6 +3,7 @@ import Container   from '../lib/container';
 import parse       from '../lib/parse';
 import Rule        from '../lib/rule';
 import Root        from '../lib/root';
+import postcss     from '../lib/postcss';
 
 import { expect } from 'chai';
 
@@ -21,6 +22,15 @@ var example = 'a { a: 1; b: 2 }' +
               '}';
 
 describe('Container', () => {
+
+    describe('error', () => {
+       it('throws error when adding declaration with unspecified value', () => {
+           expect(() => {
+              var rule = postcss.rule();
+              rule.append({prop: 'color', vlaue: 'black' });
+           }).to.throw(Error, /'value' field unspecified/);
+       });
+    });
 
     describe('push()', () => {
 

--- a/test/container.js
+++ b/test/container.js
@@ -30,6 +30,13 @@ describe('Container', () => {
               rule.append({prop: 'color', vlaue: 'black' });
            }).to.throw(Error, /'value' field unspecified/);
        });
+
+       it('throws error when adding an object whose type cannot be determined', () => {
+           expect(() => {
+              var rule = postcss.rule();
+              rule.append({ foo: 'bar' });
+           }).to.throw(Error, /Could not infer node type./);
+       });
     });
 
     describe('push()', () => {


### PR DESCRIPTION
Hello!

I think it might be helpful to provide the developer with a nice error message when a declaration is attempted to be added to a container like so:

```
rule.append({
   prop: 'transform',
   vlaue: 'translate(-50%, -50%)'
});
```

In this case, the developer has incorrectly specified the value of the rule under something other than 'value' key. Currently the error message is:

```Cannot call method 'indexOf' of undefined```

with no discernible source or traceback (at least through Grunt). 

This patch adds some nicer diagnostics, including what I hope to be a more helpful error message:

```Could not construct declaration; 'value' field unspecified.```, 

as well as an additional check for the `prop` key. 

Corresponding tests for the test suite are included.