### PR TITLE
Introduce TypeScript definitions

### DIFF
--- a/.d.ts
+++ b/.d.ts
@@ -1,0 +1,4 @@
+declare module 'postcss' {
+	import postcss from 'd.ts/postcss';
+	export = postcss;
+}

--- a/d.ts/at-rule.d.ts
+++ b/d.ts/at-rule.d.ts
@@ -1,0 +1,67 @@
+import Container from './container';
+declare class AtRule extends Container implements AtRule.NewProps {
+    /**
+     * Represents an at-rule.
+     */
+    constructor(defaults?: AtRule.NewProps);
+    'type': string;
+    /**
+     * The identifier that immediately follows the @.
+     */
+    name: string;
+    /**
+     * These are the values that follow the at-rule's name, but precede any {}
+     * block. The spec refers to this area as the at-rule's "prelude".
+     */
+    params: string;
+    /**
+     * The space symbols before the at-rule. The default value is \n; except, for
+     * the first rule in a Root, whose before property is empty.
+     */
+    before: string;
+    /**
+     * The space symbols between the at-rule's name and its parameters. The
+     * default value is a space.
+     */
+    afterName: string;
+    /**
+     * The space symbols between the at-rule's parameters and {, the
+     * block-opening curly brace. The default value is a space.
+     */
+    between: string;
+    /**
+     * The space symbols between the at-rule's last child and }, the block-closing curly brace.
+     * The default value is \n if the at-rule has children, and an empty string ('') if it does not.
+     */
+    after: string;
+    /**
+     * true if at-rule's last child declaration is followed by an (optional) semicolon.
+     * false if the semicolon is omitted.
+     */
+    semicolon: boolean;
+    /**
+     * @param overrides New properties with which to override the clone.
+     * @returns A clone of the node. The resulting cloned node and its (cloned)
+     * children will have clean parent and code style properties.
+     */
+    clone(overrides?: AtRule.NewProps): AtRule;
+    stringify(builder: any, semicolon?: boolean): void;
+    append(child: any): any;
+    prepend(child: any): any;
+    insertBefore(exist: any, add: any): any;
+    insertAfter(exist: any, add: any): any;
+}
+declare module AtRule {
+    interface NewProps {
+        /**
+         * The identifier that immediately follows the @.
+         */
+        name: string;
+        /**
+         * These are the values that follow the at-rule's name, but precede any {}
+         * block. The spec refers to this area as the at-rule's "prelude".
+         */
+        params: string;
+    }
+}
+export default AtRule;

--- a/d.ts/comment.d.ts
+++ b/d.ts/comment.d.ts
@@ -1,0 +1,42 @@
+import Node from './node';
+declare class Comment extends Node implements Comment.NewProps {
+    /**
+     * Represents a comment between declarations or statements (rule and at-rules).
+     * Comments inside selectors, at-rules parameters, or declaration values will be
+     * stored in the raw properties.
+     */
+    constructor(defaults?: Comment.NewProps);
+    'type': string;
+    /**
+     * The comment's text.
+     */
+    text: string;
+    /**
+     * The space symbols before the comment's text.
+     */
+    left: string;
+    /**
+     * The space symbols after the comment's text.
+     */
+    right: string;
+    /**
+     * The space symbols before the comment.
+     */
+    before: string;
+    /**
+     * @param overrides New properties with which to override the clone.
+     * @returns A clone of the node. The resulting cloned node and its (cloned)
+     * children will have clean parent and code style properties.
+     */
+    clone(overrides?: Comment.NewProps): Comment;
+    stringify(builder: any): void;
+}
+declare module Comment {
+    interface NewProps {
+        /**
+         * The comment's text.
+         */
+        text: string;
+    }
+}
+export default Comment;

