### PR TITLE
Mention postcss.parts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Read the [PostCSS API] for more details about the JS API.
 
 ## Plugins
 
+Go to [postcss.parts](http://postcss.parts) for a searchable catalog of the plugins mentioned below!
+
 ### Control
 
 There are two ways to make PostCSS magic more explicit.


### PR DESCRIPTION
To make it easier to find the plugin users are looking for, mention [postcss.parts](http://postcss.parts) in the README.