### PR TITLE
Add immutable-css tool to analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ See also plugins in modular minifier [`cssnano`].
 * [`css2modernizr`] creates a Modernizr config file
   that requires only the tests that your CSS uses.
 * [`doiuse`] lints CSS for browser support, using data from Can I Use.
+* [`immutable-css`] lints CSS for class mutations.
 * [`list-selectors`] lists and categorizes the selectors used in your CSS,
   for code review.
 
@@ -491,6 +492,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-short`]:                  https://github.com/jonathantneal/postcss-short
 [`postcss-alias`]:                  https://github.com/seaneking/postcss-alias
 [`perfectionist`]:                  https://github.com/ben-eb/perfectionist
+[`immutable-css`]:                  https://github.com/johnotander/immutable-css
 [`postcss-at2x`]:                   https://github.com/simonsmith/postcss-at2x
 [`postcss-calc`]:                   https://github.com/postcss/postcss-calc
 [`postcss-crip`]:                   https://github.com/johnie/postcss-crip


### PR DESCRIPTION
Figure this will be useful here now that it's `1.0`, and closes johnotander/immutable-css/issues/13 created by @ai. Currently, this tool doesn't exactly function as a PostCSS plugin. However, it does use PostCSS, and incorporating the PostCSS plugin API is on the [roadmap](https://github.com/johnotander/immutable-css/issues/20).