--- a/d.ts/container.d.ts
+++ b/d.ts/container.d.ts
@@ -1,0 +1,217 @@
+import Declaration from './declaration';
+import Comment from './comment';
+import Node from './node';
+import AtRule from './at-rule';
+import Rule from './rule';
+/**
+ * An array containing the container's children.
+ */
+declare class Container extends Node {
+    private indexes;
+    private lastEach;
+    nodes: Node[];
+    protected stringifyContent(builder: any): void;
+    protected stringifyBlock(builder: any, start: any): void;
+    push(child: Node): Container;
+    /**
+     * Iterates through the container's immediate children, calling callback for
+     * each child. Returning false within callback will break iteration. Unlike
+     * the for {}-cycle or Array#forEach() this iterator is safe if you are
+     * mutating the array of child nodes during iteration. PostCSS will adjust
+     * the current index to match the mutations. This only iterates through the
+     * container's immediate children. If you need to recursively iterate through
+     * all the container's nodes, use container.eachInside().
+     */
+    each(callback: Container.EachCallback): boolean;
+    /**
+     * Recursively iterates through the container's children, those children's
+     * children, etc., calling the callback function for each one. Like
+     * container.each(), this method is safe to use if you are mutating arrays
+     * during iteration. If you only need to iterate through the container's
+     * immediate children, use container.each().
+     */
+    eachInside(callback: Container.EachCallback): boolean;
+    /**
+     * Recursively iterates through all declaration nodes within the container,
+     * calling the callback function for each one. Like container.each(), this
+     * method is safe to use if you are mutating arrays during iteration.
+     * @param propFilter Filters declarations by property name. Only those
+     * declarations whose property matches propFilter will be iterated over.
+     */
+    eachDecl(propFilter: string | RegExp, callback?: Container.EachDeclCallback): boolean;
+    eachDecl(callback: Container.EachDeclCallback): boolean;
+    /**
+     * Recursively iterates through all rule nodes within the container, calling
+     * the callback function for each one. Like container.each(), this method is
+     * safe to use if you are mutating arrays during iteration.
+     */
+    eachRule(callback: Container.EachRuleCallback): boolean;
+    /**
+     * Recursively iterates through all at-rule nodes within the container,
+     * calling the callback function for each one. Like container.each(), this
+     * method is safe to use if you are mutating arrays during iteration.
+     * @param nameFilter Filters at-rules by name. Only the at-rules whose name
+     * matches the filter will be iterated over.
+     */
+    eachAtRule(nameFilter: string | RegExp, callback?: Container.EachAtRuleCallback): boolean;
+    eachAtRule(callback: Container.EachAtRuleCallback): boolean;
+    /**
+     * Recursively iterates through all comment nodes within the container,
+     * calling the callback function for each one. Like container.each(), this
+     * method is safe to use if you are mutating arrays during iteration.
+     */
+    eachComment(callback: Container.EachCommentCallback): boolean;
+    /**
+     * Insert a new node to the end of the container.
+     */
+    append(node: Node): any;
+    /**
+     * Because each node class is identifiable by unique properties, use the
+     * following shortcuts to create nodes in insert methods:
+     *
+     * root.append({ name: '@charset', params: '"UTF-8"' }); // at-rule
+     * root.append({ selector: 'a' });                       // rule
+     * rule.append({ prop: 'color', value: 'black' });       // declaration
+     * rule.append({ text: 'Comment' })                      // comment
+     */
+    append(props: AtRule.NewProps | Rule.NewProps | Declaration.NewProps | Comment.NewProps): any;
+    /**
+     * A string containing the CSS of the new element can also be used. This
+     * approach is slower than the other overloads.
+     */
+    append(css: string): any;
+    /**
+     * Insert a new node to the beginning of the container.
+     */
+    prepend(node: Node): any;
+    /**
+     * Because each node class is identifiable by unique properties, use the
+     * following shortcuts to create nodes in insert methods:
+     *
+     * root.append({ name: '@charset', params: '"UTF-8"' }); // at-rule
+     * root.append({ selector: 'a' });                       // rule
+     * rule.append({ prop: 'color', value: 'black' });       // declaration
+     * rule.append({ text: 'Comment' })                      // comment
+     */
+    prepend(props: AtRule.NewProps | Rule.NewProps | Declaration.NewProps | Comment.NewProps): any;
+    /**
+     * A string containing the CSS of the new element can also be used. This
+     * approach is slower than the other overloads.
+     */
+    prepend(css: string): any;
+    /**
+     * Insert a new node before an existing node within the container.
+     */
+    insertBefore(existingNode: Node | number, node: Node): any;
+    /**
+     * Because each node class is identifiable by unique properties, use the
+     * following shortcuts to create nodes in insert methods:
+     *
+     * root.append({ name: '@charset', params: '"UTF-8"' }); // at-rule
+     * root.append({ selector: 'a' });                       // rule
+     * rule.append({ prop: 'color', value: 'black' });       // declaration
+     * rule.append({ text: 'Comment' })                      // comment
+     */
+    insertBefore(existingNode: Node | number, props: AtRule.NewProps | Rule.NewProps | Declaration.NewProps | Comment.NewProps): any;
+    /**
+     * A string containing the CSS of the new element can also be used. This
+     * approach is slower than the other overloads.
+     */
+    insertBefore(existingNode: Node, css: string): any;
+    /**
+     * Insert a new node after an existing node within the container.
+     */
+    insertAfter(existingNode: Node | number, node: Node): any;
+    /**
+     * Because each node class is identifiable by unique properties, use the
+     * following shortcuts to create nodes in insert methods:
+     *
+     * root.append({ name: '@charset', params: '"UTF-8"' }); // at-rule
+     * root.append({ selector: 'a' });                       // rule
+     * rule.append({ prop: 'color', value: 'black' });       // declaration
+     * rule.append({ text: 'Comment' })                      // comment
+     */
+    insertAfter(existingNode: Node | number, props: AtRule.NewProps | Rule.NewProps | Declaration.NewProps | Comment.NewProps): any;
+    /**
+     * A string containing the CSS of the new element can also be used. This
+     * approach is slower than the other overloads.
+     */
+    insertAfter(existingNode: Node, css: string): any;
+    /**
+     * Removes node from the container, and the parent properties of node and its children.
+     * @param child Child or child's index.
+     */
+    remove(child: Node | number): Container;
+    /**
+     * Removes all children from the container, and cleans their parent properties.
+     */
+    removeAll(): Container;
+    /**
+     * Passes all declaration values within the container that match pattern
+     * through callback, replacing those values with the returned result of callback.
+     * This method is useful if you are using a custom unit or function and need
+     * to iterate through all values.
+     * @param searchValue Pattern that we need to replace.
+     * @param options To speed up the search.
+     * @param replaceValue String to replace pattern or callback that will return a
+     * new value. The callback will receive the same arguments as those passed to
+     * a function parameter of String#replace.
+     */
+    replaceValues(searchValue: string | RegExp, options: {
+        /**
+         * An array of property names. The method will only search for values that
+         * match regexp within declarations of listed properties.
+         */
+        props?: string[];
+        /**
+         * A string that used to narrow down values and speed up the regexp search.
+         * Searching every single value with a regexp can be slow. If you pass a
+         * fast string, PostCSS will first check whether the value contains the
+         * fast string; and only if it does will PostCSS check that value against
+         * regexp. For example, instead of just checking for /\d+rem/ on all values,
+         * set fast: 'rem' to first check whether a value has the rem unit, and
+         * only if it does perform the regexp check.
+         */
+        fast?: string;
+    }, replaceValue: Function | string): Container;
+    replaceValues(searchValue: string | RegExp, replaceValue: string | Container.ReplaceCallback): Container;
+    /**
+     * Determines whether the specified callback function returns true for all nodes.
+     */
+    every(callback: (value: Node, indexedDb: number, nodes: Node[]) => boolean, thisArg?: any): boolean;
+    /**
+     * Determines whether the specified callback function returns true for any node.
+     */
+    some(callback: (value: Node, index: number, array: Node[]) => boolean, thisArg?: any): boolean;
+    /**
+     * @param child Child of current container.
+     * @returns Child's index within the container's nodes array.
+     */
+    index(child: Node | number): number;
+    first: Node;
+    last: Node;
+    normalize(node: Node | string, sample: Node, nodeType?: string): Node[];
+    normalize(props: AtRule.NewProps | Rule.NewProps | Declaration.NewProps | Comment.NewProps, sample: Node, nodeType?: string): Node[];
+    cleanStyles(keepBetween: boolean): void;
+}
+declare module Container {
+    interface EachCallback {
+        (node: Node, index?: number): boolean | void;
+    }
+    interface EachDeclCallback {
+        (decl: Declaration, index?: number): boolean | void;
+    }
+    interface EachRuleCallback {
+        (rule: Rule, index?: number): boolean | void;
+    }
+    interface EachAtRuleCallback {
+        (atRule: AtRule, index?: number): boolean | void;
+    }
+    interface EachCommentCallback {
+        (comment: Comment, index?: number): boolean | void;
+    }
+    interface ReplaceCallback {
+        (substring: string, ...args: any[]): string;
+    }
+}
+export default Container;

