### PR TITLE
Support multiple nodes on DOM4 API methods

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1036,19 +1036,15 @@ if ( decl.prop.match(/^-webkit-/) ) {
 }
 ```
 
-### `node.replaceWith(otherNode)`
+### `node.replaceWith(otherNodes...)`
 
-Inserts another node before the current node, and removes the current node.
+Inserts nodes before the current node, and removes the current node.
 
 ```js
 if ( atrule.name == 'mixin' ) {
     atrule.replaceWith(mixinRules[atrule.params]);
 }
 ```
-
-Arguments:
-
-* `otherNode: (Node)`: other node to replace current one.
 
 ### `node.clone(props)`
 
@@ -1412,13 +1408,19 @@ Arguments:
 
 [`String#replace`]: (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter)
 
-### `container.prepend(node)` and `container.append(node)`
+### `container.prepend(nodes...)` and `container.append(nodes...)`
 
-Insert a new node to the start/end of the container.
+Inserts new nodes to the start/end of the container.
 
 ```js
 var decl = postcss.decl({ prop: 'color', value: 'black' });
 rule.append(decl);
+```
+
+```js
+var decl1 = postcss.decl({ prop: 'color', value: 'black' });
+var decl2 = postcss.decl({ prop: 'background-color', value: 'white' });
+rule.prepend(decl1, decl2);
 ```
 
 Arguments:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1036,7 +1036,7 @@ if ( decl.prop.match(/^-webkit-/) ) {
 }
 ```
 
-### `node.replaceWith(otherNodes...)`
+### `node.replaceWith(...otherNodes)`
 
 Inserts nodes before the current node, and removes the current node.
 
@@ -1408,7 +1408,7 @@ Arguments:
 
 [`String#replace`]: (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter)
 
-### `container.prepend(nodes...)` and `container.append(nodes...)`
+### `container.prepend(...nodes)` and `container.append(...nodes)`
 
 Inserts new nodes to the start/end of the container.
 

--- a/lib/at-rule.js
+++ b/lib/at-rule.js
@@ -27,14 +27,14 @@ export default class AtRule extends Container {
         }
     }
 
