### PR TITLE
Allow double underscores in prop names

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -209,7 +209,7 @@ export default class Parser {
             }
         }
 
-        if ( node.prop[0] === '_' || node.prop[0] === '*' ) {
+        if ( (node.prop[0] === '_' && node.prop[1] !== '_') || node.prop[0] === '*' ) {
             node.before += node.prop[0];
             node.prop    = node.prop.slice(1);
         }

--- a/test/cases/prop-hacks.css
+++ b/test/cases/prop-hacks.css
@@ -2,4 +2,5 @@ a {
     *color : black;
     _background: white;
     font-size/**/: big;
+    __custom: var;
 }

--- a/test/cases/prop-hacks.json
+++ b/test/cases/prop-hacks.json
@@ -10,7 +10,7 @@
                             "column": 5
                         },
                         "input": {
-                            "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n}\n",
+                            "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n    __custom: var;\n}\n",
                             "safe": false,
                             "file": "/prop-hacks.css",
                             "from": "/prop-hacks.css"
@@ -33,7 +33,7 @@
                             "column": 5
                         },
                         "input": {
-                            "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n}\n",
+                            "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n    __custom: var;\n}\n",
                             "safe": false,
                             "file": "/prop-hacks.css",
                             "from": "/prop-hacks.css"
@@ -56,7 +56,7 @@
                             "column": 5
                         },
                         "input": {
-                            "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n}\n",
+                            "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n    __custom: var;\n}\n",
                             "safe": false,
                             "file": "/prop-hacks.css",
                             "from": "/prop-hacks.css"
@@ -70,6 +70,29 @@
                     "prop": "font-size",
                     "between": "/**/: ",
                     "value": "big"
+                },
+                {
+                    "type": "decl",
+                    "source": {
+                        "start": {
+                            "line": 5,
+                            "column": 5
+                        },
+                        "input": {
+                            "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n    __custom: var;\n}\n",
+                            "safe": false,
+                            "file": "/prop-hacks.css",
+                            "from": "/prop-hacks.css"
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 18
+                        }
+                    },
+                    "before": "\n    ",
+                    "prop": "__custom",
+                    "between": ": ",
+                    "value": "var"
                 }
             ],
             "type": "rule",
@@ -79,13 +102,13 @@
                     "column": 1
                 },
                 "input": {
-                    "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n}\n",
+                    "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n    __custom: var;\n}\n",
                     "safe": false,
                     "file": "/prop-hacks.css",
                     "from": "/prop-hacks.css"
                 },
                 "end": {
-                    "line": 5,
+                    "line": 6,
                     "column": 1
                 }
             },
@@ -99,7 +122,7 @@
     "type": "root",
     "source": {
         "input": {
-            "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n}\n",
+            "css": "a {\n    *color : black;\n    _background: white;\n    font-size/**/: big;\n    __custom: var;\n}\n",
             "safe": false,
             "file": "/prop-hacks.css",
             "from": "/prop-hacks.css"

--- a/test/parse.js
+++ b/test/parse.js
@@ -199,6 +199,17 @@ describe('postcss.parse()', () => {
             let root = parse('a { one:: 1 }', { safe: true });
             expect(root.first.first.value).to.eql(': 1');
         });
+
+        it('preserves props with double underscore', () => {
+            let root = parse('a { __one: 1 }');
+            console.log(root.first.first)
+            expect(root.first.first.prop).to.eql('__one');
+        });
+
+        it('preserves props with double underscore in safe mode', () => {
+            let root = parse('a { __one: 1 }', { safe: true });
+            expect(root.first.first.prop).to.eql('__one');
+        });
     });
 
 });


### PR DESCRIPTION
In writing the spec for [CSSI](https://github.com/css-modules/css-modules/blob/master/INTERCHANGE_FORMAT.md), we wanted a convention to identify unlinked variables within a file. The convention we came up with was:

```css
:import("./dependency.css") {
  __localTemporaryName: exportedNameFromDependency;
}
```

The use of double-underscores is not essential to the spec by any means, but desirable from a readability standpoint. When attempting to parse this file with PostCSS, a property starting with a `_` is treated as an IE6 hack, and the `decl.prop` variable no longer matches what was written.

This PR simply only applies the IE6 hack logic if the *first* character is an underscore **but the second one isn't**. Tests are included to confirm the check is applying correctly.