--- a/d.ts/css-syntax-error.d.ts
+++ b/d.ts/css-syntax-error.d.ts
@@ -1,0 +1,83 @@
+export default class CssSyntaxError implements SyntaxError {
+    /**
+     * Contains full error text by GNU error format.
+     */
+    message: string;
+    /**
+     * Contains source line of error.
+     */
+    line: number;
+    /**
+     * Contains source column of error.
+     */
+    column: number;
+    /**
+     * Contains source code of broken file.
+     */
+    source: string;
+    /**
+     * Contains absolute path to broken file. If used, set "from" option to parser.
+     */
+    file: string;
+    /**
+     * Contains PostCSS plugin name if error did not come from CSS parser.
+     */
+    plugin: string;
+    name: string;
+    /**
+     * Contains only the error description.
+     */
+    reason: string;
+    private columnNumber;
+    private description;
+    private lineNumber;
+    private fileName;
+    generated: {
+        line: number;
+        column: number;
+        source: string;
+        file?: string;
+    };
+    /**
+     * CSS parser throws this error for broken CSS.
+     */
+    constructor(
+        /**
+         * Contains full error text by GNU error format.
+         */
+        message: string, 
+        /**
+         * Contains source line of error.
+         */
+        line?: number, 
+        /**
+         * Contains source column of error.
+         */
+        column?: number, 
+        /**
+         * Contains source code of broken file.
+         */
+        source?: string, 
+        /**
+         * Contains absolute path to broken file. If used, set "from" option to parser.
+         */
+        file?: string, 
+        /**
+         * Contains PostCSS plugin name if error did not come from CSS parser.
+         */
+        plugin?: string);
+    setMessage(): void;
+    /**
+     * @param color Color errors in red. By default, PostCSS will use
+     * process.stdout.isTTY and process.env.NODE_DISABLE_COLORS.
+     * @returns A few lines of CSS source that caused the error. If CSS has input
+     * source map without sourceContent, this method will return an empty string.
+     */
+    showSourceCode(color?: boolean): string;
+    highlight(color: boolean): string;
+    setMozillaProps(): void;
+    /**
+     * @returns Error position, message and source code of broken part.
+     */
+    toString(): string;
+}

--- a/d.ts/declaration.d.ts
+++ b/d.ts/declaration.d.ts
@@ -1,0 +1,59 @@
+import Node from './node';
+declare class Declaration extends Node implements Declaration.NewProps {
+    /**
+     * Represents a CSS declaration.
+     */
+    constructor(defaults?: Declaration.NewProps);
+    'type': string;
+    /**
+     * The declaration's property name.
+     */
+    prop: string;
+    /**
+     * The declaration's value. This value will be cleaned of comments. If the
+     * source value contained comments, those comments will be available in the
+     * _value.raw property. If you have not changed the value, the result of
+     * decl.toString() will include the original raw value (comments and all).
+     */
+    value: string;
+    /**
+     * The space symbols before the declaration. Default value is \n.
+     */
+    before: string;
+    /**
+     * The symbols between the declaration�s property and its value.
+     * Default value is a colon.
+     */
+    between: string;
+    /**
+     * true if the declaration has an !important annotation. If there are comments
+     * between the declaration's value and its !important annotation, they will be
+     * available in the _important property.
+     */
+    important: boolean;
+    _important: string;
+    /**
+     * @param overrides New properties with which to override the clone.
+     * @returns A clone of the node. The resulting cloned node and its (cloned)
+     * children will have clean parent and code style properties.
+     */
+    clone(overrides?: Declaration.NewProps): Declaration;
+    stringify(builder: any, semicolon?: boolean): void;
+    cleanStyles(keepBetween: boolean): void;
+}
+declare module Declaration {
+    interface NewProps {
+        /**
+         * The declaration's property name.
+         */
+        prop: string;
+        /**
+         * The declaration's value. This value will be cleaned of comments. If the
+         * source value contained comments, those comments will be available in the
+         * _value.raw property. If you have not changed the value, the result of
+         * decl.toString() will include the original raw value (comments and all).
+         */
+        value: string;
+    }
+}
+export default Declaration;

--- a/d.ts/input.d.ts
+++ b/d.ts/input.d.ts
@@ -1,0 +1,47 @@
+import CssSyntaxError from './css-syntax-error';
+import PreviousMap from './previous-map';
+export default class Input {
+    css: string;
+    safe: boolean;
+    /**
+     * The absolute path to the CSS source file defined with the "from" option.
+     */
+    file: string;
+    /**
+     * The unique ID of the CSS source. Used if from option is not provided
+     * (because PostCSS does not know the file path).
+     */
+    id: string;
+    /**
+     * The CSS source identifier. Contains input.file if the user set the from
+     * option, or input.id if he/she did not.
+     */
+    'from': string;
+    /**
+     * Represents the input source map passed from a compilation step before
+     * PostCSS (for example, from the Sass compiler).
+     */
+    map: PreviousMap;
+    /**
+     * Represents the source CSS.
+     */
+    constructor(css: string, options?: {
+        safe?: boolean | any;
+        from?: string;
+    });
+    error(message: string, line: number, column: number, opts?: {
+        plugin?: string;
+    }): CssSyntaxError;
+    /**
+     * Reads the input source map.
+     * @returns A symbol position in the input source (e.g., in a Sass file that
+     * was compiled to CSS before being passed to PostCSS).
+     */
+    origin(line: number, column: number): {
+        file: string;
+        line: any;
+        column: any;
+        source: any;
+    };
+    mapResolve(file: string): string;
+}

