### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,9 +404,9 @@ var processor = postcss([require('cssnext'), require('cssgrace')]);
 processor
   .process(css, { from: 'app.css', to: 'app.out.css' })
   .then(function (result) {
-      fs.fileWriteSync('app.out.css', result.css);
+      fs.writeFileSync('app.out.css', result.css);
       if ( result.map ) {
-          fs.fileWriteSync('app.out.css.map', result.map);
+          fs.writeFileSync('app.out.css.map', result.map);
       }
   });
 ```


### PR DESCRIPTION
fs.fileWriteSync is not part of the Node fs API, so change it to the correct function name.

I had a weird copy-paste error from this!