-    append(child) {
+    append() {
         if ( !this.nodes ) this.nodes = [];
-        return super.append(child);
+        return super.append.apply(this, arguments);
     }
 
-    prepend(child) {
+    prepend() {
         if ( !this.nodes ) this.nodes = [];
-        return super.prepend(child);
+        return super.prepend.apply(this, arguments);
     }
 
     insertBefore(exist, add) {

--- a/lib/at-rule.js
+++ b/lib/at-rule.js
@@ -27,14 +27,14 @@ export default class AtRule extends Container {
         }
     }
 
-    append() {
+    append(...children) {
         if ( !this.nodes ) this.nodes = [];
-        return super.append.apply(this, arguments);
+        return super.append(...children);
     }
 
-    prepend() {
+    prepend(...children) {
         if ( !this.nodes ) this.nodes = [];
-        return super.prepend.apply(this, arguments);
+        return super.prepend(...children);
     }
 
     insertBefore(exist, add) {

--- a/lib/container.js
+++ b/lib/container.js
@@ -150,18 +150,35 @@ export default class Container extends Node {
         });
     }
 
-    append(child) {
-        let nodes = this.normalize(child, this.last);
-        for ( let node of nodes ) this.nodes.push(node);
+    append() {
+        for (let index in arguments) {
+            let nodes = this.normalize(arguments[index], this.last);
+
+            for (let node of nodes) {
+                this.nodes.push(node);
+            }
+        }
+
         return this;
     }
 
-    prepend(child) {
-        let nodes = this.normalize(child, this.first, 'prepend').reverse();
-        for ( let node of nodes ) this.nodes.unshift(node);
+    prepend() {
+        let args = Array.prototype.reverse.call(arguments);
 
-        for ( let id in this.indexes ) {
-            this.indexes[id] = this.indexes[id] + nodes.length;
+        for (let index in args) {
+            let nodes = this.normalize(
+                arguments[index],
+                this.first,
+                'prepend'
+            ).reverse();
+
+            for (let node of nodes) {
+                this.nodes.unshift(node);
+            }
+
+            for ( let id in this.indexes ) {
+                this.indexes[id] = this.indexes[id] + nodes.length;
+            }
         }
 
         return this;

--- a/lib/container.js
+++ b/lib/container.js
@@ -150,9 +150,9 @@ export default class Container extends Node {
         });
     }
 
-    append() {
-        for (let index in arguments) {
-            let nodes = this.normalize(arguments[index], this.last);
+    append(...children) {
+        for (let child of children) {
+            let nodes = this.normalize(child, this.last);
 
             for (let node of nodes) {
                 this.nodes.push(node);
@@ -162,12 +162,12 @@ export default class Container extends Node {
         return this;
     }
 
-    prepend() {
-        let args = Array.prototype.reverse.call(arguments);
+    prepend(...children) {
+        children = children.reverse();
 
-        for (let index in args) {
+        for (let child of children) {
             let nodes = this.normalize(
-                arguments[index],
+                child,
                 this.first,
                 'prepend'
             ).reverse();

--- a/lib/node.js
+++ b/lib/node.js
@@ -95,9 +95,15 @@ export default class {
         return cloned;
     }
 
-    replaceWith(node) {
-        this.parent.insertBefore(this, node);
-        this.removeSelf();
+    replaceWith() {
+        if (this.parent) {
+            for (let index in arguments) {
+                this.parent.insertBefore(this, arguments[index]);
+            }
+
+            this.removeSelf();
+        }
+
         return this;
     }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -95,10 +95,10 @@ export default class {
         return cloned;
     }
 
-    replaceWith() {
+    replaceWith(...nodes) {
         if (this.parent) {
-            for (let index in arguments) {
-                this.parent.insertBefore(this, arguments[index]);
+            for (let node of nodes) {
+                this.parent.insertBefore(this, node);
             }
 
             this.removeSelf();

--- a/test/container.js
+++ b/test/container.js
@@ -408,6 +408,13 @@ describe('Container', () => {
             expect(rule.last.before).to.eql(' ');
         });
 
+        it('appends multiple children', () => {
+            let rule = parse('a { a: 1; b: 2 }').first;
+            rule.append({ prop: 'c', value: '3' }, { prop: 'd', value: '4' });
+            expect(rule.toString()).to.eql('a { a: 1; b: 2; c: 3; d: 4 }');
+            expect(rule.last.before).to.eql(' ');
+        });
+
         it('has declaration shortcut', () => {
             let rule = parse('a { a: 1; b: 2 }').first;
             rule.append({ prop: 'c', value: '3' });
@@ -474,6 +481,13 @@ describe('Container', () => {
             let rule = parse('a { a: 1; b: 2 }').first;
             rule.prepend({ prop: 'c', value: '3' });
             expect(rule.toString()).to.eql('a { c: 3; a: 1; b: 2 }');
+            expect(rule.first.before).to.eql(' ');
+        });
+
+        it('prepends multiple children', () => {
+            let rule = parse('a { a: 1; b: 2 }').first;
+            rule.prepend({ prop: 'c', value: '3' }, { prop: 'd', value: '4' });
+            expect(rule.toString()).to.eql('a { c: 3; d: 4; a: 1; b: 2 }');
             expect(rule.first.before).to.eql(' ');
         });
 

--- a/test/root.js
+++ b/test/root.js
@@ -29,6 +29,12 @@ describe('Root', () => {
             expect(css.toString()).to.eql('em {} a {} b {}');
         });
 
+        it('fixes spaces on multiple inserts before first', () => {
+            let css = parse('a {} b {}');
+            css.prepend({ selector: 'em' }, { selector: 'strong' });
+            expect(css.toString()).to.eql('em {} strong {} a {} b {}');
+        });
+
         it('uses default spaces on only first', () => {
             let css = parse('a {}');
             css.prepend({ selector: 'em' });
@@ -57,6 +63,13 @@ describe('Root', () => {
             let a = parse('a{}a{}');
             let b = parse('b {\n}\n');
             expect(a.append(b).toString()).to.eql('a{}a{}b{}');
+        });
+
+        it('saves compressed style with multiple nodes', () => {
+            let a = parse('a{}a{}');
+            let b = parse('b {\n}\n');
+            let c = parse('c {\n}\n');
+            expect(a.append(b, c).toString()).to.eql('a{}a{}b{}c{}');
         });
 
     });


### PR DESCRIPTION
[DOM4](https://dom.spec.whatwg.org/) mutation methods accept multiple elements. Feature parity would be helpful between DOM4 and postcss.

- Supports multiple nodes on [append](https://dom.spec.whatwg.org/#dom-parentnode-appendnodes), [prepend](https://dom.spec.whatwg.org/#dom-parentnode-prependnodes), and [replaceWith](https://dom.spec.whatwg.org/#dom-childnode-replacewithnodes).
- Adds tests.
- Updates API documentation.