--- a/d.ts/lazy-result.d.ts
+++ b/d.ts/lazy-result.d.ts
@@ -1,0 +1,131 @@
+import Result from './result';
+import postcss from './postcss';
+import Processor from './processor';
+import Root from './root';
+import RSVP from 'es6-promise';
+export default class LazyResult {
+    private stringified;
+    private processed;
+    private result;
+    private error;
+    private plugin;
+    private processing;
+    /**
+     * Promise proxy for result of PostCSS transformations.
+     */
+    constructor(processor: Processor, 
+        /**
+         * String with input CSS or any object with toString() method, like file stream.
+         * Optionally, send Result instance and the processor will take the existing
+         * [Root] parser from it.
+         */
+        css: string | {
+        toString(): string;
+    } | Result, options?: {
+        /**
+         * The path of the CSS source file. You should always set from, because it is
+         * used in source map generation and syntax error messages.
+         */
+        from?: string;
+        /**
+         * The path where you'll put the output CSS file. You should always set it
+         * to generate correct source maps.
+         */
+        to?: string;
+        /**
+         * Enable Safe Mode, in which PostCSS will try to fix CSS syntax errors.
+         */
+        safe?: boolean;
+        map?: postcss.SourceMapOptions;
+    });
+    /**
+     * @returns A Processor instance, which will be used for CSS transformations.
+     */
+    processor: Processor;
+    /**
+     * @returns Options from the Processor#process(css, opts) call that produced
+     * this Result instance.
+     */
+    opts: Result.Options;
+    /**
+     * Processes input CSS through synchronous plugins, converts Root to CSS string.
+     * This property will work only with synchronous plugins. If processor contains any
+     * asynchronous plugins it will throw a error. You should use LazyResult#then() instead.
+     * @returns Result#css.
+     */
+    css: string;
+    /**
+     * Processes input CSS through synchronous plugins. This property will work only
+     * with synchronous plugins. If processor contains any asynchronous plugins it
+     * will throw an error. You should use LazyResult#then() instead.
+     * @returns Result#map.
+     */
+    map: {
+        addMapping(mapping: {
+            generated: {
+                line: number;
+                column: number;
+            };
+            original: {
+                line: number;
+                column: number;
+            };
+            source: string;
+            name?: string;
+        }): void;
+        setSourceContent(sourceFile: string, sourceContent: string): void;
+        applySourceMap(sourceMapConsumer: any, sourceFile?: string, sourceMapPath?: string): void;
+        toJSON: () => any;
+        toString: () => string;
+    };
+    /**
+     * Processes input CSS through synchronous plugins and returns Result#root.
+     * This property will work only with synchronous plugins. If processor contains
+     * any asynchronous plugins it will throw an error. You should use
+     * LazyResult#then() instead.
+     */
+    root: Root;
+    /**
+     * Processes input CSS through synchronous plugins and returns Result#messages.
+     * This property will work only with synchronous plugins. If processor contains
+     * any asynchronous plugins it will throw an error. You should use
+     * LazyResult#then() instead.
+     */
+    messages: {
+        'type': string;
+        plugin: string;
+        browsers?: string[];
+    }[];
+    /**
+     * Processes input CSS through synchronous plugins and calls [Result#warnings()].
+     * This property will work only with synchronous plugins. If processor contains
+     * any asynchronous plugins it will throw a error. You should use
+     * LazyResult#then() instead.
+     */
+    warnings(): {
+        'type': string;
+        plugin: string;
+        browsers?: string[];
+    }[];
+    /**
+     * Alias for LazyResult#css property.
+     */
+    toString(): string;
+    /**
+     * Processes input CSS through synchronous and asynchronous plugins and call
+     * onFulfilled with Result instance. If a plugin throws an error, onRejected
+     * callback will be executed.
+     */
+    then(onFulfilled: any, onRejected: any): RSVP.Promise<{}>;
+    /**
+     * Processes input CSS through synchronous and asynchronous plugins and call
+     * onRejected on errors from any plugin.
+     */
+    catch(onRejected: any): RSVP.Promise<{}>;
+    private handleError(error, plugin);
+    private asyncTick(resolve, reject);
+    private async();
+    private sync();
+    private run(plugin);
+    stringify(): Result;
+}

--- a/d.ts/list.d.ts
+++ b/d.ts/list.d.ts
@@ -1,0 +1,6 @@
+declare var _default: {
+    split(s: string, separators: string[], last?: boolean): any[];
+    space(s: string): any;
+    comma(s: string): any;
+};
+export default _default;

--- a/d.ts/map-generator.d.ts
+++ b/d.ts/map-generator.d.ts
@@ -1,0 +1,25 @@
+import Root from './root';
+export default class MapGenerator {
+    private root;
+    private opts;
+    private mapOpts;
+    private previousMaps;
+    private map;
+    private css;
+    constructor(root: Root, opts: any);
+    isMap(): boolean;
+    previous(): any;
+    isInline(): any;
+    isSourcesContent(): any;
+    clearAnnotation(): void;
+    setSourcesContent(): void;
+    applyPrevMaps(): void;
+    isAnnotation(): any;
+    addAnnotation(): void;
+    outputFile(): any;
+    generateMap(): any[];
+    relative(file: any): any;
+    sourcePath(node: any): any;
+    stringify(): void;
+    generate(): any[];
+}

