### PR TITLE
Add postcss-css-variables plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ on different parts of CSS.
 * [`postcss-custom-media`] supports custom aliases for media queries.
 * [`postcss-custom-properties`] supports variables, using syntax from
   the W3C Custom Properties.
+* [`postcss-css-variables`] supports variables for descendant/nested rules and at-rules
 * [`postcss-custom-selectors`] adds custom aliases for selectors.
 * [`postcss-font-variant`] transpiles human-readable `font-variant` to more
   widely supported CSS.
@@ -305,6 +306,7 @@ on different parts of CSS.
 [`postcss-discard-empty`]:       https://github.com/ben-eb/postcss-discard-empty
 [`postcss-reduce-idents`]:       https://github.com/ben-eb/postcss-reduce-idents
 [`postcss-simple-extend`]:       https://github.com/davidtheclark/postcss-simple-extend
+[`postcss-css-variables`]:       https://github.com/MadLittleMods/postcss-css-variables
 [`postcss-selector-not`]:        https://github.com/postcss/postcss-selector-not
 [`postcss-default-unit`]:        https://github.com/antyakushev/postcss-default-unit
 [`postcss-media-minmax`]:        https://github.com/postcss/postcss-media-minmax


### PR DESCRIPTION
[`postcss-css-variables`](https://github.com/MadLittleMods/postcss-css-variables) transforms [CSS Custom Property syntax(CSS variables)](http://dev.w3.org/csswg/css-variables/) into static representation that can be used today.

[Try it out on the code playground](http://localhost/random/postcss-test1/node_modules/postcss-css-variables/playground/) or checkout the [usage section in the readme](https://github.com/MadLittleMods/postcss-css-variables#usage).

It works out the proper variable scope for descendant or nested rules/selectors to assign the associated value.

It also works with `@rules` such as media queries and updates any property that references the variable when the media query is active.

