### PR TITLE
Add adapters section + PostStylus link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,10 @@ See also plugins in modular minifier [`cssnano`].
 * [`postcss-canadian-stylesheets`] Canadian Style Sheets.
 * [`postcss-spiffing`] lets you use British English in your CSS.
 
+### Adapters
+
+* [`poststylus`] PostCSS adapter for Stylus output
+
 [`postcss-australian-stylesheets`]: https://github.com/dp-lewis/postcss-australian-stylesheets
 [`postcss-pseudo-class-any-link`]:  https://github.com/jonathantneal/postcss-pseudo-class-any-link
 [`postcss-canadian-stylesheets`]:   https://github.com/chancancode/postcss-canadian-stylesheets
@@ -406,6 +410,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-map`]:                    https://github.com/pascalduez/postcss-map
 [`postcss-for`]:                    https://github.com/antyakushev/postcss-for
 [`css-byebye`]:                     https://github.com/AoDev/css-byebye
+[`poststylus`]:                     https://github.com/seaneking/poststylus
 [`cssgrace`]:                       https://github.com/cssdream/cssgrace
 [`csswring`]:                       https://github.com/hail2u/node-csswring
 [`csstyle`]:                        https://github.com/geddski/csstyle


### PR DESCRIPTION
https://github.com/seaneking/poststylus

Feel free to reject this one if you feel it doesn't fit in the current PostCSS ecosystem, but I've made a little Stylus -> PostCSS adapter that I think would be handy for a lot of PostCSS converts. It loads an array of PostCSS plugins into Stylus' generated css, then passes the post-processed css back to Stylus for final compiling to file, similar to the way that [autoprefixer-stylus](https://github.com/jenius/autoprefixer-stylus) works.

Wasn't sure where this would fit in the readme, so added a new sub-section under plugins and put it there. Let me know if you want this changed (since I guess it's not technically a postcss plugin).

Use-case is people like me, who often still prefer to author stylesheets with a preprocessor like Stylus but want to move all the heavy-lifting/grunt-work utilities to PostCSS. 