--- a/d.ts/node.d.ts
+++ b/d.ts/node.d.ts
@@ -1,0 +1,162 @@
+import CssSyntaxError from './css-syntax-error';
+import Container from './container';
+import Input from './Input';
+import Root from './Root';
+export interface Position {
+    line: number;
+    column: number;
+}
+export default class Node {
+    /**
+     * Returns a string representing the node's type.
+     */
+    'type': string;
+    /**
+     * The rule's full selector represented as a string. If there are multiple
+     * comma-separated selectors, the entire group will be included.
+     * This value will be cleaned of comments. If the source selector contained
+     * comments, those comments will be available in the _selector.raw property.
+     * If you have not changed the selector, the result of rule.toString() will
+     * include the original raw selector value (comments and all).
+     */
+    selector: string;
+    /**
+     * An array containing the rule's individual selectors.
+     * Groups of selectors are split at commas.
+     */
+    selectors: string[];
+    /**
+     * The space symbols before the rule. The default value is \n, except for
+     * first rule in root, whose before property is empty.
+     */
+    before: string;
+    /**
+     * The space symbols between the rule's last child and }, the block-closing curly brace.
+     * The default value is \n if rule has children and an empty string ('') if it does not.
+     */
+    after: string;
+    /**
+     * true if rule's last child declaration is followed by an (optional) semicolon.
+     * false if the semicolon is omitted.
+     */
+    semicolon: boolean;
+    /**
+     * Returns the node's parent node.
+     */
+    parent: Container;
+    nodes: Node[];
+    /**
+     * Returns the input source of the node.
+     */
+    source: {
+        input: Input;
+        /**
+         * The starting position of the node's source.
+         */
+        start?: Position;
+        /**
+         * The ending position of the node's source.
+         */
+        end?: Position;
+    };
+    constructor(defaults?: {
+        parent?: Node;
+        nodes?: Node[];
+    });
+    /**
+     *
+     * @param message Error description.
+     * @param opts
+     * @returns An error containing the original position of the node in the
+     * source, showing line and column numbers and also a small excerpt to
+     * facilitate debugging.
+     */
+    error(message: string, opts?: {
+        /**
+         * Plugin name that created this error. PostCSS will set it automatically.
+         */
+        plugin?: string;
+    }): CssSyntaxError;
+    /**
+     * Removes the node from its parent, and cleans the parent property in the
+     * node and its children.
+     */
+    removeSelf(): Node;
+    replace(nodes: any): Node;
+    /**
+     * @returns A CSS string representing the node.
+     */
+    toString(): string;
+    stringify(builder: any, semicolon?: boolean): void;
+    /**
+     * @param overrides New properties with which to override the clone.
+     * @returns A clone of the node. The resulting cloned node and its (cloned)
+     * children will have clean parent and code style properties.
+     */
+    clone(overrides?: {}): any;
+    /**
+     * Shortcut to clone the node and insert the resulting cloned node before
+     * the current node.
+     * @param overrides New properties with which to override the clone.
+     */
+    cloneBefore(overrides?: {}): any;
+    /**
+     * Shortcut to clone the node and insert the resulting cloned node after the
+     * current node.
+     * @param overrides New properties with which to override the clone.
+     */
+    cloneAfter(overrides?: {}): any;
+    /**
+     * Inserts another node before the current node and removes the current node.
+     */
+    replaceWith(otherNode: Node): Node;
+    /**
+     * Removes the node from its current parent and inserts it at the end of newParent.
+     * This will clean the before and after code style properties from the node,
+     * and replace them with the indentation style of newParent. It will also clean
+     * the between property if newParent is in another Root.
+     * @param newParent Container node where the current node will be removed.
+     */
+    moveTo(newParent: Container): Node;
+    /**
+     * Removes the node from its current parent and inserts it into a new parent
+     * before otherNode. This will also clean the node's code style
+     * properties just as node.moveTo(newParent) does.
+     * @param otherNode Will be after current node after moving.
+     */
+    moveBefore(otherNode: Node): Node;
+    /**
+     * Removes the node from its current parent and inserts it into a new parent
+     * after otherNode. This will also clean the node's code style
+     * properties just as node.moveTo(newParent) does.
+     * @param otherNode Will be before current node after moving.
+     */
+    moveAfter(otherNode: Node): Node;
+    /**
+     * @returns The next child of the node's parent or returns undefined if the
+     * current node is the last child.
+     */
+    next: Node;
+    /**
+     * @returns The previous child of the node's parent or returns undefined if the
+     * current node is the first child.
+     */
+    prev: Node;
+    toJSON(): {};
+    /**
+     * @param prop Name or code style property.
+     * @param detect Name of default value. It can be easily missed if the value
+     * is the same as prop.
+     * @returns a code style property value. If the node is missing the code
+     * style property (because the node was manually built or cloned), PostCSS
+     * will try to autodetect the code style property by looking at other nodes
+     * in the tree.
+     */
+    style(prop: string, detect?: string): any;
+    /**
+     * @returns The Root instance of the node�s tree.
+     */
+    root: Root;
+    cleanStyles(keepBetween?: boolean): void;
+    stringifyRaw(prop: any): any;
+}

--- a/d.ts/parse.d.ts
+++ b/d.ts/parse.d.ts
@@ -1,0 +1,4 @@
+import postcss from './postcss';
+import Root from './root';
+declare var _default: (css: string, options?: postcss.SourceMapOptions) => Root;
+export default _default;

--- a/d.ts/parser.d.ts
+++ b/d.ts/parser.d.ts
@@ -1,0 +1,29 @@
+import Input from './input';
+import Root from './root';
+export default class Parser {
+    input: Input;
+    pos: number;
+    root: Root;
+    spaces: string;
+    semicolon: boolean;
+    private current;
+    private tokens;
+    constructor(input: Input);
+    tokenize(): void;
+    loop(): void;
+    private comment(token);
+    private emptyRule(token);
+    private word();
+    private rule(tokens);
+    private decl(tokens);
+    private atrule(token);
+    private end(token);
+    private endFile();
+    private unknownWord(decl, token);
+    private checkMissedSemicolon(tokens);
+    private init(node, line?, column?);
+    private raw(node, prop, tokens);
+    private spacesFromEnd(tokens);
+    private spacesFromStart(tokens);
+    private stringFrom(tokens, from);
+}

