### PR TITLE
PoC for node.positionAt()

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -341,4 +341,19 @@ export default class {
             return value;
         }
     }
+
+    positionAt(indexRelativeToBefore) {
+        let index = indexRelativeToBefore - this.before.length;
+        let start = this.source.start;
+        let indexLine = start.line;
+        let startToIndex = this.toString().substr(this.before.length, index);
+        for ( let i = 0, l = startToIndex.length; i < l; i++ ) {
+            if (startToIndex[i] === '\n') indexLine += 1;
+        }
+        let startColumn = start.line === indexLine ? start.column : 1;
+        let lastNewlineToIndex = startToIndex
+          .slice(startToIndex.lastIndexOf('\n') + 1);
+        let indexColumn = startColumn + lastNewlineToIndex.length;
+        return { line: indexLine, column: indexColumn };
+    }
 }

--- a/test/node.js
+++ b/test/node.js
@@ -441,4 +441,27 @@ describe('Node', () => {
 
     });
 
+    describe.only('positionAt()', () => {
+        it('returns correct position when node starts mid-line', () => {
+            let css = parse('a { one: 1; }');
+            let one = css.first.first;
+            expect(one.positionAt(4).line).to.equal(1);
+            expect(one.positionAt(4).column).to.equal(8);
+        });
+
+        it('returns correct position when node.before contains newline', () => {
+            let css = parse('a {\n  one: 1;\n}');
+            let one = css.first.first;
+            expect(one.positionAt(6).line).to.equal(2);
+            expect(one.positionAt(6).column).to.equal(6);
+        });
+
+        it('returns correct position when node contains newlines', () => {
+            let css = parse('a {\n\tmargin: 1px,\n\t\t2px,\n\t\t3px;\n}');
+            let one = css.first.first;
+            expect(one.positionAt(25).line).to.equal(4);
+            expect(one.positionAt(25).column).to.equal(4);
+        });
+    });
+
 });


### PR DESCRIPTION
This PR is for discussion. It's just a proof-of-concept for a `positionAt()` method on the `Node` class, addressing https://github.com/postcss/postcss/issues/348, to help that discussion along. 

There's a good chance somebody with better knowledge of the codebase could find a better way to write this, using other existing stuff. But there's also a good chance that others have ideas about how this method should work (if it should exist). So I just thought I'd throw something out to see what people have to say.

This method accepts an index *relative to the beginning of `node.toString()`* -- which means, relative to the beginning of the `before` string, since that `before` string is included in `node.toString()`. I thought this might be appropriate because `node.toString()` is probably what a user would use to calculate the index of the character she's interested in. In the first two test-cases, for example, the user is giving the index of `:` relative to the start of that declaration's `toString()` result. In the third test-case, the user is giving the index of  the `p` in `3px`.

I'm thinking about this with a pretty specific application in mind: stylelint would want to provide exact positions if, for example, the colon had an unwanted space before it, or the `px` violated some linting rule.