--- a/d.ts/postcss.d.ts
+++ b/d.ts/postcss.d.ts
@@ -1,0 +1,96 @@
+import Declaration from './declaration';
+import Processor from './processor';
+import Comment from './comment';
+import AtRule from './at-rule';
+import Node from './node';
+import Result from './result';
+import Rule from './rule';
+import Root from './root';
+declare function postcss(plugins?: (postcss.Plugin | postcss.Transformer | Processor)[]): Processor;
+declare module postcss {
+    /**
+     *
+     * @param name Plugin name. Same as in name property in package.json. It will
+     * be saved in plugin.postcssPlugin property.
+     * @param initializer Will receive plugin options and should return functions
+     * to modify nodes in input CSS.
+     */
+    function plugin(name: string, initializer: PluginInitializer): Plugin;
+    interface Plugin {
+        (): Transformer;
+        postcss: Transformer;
+    }
+    interface Transformer {
+        (root: Root, result?: Result): void | Promise<void>;
+        postcssPlugin?: string;
+        postcssVersion?: string;
+    }
+    interface PluginInitializer {
+        (pluginOptions?: any): Transformer;
+    }
+    var vendor: {
+        prefix(prop: any): any;
+        unprefixed(prop: any): any;
+    };
+    function parse(): any;
+    var list: {
+        split(s: string, separators: string[], last?: boolean): any[];
+        space(s: string): any;
+        comma(s: string): any;
+    };
+    function comment(defaults?: Comment.NewProps): Comment;
+    function atRule(defaults?: AtRule.NewProps): AtRule;
+    function decl(defaults: Declaration.NewProps): Declaration;
+    function rule(defaults?: Rule.NewProps): Rule;
+    function root(defaults?: NodeDefaults): Root;
+    interface NodeDefaults {
+        name?: string;
+        parent?: Node;
+        nodes?: Node[];
+    }
+    interface SourceMapOptions {
+        /**
+         * Indicates that the source map should be embedded in the output CSS as a
+         * Base64-encoded comment. By default, it is true. But if all previous maps
+         * are external, not inline, PostCSS will not embed the map even if you do
+         * not set this option.
+         *
+         * If you have an inline source map, the result.map property will be empty,
+         * as the source map will be contained within the text of result.css.
+         */
+        inline?: boolean;
+        /**
+         * Source map content from a previous processing step (for example, Sass compilation).
+         * PostCSS will try to read the previous source map automatically (based on comments
+         * within the source CSS), but you can use this option to identify it manually.
+         * If desired, you can omit the previous map with prev: false.
+         */
+        prev?: any;
+        /**
+         * Indicates that PostCSS should set the origin content (for example, Sass source)
+         * of the source map. By default, it is true. But if all previous maps do not
+         * contain sources content, PostCSS will also leave it out even if you do not set
+         * this option.
+         */
+        sourcesContent?: boolean;
+        /**
+         * Indicates that PostCSS should add annotation comments to the CSS. By default,
+         * PostCSS will always add a comment with a path to the source map. PostCSS will
+         * not add annotations to CSS files that do not contain any comments.
+         *
+         * By default, PostCSS presumes that you want to save the source map as
+         * opts.to + '.map' and will use this path in the annotation comment. A different
+         * path can be set by providing a string value for annotation.
+         *
+         * If you have set inline: true, annotation cannot be disabled.
+         */
+        annotation?: boolean | string;
+        /**
+         * If true, PostCSS will try to correct any syntax errors that it finds in the CSS.
+         * This is useful for legacy code filled with hacks. Another use-case is interactive
+         * tools with live input � for example, the Autoprefixer demo.
+         */
+        safe?: boolean;
+    }
+}
+export default postcss;

--- a/d.ts/previous-map.d.ts
+++ b/d.ts/previous-map.d.ts
@@ -1,0 +1,15 @@
+export default class PreviousMap {
+    private inline;
+    private annotation;
+    private root;
+    private consumerCache;
+    text: string;
+    file: string;
+    constructor(css: any, opts: any);
+    consumer(): any;
+    withContent(): boolean;
+    startWith(string: any, start: any): boolean;
+    loadAnnotation(css: any): void;
+    decodeInline(text: any): any;
+    loadMap(file: any, prev: any): any;
+}

--- a/d.ts/processor.d.ts
+++ b/d.ts/processor.d.ts
@@ -1,0 +1,57 @@
+import LazyResult from './lazy-result';
+import postcss from './postcss';
+import Result from './result';
+declare class Processor {
+    static version: any;
+    /**
+     * Contains plugins added to this processor.
+     */
+    plugins: postcss.Plugin[];
+    /**
+     * A Processor instance contains plugins to process CSS. Create one Processor
+     * instance, initialize its plugins, and then use that instance on many CSS files.
+     */
+    constructor(plugins?: (postcss.Plugin | postcss.Transformer | Processor)[]);
+    /**
+     * Adds a plugin to be used as a CSS processor. Plugins can also be added by
+     */
+    use(plugin: postcss.Plugin | postcss.Transformer | Processor): Processor;
+    /**
+     * Parses source CSS and returns LazyResult instance. Because some plugins can
+     * be asynchronous it doesn't make any transformations. Transformations will be
+     * applied in LazyResult's methods.
+     * @param css
+     * @param options
+     * @returns {}
+     */
+    process(
+        /**
+         * String with input CSS or any object with toString() method, like file stream.
+         * Optionally, send Result instance and the processor will take the existing
+         * [Root] parser from it.
+         */
+        css: string | {
+        toString(): string;
+    } | Result, options?: Processor.ProcessOptions): LazyResult;
+    private normalize(plugins);
+}
+declare module Processor {
+    interface ProcessOptions {
+        /**
+         * The path of the CSS source file. You should always set from, because it is
+         * used in source map generation and syntax error messages.
+         */
+        from?: string;
+        /**
+         * The path where you'll put the output CSS file. You should always set it
+         * to generate correct source maps.
+         */
+        to?: string;
+        /**
+         * Enable Safe Mode, in which PostCSS will try to fix CSS syntax errors.
+         */
+        safe?: boolean;
+        map?: postcss.SourceMapOptions;
+    }
+}
+export default Processor;

--- a/d.ts/result.d.ts
+++ b/d.ts/result.d.ts
@@ -1,0 +1,148 @@
+import postcss from './postcss';
+import Processor from './processor';
+import Root from './root';
+declare class Result {
+    /**
+     * The Processor instance used for this transformation.
+     */
+    processor: Processor;
+    /**
+     * Contains Root node after all transformations.
+     */
+    root: Root;
+    /**
+     * Options from the Processor#process(css, opts) or Root#toResult(opts) call
+     * that produced this Result instance.
+     */
+    opts: Result.Options;
+    /**
+     * A CSS string representing this Result's Root instance.
+     */
+    css: string;
+    /**
+     * An instance of the SourceMapGenerator class from the source-map library,
+     * representing changes to the Result�s Root instance.
+     */
+    map: {
+        /**
+         * Add a single mapping from original source line and column to the generated
+         * source's line and column for this source map being created. The mapping
+         * object should have the following properties:
+         * @param mapping
+         * @returns {}
+         */
+        addMapping(mapping: {
+            generated: {
+                line: number;
+                column: number;
+            };
+            original: {
+                line: number;
+                column: number;
+            };
+            /**
+             * The original source file (relative to the sourceRoot).
+             */
+            source: string;
+            name?: string;
+        }): void;
+        /**
+         * Set the source content for an original source file.
+         * @param sourceFile The URL of the original source file.
+         * @param sourceContent The content of the source file.
+         */
+        setSourceContent(sourceFile: string, sourceContent: string): void;
+        /**
+         * Applies a SourceMap for a source file to the SourceMap. Each mapping to
+         * the supplied source file is rewritten using the supplied SourceMap.
+         * Note: The resolution for the resulting mappings is the minimium of this
+         * map and the supplied map.
+         * @param sourceMapConsumer The SourceMap to be applied.
+         * @param sourceFile The filename of the source file. If omitted, sourceMapConsumer
+         * file will be used, if it exists. Otherwise an error will be thrown.
+         * @param sourceMapPath The dirname of the path to the SourceMap to be applied.
+         * If relative, it is relative to the SourceMap. This parameter is needed when
+         * the two SourceMaps aren't in the same directory, and the SourceMap to be
+         * applied contains relative source paths. If so, those relative source paths
+         * need to be rewritten relative to the SourceMap.
+         * If omitted, it is assumed that both SourceMaps are in the same directory;
+         * thus, not needing any rewriting (Supplying '.' has the same effect).
+         */
+        applySourceMap(sourceMapConsumer, sourceFile?: string, sourceMapPath?: string): void;
+        /**
+         * Renders the source map being generated to JSON.
+         */
+        toJSON: () => any;
+        /**
+         * Renders the source map being generated to a string.
+         */
+        toString: () => string;
+    };
+    /**
+     * Contains messages from plugins. For example, warnings or custom messages to
+     * plugins communication. Add a warning using Result#warn() and get all warnings
+     * using Result#warnings() method.
+     */
+    messages: {
+        'type': string;
+        plugin: string;
+        browsers?: string[];
+    }[];
+    lastPlugin: postcss.Transformer;
+    /**
+     * Provides the result of the PostCSS transformations.
+     */
+    constructor(
+        /**
+         * The Processor instance used for this transformation.
+         */
+        processor: Processor, 
+        /**
+         * Contains Root node after all transformations.
+         */
+        root: Root, 
+        /**
+         * Options from the Processor#process(css, opts) or Root#toResult(opts) call
+         * that produced this Result instance.
+         */
+        opts?: Result.Options);
+    /**
+     * Alias for Result#css property.
+     */
+    toString(): string;
+    /**
+     * Creates Warning and adds it to Result#messages.
+     */
+    warn(text: string, options?: Result.Options): void;
+    /**
+     * Filters Warning instances from [Result#messages].
+     * @returns Warnings from plugins.
+     */
+    warnings(): {
+        'type': string;
+        plugin: string;
+        browsers?: string[];
+    }[];
+    /**
+     * Deprecated and will be removed in 5.0. Use result.opts.from instead.
+     */
+    from: string;
+    /**
+     * Deprecated and will be removed in 5.0. Use result.opts.to instead.
+     */
+    to: string;
+}
+declare module Result {
+    interface Options extends Processor.ProcessOptions {
+        /**
+         * CSS node, that was a source of warning.
+         */
+        node?: Node;
+        /**
+         * Name of plugin that created this warning. Result#warn() will fill it
+         * automatically with plugin.postcssPlugin value.
+         */
+        plugin?: string;
+    }
+}
+export default Result;

--- a/d.ts/root.d.ts
+++ b/d.ts/root.d.ts
@@ -1,0 +1,43 @@
+import Container from './container';
+import postcss from './postcss';
+import PreviousMap from './previous-map';
+import Node from './node';
+import AtRule from './at-rule';
+import Rule from './rule';
+import Comment from './comment';
+import Declaration from './declaration';
+import Result from './result';
+/**
+ * Represents a CSS file and contains all its parsed nodes.
+ */
+export default class Root extends Container {
+    'type': string;
+    /**
+     * The space symbols after the last child of root, such as \n at the end of a file.
+     */
+    after: string;
+    prevMap: PreviousMap;
+    styleCache: {
+        [key: string]: any;
+    };
+    /**
+     * @returns A clone of the node. The resulting cloned node and its (cloned)
+     * children will have clean parent and code style properties.
+     */
+    clone(): Root;
+    remove(child: any): Container;
+    normalize(node: Node | string, sample: Node, nodeType?: string): Node[];
+    normalize(props: AtRule.NewProps | Rule.NewProps | Declaration.NewProps | Comment.NewProps, sample: Node, nodeType?: string): Node[];
+    stringify(builder: any): void;
+    /**
+     * @returns A Result instance representing the root's CSS.
+     */
+    toResult(options?: {
+        /**
+         * The path where you'll put the output CSS file. You should always set to
+         * generate correct source maps.
+         */
+        to?: string;
+        map?: postcss.SourceMapOptions;
+    }): Result;
+}

--- a/d.ts/rule.d.ts
+++ b/d.ts/rule.d.ts
@@ -1,0 +1,55 @@
+import Container from './container';
+declare class Rule extends Container implements Rule.NewProps {
+    /**
+     * Represents a CSS rule: a selector followed by a declaration block.
+     */
+    constructor(defaults?: Rule.NewProps);
+    'type': string;
+    /**
+     * The rule's full selector. If there are multiple comma-separated selectors,
+     * the entire group will be included.
+     */
+    selector: string;
+    /**
+     * @param overrides New properties with which to override the clone.
+     * @returns A clone of the node. The resulting cloned node and its (cloned)
+     * children will have clean parent and code style properties.
+     */
+    clone(overrides?: Rule.NewProps): Rule;
+    /**
+     * An array containing the rule's individual selectors.
+     * Groups of selectors are split at commas.
+     */
+    selectors: string[];
+    /**
+     * The space symbols before the rule. The default value is \n, except for
+     * first rule in root, whose before property is empty.
+     */
+    before: string;
+    /**
+     * The space symbols between the rule's selectors and {, the block-opening curly brace.
+     * The default value is a single space.
+     */
+    between: string;
+    /**
+     * The space symbols between the rule's last child and }, the block-closing curly brace.
+     * The default value is \n if rule has children and an empty string ('') if it does not.
+     */
+    after: string;
+    /**
+     * true if rule's last child declaration is followed by an (optional) semicolon.
+     * false if the semicolon is omitted.
+     */
+    semicolon: boolean;
+    stringify(builder: any): void;
+}
+declare module Rule {
+    interface NewProps {
+        /**
+     * The rule's full selector. If there are multiple comma-separated selectors,
+     * the entire group will be included.
+     */
+        selector: string;
+    }
+}
+export default Rule;

--- a/d.ts/tokenize.d.ts
+++ b/d.ts/tokenize.d.ts
@@ -1,0 +1,3 @@
+import Input from './input';
+declare var _default: (input: Input) => any[];
+export default _default;

--- a/d.ts/vendor.d.ts
+++ b/d.ts/vendor.d.ts
@@ -1,0 +1,5 @@
+declare var _default: {
+    prefix(prop: any): any;
+    unprefixed(prop: any): any;
+};
+export default _default;

--- a/d.ts/warn-once.d.ts
+++ b/d.ts/warn-once.d.ts
@@ -1,0 +1,2 @@
+declare var _default: (message: string) => void;
+export default _default;

--- a/d.ts/warning.d.ts
+++ b/d.ts/warning.d.ts
@@ -1,0 +1,40 @@
+import Node from './node';
+export default class Warning implements WarningProps {
+    /**
+     * Contains warning message.
+     */
+    text: string;
+    'type': string;
+    /**
+     * Contains name of plugin that created this warning. When you call Result#warn(),
+     * it will fill this property automatically.
+     */
+    plugin: string;
+    /**
+     * The CSS node that caused the warning.
+     */
+    node: Node;
+    /**
+     * Warning from plugins. It can be created using Result#warn().
+     */
+    constructor(
+        /**
+         * Contains warning message.
+         */
+        text: string, options?: WarningProps);
+    /**
+     * @returns String with error position, message.
+     */
+    toString(): string;
+}
+export interface WarningProps {
+    /**
+     * Contains name of plugin that created this warning. When you call Result#warn(),
+     * it will fill this property automatically.
+     */
+    plugin?: string;
+    /**
+     * The CSS node that caused the warning.
+     */
+    node?: Node;
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,15 @@ The `postcss` function is the main entry point for PostCSS.
 var postcss = require('postcss');
 ```
 
+For those using [TypeScript](http://www.typescriptlang.org/) with an
+[ES6 compile target](https://github.com/Microsoft/TypeScript/wiki/tsconfig.json),
+you can import the PostCSS API like so:
+
+```ts
+///<reference path="node_modules/postcss/.d.ts" />
+import * as postcss from 'postcss';
+```
+
 ### `postcss(plugins)`
 
 Returns a new [`Processor`] instance that will apply `plugins`


### PR DESCRIPTION
I'm not sure how well-received this will be, but I wrote some TypeScript definitions for this project that allow you to get type information and documentation from at least [Visual Studio Editors](https://www.visualstudio.com/en-us/visual-studio-homepage-vs.aspx), which are now [free for open source developers](https://www.visualstudio.com/products/visual-studio-community-vs), even on [Linux and OS X](https://www.visualstudio.com/products/code-vs).

As an added bonus, this [restricts plugin developers to the public API](https://github.com/postcss/postcss/blob/master/docs/guidelines/plugin.md#24-use-only-the-public-postcss-api).

Here's an attached screenshot that illustrates methods available via inheritance from the `Node` class:

![postcss-typescript](https://cloud.githubusercontent.com/assets/1058243/8884963/039107a2-3221-11e5-8852-20accd238329.png)

Here's another example that illustrates the knowledge that we're dealing with a `Declaration` here:

![postcss-typescript2](https://cloud.githubusercontent.com/assets/1058243/8885070/fc91f550-3221-11e5-8d1e-306e08815752.png)
