### PR TITLE
Introduce TypeScript definitions

### DIFF
--- a/.yaspellerrc
+++ b/.yaspellerrc
@@ -84,6 +84,7 @@
     "transpile",
     "transpiles",
     "transpiling",
+    "tokenize",
     "tokenizer",
     "linters",
     "rebases",

--- a/d.ts/at-rule.d.ts
+++ b/d.ts/at-rule.d.ts
@@ -1,0 +1,41 @@
+import Container from './container';
+import postcss from './postcss';
+export default class AtRule extends Container implements postcss.AtRule {
+    /**
+     * Returns a string representing the node's type. Possible values are
+     * root, atrule, rule, decl or comment.
+     */
+    type: string;
+    /**
+     * Contains information to generate byte-to-byte equal node string as it
+     * was in origin input.
+     */
+    raws: postcss.AtRuleRaws;
+    /**
+     * The identifier that immediately follows the @.
+     */
+    name: string;
+    /**
+     * These are the values that follow the at-rule's name, but precede any {}
+     * block. The spec refers to this area as the at-rule's "prelude".
+     */
+    params: string;
+    /**
+     * Represents an at-rule. This node will have a nodes property,
+     * representing its children, if it is followed in the CSS by a {} block.
+     */
+    constructor(defaults?: postcss.AtRuleNewProps);
+    /**
+     * @param overrides New properties to override in the clone.
+     * @returns A clone of this node. The node and its (cloned) children will
+     * have a clean parent and code style properties.
+     */
+    clone(overrides?: Object): AtRule;
+    toJSON(): postcss.JsonAtRule;
+    append(...children: any[]): Container;
+    prepend(...children: any[]): Container;
+    insertBefore(oldNode: any, newNode: any): Container;
+    insertAfter(oldNode: any, newNode: any): Container;
+    afterName: string;
+    _params: string;
+}

--- a/d.ts/comment.d.ts
+++ b/d.ts/comment.d.ts
@@ -1,0 +1,28 @@
+import postcss from './postcss';
+import Node from './node';
+export default class Comment extends Node implements postcss.Comment {
+    /**
+     * Returns a string representing the node's type. Possible values are
+     * root, atrule, rule, decl or comment.
+     */
+    type: string;
+    /**
+     * The comment's text.
+     */
+    text: string;
+    /**
+     * Represents a comment between declarations or statements (rule and at-rules).
+     * Comments inside selectors, at-rules parameters, or declaration values will
+     * be stored in the Node#raws properties.
+     */
+    constructor(defaults?: postcss.CommentNewProps);
+    /**
+     * @param overrides New properties to override in the clone.
+     * @returns A clone of this node. The node and its (cloned) children will
+     * have a clean parent and code style properties.
+     */
+    clone(overrides?: Object): any;
+    toJSON(): postcss.JsonComment;
+    left: string;
+    right: string;
+}

--- a/d.ts/container.d.ts
+++ b/d.ts/container.d.ts
@@ -1,0 +1,217 @@
+import Comment from './comment';
+import postcss from './postcss';
+import AtRule from './at-rule';
+import Node from './node';
+import Rule from './rule';
+/**
+ * Containers can store any content. If you write a rule inside a rule,
+ * PostCSS will parse it.
+ */
+export default class Container extends Node implements postcss.Container {
+    private indexes;
+    /**
+     * Contains the container's children.
+     */
+    nodes: Node[];
+    /**
+     * @param overrides New properties to override in the clone.
+     * @returns A clone of this node. The node and its (cloned) children will
+     * have a clean parent and code style properties.
+     */
+    clone(overrides?: Object): any;
+    toJSON(): postcss.JsonContainer;
+    cleanRaws(keepBetween?: boolean): void;
+    push(child: any): Container;
+    /**
+     * Iterates through the container's immediate children, calling the
+     * callback function for each child. If you need to recursively iterate
+     * through all the container's nodes, use container.eachInside(). Unlike
+     * the for {} -cycle or Array#forEach() this iterator is safe if you are
+     * mutating the array of child nodes during iteration.
+     * @param callback Iterator. Returning false will break iteration. Safe
+     * if you are mutating the array of child nodes during iteration. PostCSS
+     * will adjust the current index to match the mutations.
+     */
+    each(callback: (node: Node, index: number) => any): boolean | void;
+    /**
+     * Recursively iterates through the container's children, those children's
+     * children, etc., calling callback for each. Like container.each(), this
+     * method is safe to use if you are mutating arrays during iteration. If
+     * you only need to iterate through the container's immediate children, use
+     * container.each().
+     * @param callback Iterator.
+     */
+    eachInside(callback: (node: Node, index: number) => any): boolean | void;
+    /**
+     * Recursively iterates through all declaration nodes within the container.
+     * Like container.each(), this method is safe to use if you are mutating
+     * arrays during iteration.
+     * @param propFilter Filters declarations by property name. Only those
+     * declarations whose property matches propFilter will be iterated over.
+     * @param callback Called for each declaration node within the container.
+     */
+    eachDecl(propFilter: string | RegExp, callback?: (decl: postcss.Declaration, index: number) => any): boolean | void;
+    eachDecl(callback: (decl: postcss.Declaration, index: number) => any): boolean | void;
+    /**
+     * Recursively iterates through all rule nodes within the container.
+     * Like container.each(), this method is safe to use if you are mutating
+     * arrays during iteration.
+     * @param selectorFilter Filters rules by selector. Only those rules whose
+     * name matches the filter will be iterated over.
+     * @param callback Iterator called for each rule node within the
+     * container.
+     */
+    eachRule(selectorFilter: string | RegExp, callback: (atRule: Rule, index: number) => any): boolean | void;
+    eachRule(callback: (atRule: Rule, index: number) => any): boolean | void;
+    /**
+     * Recursively iterates through all at-rule nodes. Like container.each(),
+     * this method is safe to use if you are mutating arrays during iteration.
+     * @param nameFilter Filters at-rules by name. Only those at-rules whose
+     * name matches filter will be iterated over.
+     * @param callback Iterator called for each at-rule node within the
+     * container.
+     */
+    eachAtRule(nameFilter: string | RegExp, callback: (atRule: AtRule, index: number) => any): boolean | void;
+    eachAtRule(callback: (atRule: AtRule, index: number) => any): boolean | void;
+    /**
+     * Recursively iterates through all comment nodes within the container.
+     * Like container.each(), this method is safe to use if you are mutating
+     * arrays during iteration.
+     * @param callback Iterator called for each comment node within the container.
+     */
+    eachComment(callback: (comment: Comment, indexed: number) => any): void | boolean;
+    /**
+     * Inserts new nodes to the end of the container.
+     * Because each node class is identifiable by unique properties, use the
+     * following shortcuts to create nodes in insert methods:
+     *     root.append({ name: '@charset', params: '"UTF-8"' }); // at-rule
+     *     root.append({ selector: 'a' });                       // rule
+     *     rule.append({ prop: 'color', value: 'black' });       // declaration
+     *     rule.append({ text: 'Comment' })                      // comment
+     * A string containing the CSS of the new element can also be used. This
+     * approach is slower than the above shortcuts.
+     *     root.append('a {}');
+     *     root.first.append('color: black; z-index: 1');
+     * @param nodes New nodes.
+     * @returns This container for chaining.
+     */
+    append(...nodes: (Node | Object | string)[]): Container;
+    /**
+     * Inserts new nodes to the beginning of the container.
+     * Because each node class is identifiable by unique properties, use the
+     * following shortcuts to create nodes in insert methods:
+     *     root.prepend({ name: '@charset', params: '"UTF-8"' }); // at-rule
+     *     root.prepend({ selector: 'a' });                       // rule
+     *     rule.prepend({ prop: 'color', value: 'black' });       // declaration
+     *     rule.prepend({ text: 'Comment' })                      // comment
+     * A string containing the CSS of the new element can also be used. This
+     * approach is slower than the above shortcuts.
+     *     root.prepend('a {}');
+     *     root.first.prepend('color: black; z-index: 1');
+     * @param nodes New nodes.
+     * @returns This container for chaining.
+     */
+    prepend(...nodes: (Node | Object | string)[]): Container;
+    /**
+     * Insert newNode before oldNode within the container.
+     * @param oldNode Child or child's index.
+     * @returns This container for chaining.
+     */
+    insertBefore(oldNode: Node | number, newNode: Node | Object | string): Container;
+    /**
+     * Insert newNode after oldNode within the container.
+     * @param oldNode Child or child's index.
+     * @returns This container for chaining.
+     */
+    insertAfter(oldNode: Node | number, newNode: Node | Object | string): Container;
+    /**
+     * Removes the container from its parent and cleans the parent property in the
+     * container and its children.
+     * @returns This container for chaining.
+     */
+    remove(): any;
+    /**
+     * Removes child from the container, and the parent properties of node and
+     * its children.
+     * @param child Child or child's index.
+     * @returns This container for chaining.
+     */
+    removeChild(child: Node | number): Container;
+    /**
+     * Removes all children from the container and cleans their parent
+     * properties.
+     * @returns This container for chaining.
+     */
+    removeAll(): Container;
+    /**
+     * Passes all declaration values within the container that match pattern
+     * through the callback, replacing those values with the returned result of
+     * callback. This method is useful if you are using a custom unit or
+     * function and need to iterate through all values.
+     * @param pattern Pattern that we need to replace.
+     * @param options Options to speed up the search.
+     * @param callbackOrReplaceValue String to replace pattern or callback
+     * that will return a new value. The callback will receive the same
+     * arguments as those passed to a function parameter of String#replace.
+     */
+    replaceValues(pattern: string | RegExp, options: {
+        /**
+         * Property names. The method will only search for values that match
+         * regexp  within declarations of listed properties.
+         */
+        props?: string[];
+        /**
+         * Used to narrow down values and speed up the regexp search. Searching
+         * every single value with a regexp can be slow. If you pass a fast
+         * string, PostCSS will first check whether the value contains the fast
+         * string; and only if it does will PostCSS check that value against
+         * regexp. For example, instead of just checking for /\d+rem/ on all
+         * values, set fast: 'rem' to first check whether a value has the rem
+         * unit, and only if it does perform the regexp check.
+         */
+        fast?: string;
+    }, callbackOrReplaceValue: string | {
+        (substring: string, ...args: any[]): string;
+    }): Container;
+    replaceValues(pattern: string | RegExp, callbackOrReplaceValue: string | {
+        (substring: string, ...args: any[]): string;
+    }): Container;
+    /**
+     * Determines whether all child nodes satisfy the specified test.
+     * @param callback A function that accepts up to three arguments. The
+     * every method calls the callback function for each node until the
+     * callback returns false, or until the end of the array.
+     * @returns True if the callback returns true for all of the container's
+     * children.
+     */
+    every(callback: (node: Node, index: number, nodes: Node[]) => any, thisArg?: any): boolean;
+    /**
+     * Determines whether the specified callback returns true for any child node.
+     * @param callback A function that accepts up to three arguments. The some
+     * method calls the callback for each node until the callback returns true,
+     * or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the
+     * callback function. If thisArg is omitted, undefined is used as the
+     * this value.
+     * @returns True if callback returns a true value for (at least) one of the
+     * container's children.
+     */
+    some(callback: (node: Node, index: number, nodes: Node[]) => boolean, thisArg?: any): boolean;
+    /**
+     * @param child Child of current container.
+     * @returns The child's index within the container's "nodes" array.
+     */
+    index(child: Node | number): number;
+    /**
+     * @returns The container's first child.
+     */
+    first: Node;
+    /**
+     * @returns The container's last child.
+     */
+    last: Node;
+    protected normalize(node: Node | string, sample?: Node, type?: string | boolean): Node[];
+    protected normalize(props: postcss.AtRuleNewProps | postcss.RuleNewProps | postcss.DeclarationNewProps | postcss.CommentNewProps, sample?: Node, type?: string | boolean): Node[];
+    semicolon: boolean;
+    after: string;
+}

--- a/d.ts/css-syntax-error.d.ts
+++ b/d.ts/css-syntax-error.d.ts
@@ -1,0 +1,120 @@
+import postcss from './postcss';
+export default class CssSyntaxError implements postcss.CssSyntaxError, SyntaxError {
+    /**
+     * Contains full error text by GNU error format.
+     */
+    message: string;
+    /**
+     * Contains source line of error. PostCSS will use the input source map
+     * to detect the original error location. If you wrote a Sass file, then
+     * compiled it to CSS and parsed it with PostCSS, PostCSS will show the
+     * original position in the Sass file. If you need position in PostCSS
+     * input (e.g., to debug previous compiler), use error.generated.line.
+     */
+    line: number;
+    /**
+     * Contains the source column of the error. PostCSS will use input
+     * source map to detect the original error location. If you wrote a Sass
+     * file, then compiled it to CSS and parsed it with PostCSS, PostCSS
+     * will show the original position in the Sass file. If you need
+     * position in PostCSS input (e.g., to debug previous compiler), use
+     * error.generated.column.
+     */
+    column: number;
+    /**
+     * Contains source code of broken file. PostCSS will use input source
+     * map to detect the original error location. If you wrote a Sass file,
+     * then compiled it to CSS and parsed it with PostCSS, PostCSS will show
+     * the original position in the Sass file. If you need position in
+     * PostCSS input (e.g., to debug previous compiler), use
+     * error.generated.source.
+     */
+    source: string;
+    /**
+     * If parser's from option is set, contains absolute path to broken file.
+     * PostCSS will use the input source map to detect the original error
+     * location. If you wrote a Sass file, then compiled it to CSS and
+     * parsed it with PostCSS, PostCSS will show the original position in
+     * the Sass file. If you need the position in PostCSS input
+     * (e.g., to debug previous compiler), use error.generated.file.
+     */
+    file: string;
+    /**
+     * Contains PostCSS plugin name if error did not come from CSS parser.
+     */
+    plugin: string;
+    name: string;
+    /**
+     * Contains only the error description.
+     */
+    reason: string;
+    private columnNumber;
+    private description;
+    private lineNumber;
+    private fileName;
+    input: postcss.InputOrigin;
+    /**
+     * The CSS parser throws this error for broken CSS.
+     */
+    constructor(
+        /**
+         * Contains full error text by GNU error format.
+         */
+        message: string, 
+        /**
+         * Contains source line of error. PostCSS will use the input source map
+         * to detect the original error location. If you wrote a Sass file, then
+         * compiled it to CSS and parsed it with PostCSS, PostCSS will show the
+         * original position in the Sass file. If you need position in PostCSS
+         * input (e.g., to debug previous compiler), use error.generated.line.
+         */
+        line?: number, 
+        /**
+         * Contains the source column of the error. PostCSS will use input
+         * source map to detect the original error location. If you wrote a Sass
+         * file, then compiled it to CSS and parsed it with PostCSS, PostCSS
+         * will show the original position in the Sass file. If you need
+         * position in PostCSS input (e.g., to debug previous compiler), use
+         * error.generated.column.
+         */
+        column?: number, 
+        /**
+         * Contains source code of broken file. PostCSS will use input source
+         * map to detect the original error location. If you wrote a Sass file,
+         * then compiled it to CSS and parsed it with PostCSS, PostCSS will show
+         * the original position in the Sass file. If you need position in
+         * PostCSS input (e.g., to debug previous compiler), use
+         * error.generated.source.
+         */
+        source?: string, 
+        /**
+         * If parser's from option is set, contains absolute path to broken file.
+         * PostCSS will use the input source map to detect the original error
+         * location. If you wrote a Sass file, then compiled it to CSS and
+         * parsed it with PostCSS, PostCSS will show the original position in
+         * the Sass file. If you need the position in PostCSS input
+         * (e.g., to debug previous compiler), use error.generated.file.
+         */
+        file?: string, 
+        /**
+         * Contains PostCSS plugin name if error did not come from CSS parser.
+         */
+        plugin?: string);
+    private setMessage();
+    /**
+     * @param color Whether arrow should be colored red by terminal color codes.
+     * By default, PostCSS will use process.stdout.isTTY and
+     * process.env.NODE_DISABLE_COLORS.
+     * @returns A few lines of CSS source that caused the error. If CSS has
+     * input source map without sourceContent this method will return an empty
+     * string.
+     */
+    showSourceCode(color?: boolean): string;
+    private highlight(color);
+    private setMozillaProps();
+    /**
+     *
+     * @returns Error position, message and source code of broken part.
+     */
+    toString(): string;
+}

--- a/d.ts/declaration.d.ts
+++ b/d.ts/declaration.d.ts
@@ -1,0 +1,42 @@
+import postcss from './postcss';
+import Node from './node';
+export default class Declaration extends Node implements postcss.Declaration {
+    /**
+     * Returns a string representing the node's type. Possible values are
+     * root, atrule, rule, decl or comment.
+     */
+    type: string;
+    /**
+     * Contains information to generate byte-to-byte equal node string as it
+     * was in origin input.
+     */
+    raws: postcss.DeclarationRaws;
+    /**
+     * The declaration's property name.
+     */
+    prop: string;
+    /**
+     * The declaration's value. This value will be cleaned of comments. If the
+     * source value contained comments, those comments will be available in the
+     * _value.raws property. If you have not changed the value, the result of
+     * decl.toString() will include the original raws value (comments and all).
+     */
+    value: string;
+    /**
+     * True if the declaration has an !important annotation.
+     */
+    important: boolean;
+    /**
+     * Represents a CSS declaration.
+     */
+    constructor(defaults?: postcss.DeclarationNewProps);
+    /**
+     * @param overrides New properties to override in the clone.
+     * @returns A clone of this node. The node and its (cloned) children will
+     * have a clean parent and code style properties.
+     */
+    clone(overrides?: Object): any;
+    toJSON(): postcss.JsonDeclaration;
+    _value: string;
+    _important: string;
+}

--- a/d.ts/input.d.ts
+++ b/d.ts/input.d.ts
@@ -1,0 +1,46 @@
+import CssSyntaxError from './css-syntax-error';
+import PreviousMap from './previous-map';
+import LazyResult from './lazy-result';
+import postcss from './postcss';
+import Result from './result';
+export default class Input implements postcss.Input {
+    /**
+     * The absolute path to the CSS source file defined with the "from" option.
+     */
+    file: string;
+    /**
+     * The unique ID of the CSS source. Used if "from" option is not provided
+     * (because PostCSS does not know the file path).
+     */
+    id: string;
+    /**
+     * Represents the input source map passed from a compilation step before
+     * PostCSS (for example, from the Sass compiler).
+     */
+    map: PreviousMap;
+    css: string;
+    /**
+     * Represents the source CSS.
+     */
+    constructor(css: string | {
+        toString(): string;
+    } | LazyResult | Result, opts?: {
+        safe?: boolean | any;
+        from?: string;
+    });
+    /**
+     * The CSS source identifier. Contains input.file if the user set the "from"
+     * option, or input.id if he/she did not.
+     */
+    from: string;
+    error(message: string, line: number, column: number, opts?: {
+        plugin?: string;
+    }): CssSyntaxError;
+    /**
+     * Reads the input source map.
+     * @returns A symbol position in the input source (e.g., in a Sass file
+     * that was compiled to CSS before being passed to PostCSS):
+     */
+    origin(line: number, column: number): postcss.InputOrigin;
+    private mapResolve(file);
+}

--- a/d.ts/lazy-result.d.ts
+++ b/d.ts/lazy-result.d.ts
@@ -1,0 +1,90 @@
+import Processor from './processor';
+import postcss from './postcss';
+import Result from './result';
+import Root from './root';
+export default class LazyResult implements postcss.LazyResult {
+    private stringified;
+    private processed;
+    private result;
+    private error;
+    private plugin;
+    private processing;
+    /**
+     * Promise proxy for result of PostCSS transformations.
+     */
+    constructor(processor: Processor, 
+        /**
+         * String with input CSS or any object with toString() method, like file stream.
+         * Optionally, send Result instance and the processor will take the existing
+         * [Root] parser from it.
+         */
+        css: string | {
+        toString(): string;
+    } | LazyResult | Result, opts?: postcss.ProcessOptions);
+    /**
+     * @returns A processor used for CSS transformations.
+     */
+    processor: Processor;
+    /**
+     * @returns Options from the Processor#process(css, opts) call that produced
+     * this Result instance.
+     */
+    opts: postcss.ResultOptions;
+    /**
+     * Processes input CSS through synchronous plugins and converts Root to
+     * CSS string. This property will work only with synchronous plugins. If
+     * processor contains any asynchronous plugins it will throw a error. You
+     * should use LazyResult#then() instead.
+     */
+    css: string;
+    /**
+     * Alias for css property to use when syntaxes generate non-CSS output.
+     */
+    content: string;
+    /**
+     * Processes input CSS through synchronous plugins. This property will
+     * work only with synchronous plugins. If processor contains any
+     * asynchronous plugins it will throw an error. You should use
+     * LazyResult#then() instead.
+     */
+    map: postcss.ResultMap;
+    /**
+     * Processes input CSS through synchronous plugins. This property will work
+     * only with synchronous plugins. If processor contains any asynchronous
+     * plugins it will throw an error. You should use LazyResult#then() instead.
+     */
+    root: Root;
+    /**
+     * Processes input CSS through synchronous plugins. This property will work
+     * only with synchronous plugins. If processor contains any asynchronous
+     * plugins it will throw an error. You should use LazyResult#then() instead.
+     */
+    messages: postcss.ResultMessage[];
+    /**
+     * Processes input CSS through synchronous plugins and calls Result#warnings().
+     * This property will work only with synchronous plugins. If processor
+     * contains any asynchronous plugins it will throw a error. You should use
+     * LazyResult#then()  instead.
+     */
+    warnings(): postcss.ResultMessage[];
+    /**
+     * Alias for css property.
+     */
+    toString(): string;
+    /**
+     * Processes input CSS through synchronous and asynchronous plugins.
+     * @param onRejected Called if any plugin throws an error.
+     */
+    then(onFulfilled: (result: Result) => void, onRejected?: (error: Error) => void): Function | any;
+    /**
+     * Processes input CSS through synchronous and asynchronous plugins.
+     * @param onRejected Called if any plugin throws an error.
+     */
+    catch(onRejected: (error: Error) => void): Function | any;
+    private handleError(error, plugin);
+    private asyncTick(resolve, reject);
+    private async();
+    sync(): Result;
+    private run(plugin);
+    stringify(): Result;
+}

--- a/d.ts/list.d.ts
+++ b/d.ts/list.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Contains helpers for safely splitting lists of CSS values, preserving
+ * parentheses and quotes.
+ */
+declare module List {
+    /**
+     * Safely splits space-separated values (such as those for background,
+     * border-radius and other shorthand properties).
+     */
+    function space(str: string): string[];
+    /**
+     * Safely splits comma-separated values (such as those for transition-* and
+     * background  properties).
+     */
+    function comma(str: string): string[];
+}
+export default List;

--- a/d.ts/map-generator.d.ts
+++ b/d.ts/map-generator.d.ts
@@ -1,0 +1,26 @@
+import Root from './root';
+export default class MapGenerator {
+    private stringify;
+    private root;
+    private opts;
+    private mapOpts;
+    private previousMaps;
+    private map;
+    private css;
+    constructor(stringify: any, root: Root, opts: any);
+    isMap(): boolean;
+    previous(): any;
+    isInline(): any;
+    isSourcesContent(): any;
+    clearAnnotation(): void;
+    setSourcesContent(): void;
+    applyPrevMaps(): void;
+    isAnnotation(): any;
+    addAnnotation(): void;
+    outputFile(): any;
+    generateMap(): any[];
+    relative(file: any): any;
+    sourcePath(node: any): any;
+    generateString(): void;
+    generate(): any[];
+}

--- a/d.ts/node.d.ts
+++ b/d.ts/node.d.ts
@@ -1,0 +1,154 @@
+import Container from './container';
+import CssSyntaxError from './css-syntax-error';
+import postcss from './postcss';
+import Result from './result';
+import Root from './root';
+export default class Node implements postcss.Node {
+    /**
+     * Returns a string representing the node's type. Possible values are
+     * root, atrule, rule, decl or comment.
+     */
+    type: string;
+    /**
+     * Contains information to generate byte-to-byte equal node string as it
+     * was in origin input.
+     */
+    raws: postcss.NodeRaws;
+    /**
+     * Returns the node's parent node.
+     */
+    parent: Container;
+    /**
+     * Returns the input source of the node. The property is used in source map
+     * generation. If you create a node manually (for example, with
+     * postcss.decl() ), that node will not have a  source  property and will
+     * be absent from the source map. For this reason, the plugin developer
+     * should consider cloning nodes to create new ones (in which case the new
+     * node's source will reference the original, cloned node) or setting the
+     * source property manually.
+     */
+    source: postcss.NodeSource;
+    constructor(defaults?: Object);
+    /**
+     * This method produces very useful error messages. If present, an input
+     * source map will be used to get the original position of the source, even
+     * from a previous compilation step (e.g., from Sass compilation).
+     * @returns The original position of the node in the source, showing line
+     * and column numbers and also a small excerpt to facilitate debugging.
+     */
+    error(
+        /**
+         * Error description.
+         */
+        message: string, options?: postcss.NodeErrorOptions): CssSyntaxError;
+    /**
+     * Creates a Warning and adds it to messages. This method is provided as
+     * a convenience wrapper for Result#warn.
+     * @param result The result that will receive the warning.
+     * @param message Error description.
+     */
+    warn(result: Result, message: string): void;
+    /**
+     * Deprecated. Use Node#remove.
+     */
+    removeSelf(): void;
+    /**
+     * Removes the node from its parent and cleans the parent property in the
+     * node and its children.
+     * @returns This node for chaining.
+     */
+    remove(): Node;
+    replace(nodes: any): Node;
+    /**
+     * @returns A CSS string representing the node.
+     */
+    toString(stringifier?: any): string;
+    /**
+     * @param overrides New properties to override in the clone.
+     * @returns A clone of this node. The node and its (cloned) children will
+     * have a clean parent and code style properties.
+     */
+    clone(overrides?: Object): Node;
+    /**
+     * Shortcut to clone the node and insert the resulting cloned node before
+     * the current node.
+     * @param overrides New Properties to override in the clone.
+     * @returns The cloned node.
+     */
+    cloneBefore(overrides?: Object): Node;
+    /**
+     * Shortcut to clone the node and insert the resulting cloned node after
+     * the current node.
+     * @param overrides New Properties to override in the clone.
+     * @returns The cloned node.
+     */
+    cloneAfter(overrides?: Object): Node;
+    /**
+     * Inserts nodes before the current node and removes the current node.
+     * @returns This node for chaining.
+     */
+    replaceWith(...nodes: (Node | Object)[]): Node;
+    /**
+     * Removes the node from its current parent and inserts it at the end of
+     * newParent. This will clean the before and after code style properties
+     * from the node, and replace them with the indentation style of newParent.
+     * It will also clean the between property if newParent is in another Root.
+     * @param newParent Where the current node will be moved.
+     * @returns This node for chaining.
+     */
+    moveTo(newParent: Container): Node;
+    /**
+     * Removes the node from its current parent and inserts it into a new
+     * parent before otherNode. This will also clean the node's code style
+     * properties just as node.moveTo(newParent) does.
+     * @param otherNode Will be after the current node after moving.
+     * @returns This node for chaining.
+     */
+    moveBefore(otherNode: Node): Node;
+    /**
+     * Removes the node from its current parent and inserts it into a new
+     * parent after otherNode. This will also clean the node's code style
+     * properties just as node.moveTo(newParent) does.
+     * @param otherNode Will be before the current node after moving.
+     * @returns This node for chaining.
+     */
+    moveAfter(otherNode: Node): Node;
+    /**
+     * @returns The next child of the node's parent; or, returns undefined if
+     * the current node is the last child.
+     */
+    next(): Node;
+    /**
+     * @returns The previous child of the node's parent; or, returns undefined
+     * if the current node is the first child.
+     */
+    prev(): Node;
+    toJSON(): postcss.JsonNode;
+    /**
+     * @param prop Name or code style property.
+     * @param defaultType Name of default value. It can be easily missed if the
+     * value is the same as prop.
+     * @returns A code style property value. If the node is missing the code
+     * style property (because the node was manually built or cloned), PostCSS
+     * will try to autodetect the code style property by looking at other nodes
+     * in the tree.
+     */
+    raw(prop: string, defaultType?: string): any;
+    /**
+     * @returns The Root instance of the node's tree.
+     */
+    root(): Root;
+    cleanRaws(keepBetween?: boolean): void;
+    positionInside(index: number): {
+        line: number;
+        column: number;
+    };
+    positionBy(options: any): {
+        column: number;
+        line: number;
+    };
+    style(prop: string, defaultType?: string): any;
+    cleanStyles(keepBetween?: boolean): void;
+    before: string;
+    between: string;
+}

--- a/d.ts/parse.d.ts
+++ b/d.ts/parse.d.ts
@@ -1,0 +1,20 @@
+import LazyResult from './lazy-result';
+import postcss from './postcss';
+import Result from './result';
+import Root from './root';
+/**
+ * Parses source CSS.
+ * @param css The CSS to parse.
+ * @param options
+ * @returns {} A new Root node, which contains the source CSS nodes.
+ */
+declare function parse(css: string | {
+    toString(): string;
+} | LazyResult | Result, options?: {
+    from?: string;
+    map?: postcss.SourceMapOptions;
+}): Root;
+declare module parse {
+    var parse: postcss.Syntax | postcss.Parse;
+}
+export default parse;

--- a/d.ts/parser.d.ts
+++ b/d.ts/parser.d.ts
@@ -1,0 +1,38 @@
+import Input from './input';
+import Node from './node';
+import Root from './root';
+export default class Parser {
+    input: Input;
+    pos: number;
+    root: Root;
+    spaces: string;
+    semicolon: boolean;
+    private current;
+    private tokens;
+    constructor(input: Input);
+    tokenize(): void;
+    loop(): void;
+    comment(token: any): void;
+    emptyRule(token: any): void;
+    word(): void;
+    rule(tokens: any): void;
+    decl(tokens: any): void;
+    atrule(token: any): void;
+    end(token: any): void;
+    endFile(): void;
+    init(node: Node, line?: number, column?: number): void;
+    raw(node: any, prop: any, tokens: any): void;
+    spacesFromEnd(tokens: any): string;
+    spacesFromStart(tokens: any): string;
+    stringFrom(tokens: any, from: any): string;
+    colon(tokens: any): number | boolean;
+    unknownDecl(node: any, token: any): void;
+    unclosedBracket(bracket: any): void;
+    unknownWord(start: any): void;
+    unexpectedClose(token: any): void;
+    unclosedBlock(): void;
+    doubleColon(token: any): void;
+    unnamedAtrule(node: any, token: any): void;
+    precheckMissedSemicolon(tokens: any): void;
+    checkMissedSemicolon(tokens: any): void;
+}

--- a/d.ts/postcss.d.ts
+++ b/d.ts/postcss.d.ts
@@ -1,0 +1,1227 @@
+import PreviousMap from './previous-map';
+import Stringifier from './stringifier';
+import _vendor from './vendor';
+import _list from './list';
+/**
+ * @param plugins Can also be included with the Processor#use method.
+ * @returns A processor that will apply plugins as CSS processors.
+ */
+declare function postcss(plugins?: (typeof postcss.acceptedPlugin)[]): postcss.Processor;
+declare function postcss(...plugins: (typeof postcss.acceptedPlugin)[]): postcss.Processor;
+declare module postcss {
+    var acceptedPlugin: Plugin<any> | Transformer | {
+        postcss: TransformCallback | Processor;
+    } | Processor;
+    /**
+     * Creates a PostCSS plugin with a standard API.
+     * @param name Plugin name. Same as in name property in package.json. It will
+     * be saved in plugin.postcssPlugin property.
+     * @param initializer Will receive plugin options and should return functions
+     * to modify nodes in input CSS.
+     */
+    function plugin<T>(name: string, initializer: PluginInitializer<T>): Plugin<T>;
+    interface Plugin<T> extends Transformer {
+        (opts?: T): Transformer;
+        postcss: Transformer;
+        process: (css, opts?: any) => LazyResult;
+    }
+    interface Transformer extends TransformCallback {
+        postcssPlugin?: string;
+        postcssVersion?: string;
+    }
+    interface TransformCallback {
+        /**
+         * @returns Asynchronous plugins should return a promise.
+         */
+        (root: Root, result?: Result): void | Function | any;
+    }
+    interface PluginInitializer<T> {
+        (pluginOptions?: T): Transformer;
+    }
+    /**
+     * Contains the Vendor module, which contains helpers for working with
+     * vendor prefixes.
+     */
+    var vendor: typeof _vendor;
+    /**
+     * Default function to convert nodes tree to CSS string.
+     */
+    function stringify(node: Node, builder: Stringifier.Builder): void;
+    /**
+     * Parses source CSS.
+     * @param css The CSS to parse.
+     * @param options
+     * @returns {} A new Root node, which contains the source CSS nodes.
+     */
+    function parse(css: string | {
+        toString(): string;
+    } | LazyResult | Result, options?: {
+        from?: string;
+        map?: postcss.SourceMapOptions;
+    }): Root;
+    /**
+     * Contains the List module, which contains helpers for safely splitting
+     * lists of CSS values, preserving parentheses and quotes.
+     */
+    var list: typeof _list;
+    /**
+     * Creates a new Comment node.
+     * @param defaults Properties for the new node.
+     * @returns The new node.
+     */
+    function comment(defaults?: CommentNewProps): Comment;
+    /**
+     * Creates a new AtRule node.
+     * @param defaults Properties for the new node.
+     * @returns The new node.
+     */
+    function atRule(defaults?: AtRuleNewProps): AtRule;
+    /**
+     * Creates a new Declaration node.
+     * @param defaults Properties for the new node.
+     * @returns The new node.
+     */
+    function decl(defaults?: DeclarationNewProps): Declaration;
+    /**
+     * Creates a new Rule node.
+     * @param defaults Properties for the new node.
+     * @returns The new node.
+     */
+    function rule(defaults?: RuleNewProps): Rule;
+    /**
+     * Creates a new Root node.
+     * @param defaults Properties for the new node.
+     * @returns The new node.
+     */
+    function root(defaults?: Object): Root;
+    interface SourceMapOptions {
+        /**
+         * Indicates that the source map should be embedded in the output CSS as a
+         * Base64-encoded comment. By default, it is true. But if all previous maps
+         * are external, not inline, PostCSS will not embed the map even if you do
+         * not set this option.
+         *
+         * If you have an inline source map, the result.map property will be empty,
+         * as the source map will be contained within the text of result.css.
+         */
+        inline?: boolean;
+        /**
+         * Source map content from a previous processing step (for example, Sass compilation).
+         * PostCSS will try to read the previous source map automatically (based on comments
+         * within the source CSS), but you can use this option to identify it manually.
+         * If desired, you can omit the previous map with prev: false.
+         */
+        prev?: any;
+        /**
+         * Indicates that PostCSS should set the origin content (for example, Sass source)
+         * of the source map. By default, it is true. But if all previous maps do not
+         * contain sources content, PostCSS will also leave it out even if you do not set
+         * this option.
+         */
+        sourcesContent?: boolean;
+        /**
+         * Indicates that PostCSS should add annotation comments to the CSS. By default,
+         * PostCSS will always add a comment with a path to the source map. PostCSS will
+         * not add annotations to CSS files that do not contain any comments.
+         *
+         * By default, PostCSS presumes that you want to save the source map as
+         * opts.to + '.map' and will use this path in the annotation comment. A different
+         * path can be set by providing a string value for annotation.
+         *
+         * If you have set inline: true, annotation cannot be disabled.
+         */
+        annotation?: boolean | string;
+        /**
+         * If true, PostCSS will try to correct any syntax errors that it finds in the CSS.
+         * This is useful for legacy code filled with hacks. Another use-case is interactive
+         * tools with live input — for example, the Autoprefixer demo.
+         */
+        safe?: boolean;
+    }
+    /**
+     * A Processor instance contains plugins to process CSS. Create one
+     * Processor  instance, initialize its plugins, and then use that instance
+     * on many CSS files.
+     */
+    interface Processor {
+        /**
+         * Adds a plugin to be used as a CSS processor. Plugins can also be
+         * added by passing them as arguments when creating a postcss instance.
+         */
+        use(plugin: typeof acceptedPlugin): Processor;
+        /**
+         * Parses source CSS. Because some plugins can be asynchronous it doesn't
+         * make any transformations. Transformations will be applied in LazyResult's
+         * methods.
+         * @param css Input CSS or any object with toString() method, like a file
+         * stream. If a Result instance is passed the processor will take the
+         * existing Root parser from it.
+         */
+        process(css: string | {
+            toString(): string;
+        } | Result, options?: ProcessOptions): LazyResult;
+        /**
+         * Contains plugins added to this processor.
+         */
+        plugins: Plugin<any>[];
+        /**
+         * Contains current version of PostCSS (e.g., "4.0.5").
+         */
+        version: string;
+    }
+    interface ProcessOptions extends Syntax {
+        /**
+         * The path of the CSS source file. You should always set from, because it is
+         * used in source map generation and syntax error messages.
+         */
+        from?: string;
+        /**
+         * The path where you'll put the output CSS file. You should always set it
+         * to generate correct source maps.
+         */
+        to?: string;
+        syntax?: Syntax;
+        /**
+         * Enable Safe Mode, in which PostCSS will try to fix CSS syntax errors.
+         */
+        safe?: boolean;
+        map?: postcss.SourceMapOptions;
+        /**
+         * Function to generate AST by string.
+         */
+        parser?: Parse | Syntax;
+        /**
+         * Class to generate string by AST.
+         */
+        stringifier?: Stringify | Syntax;
+    }
+    interface Syntax {
+        /**
+         * Function to generate AST by string.
+         */
+        parse?: Parse;
+        /**
+         * Class to generate string by AST.
+         */
+        stringify?: Stringify;
+    }
+    interface Parse {
+        (css?: string, opts?: postcss.SourceMapOptions): Root;
+    }
+    interface Stringify {
+        (node?: postcss.Node, builder?: any): postcss.Result | void;
+    }
+    /**
+     * Promise proxy for result of PostCSS transformations.
+     */
+    interface LazyResult {
+        /**
+         * Processes input CSS through synchronous and asynchronous plugins.
+         * @param onRejected Called if any plugin throws an error.
+         */
+        then(onFulfilled: (result: Result) => void, onRejected?: (error: Error) => void): Function | any;
+        /**
+         * Processes input CSS through synchronous and asynchronous plugins.
+         * @param onRejected Called if any plugin throws an error.
+         */
+        catch(onRejected: (error: Error) => void): Function | any;
+        /**
+         * Alias for css property.
+         */
+        toString(): string;
+        /**
+         * Processes input CSS through synchronous plugins and converts Root to
+         * CSS string. This property will work only with synchronous plugins. If
+         * processor contains any asynchronous plugins it will throw a error. You
+         * should use LazyResult#then() instead.
+         * @returns Result#css.
+         */
+        css: string;
+        /**
+         * Alias for css property to use when syntaxes generate non-CSS output.
+         */
+        content: string;
+        /**
+         * Processes input CSS through synchronous plugins. This property will
+         * work only with synchronous plugins. If processor contains any
+         * asynchronous plugins it will throw an error. You should use
+         * LazyResult#then() instead.
+         */
+        map: ResultMap;
+        /**
+         * Processes input CSS through synchronous plugins. This property will work
+         * only with synchronous plugins. If processor contains any asynchronous
+         * plugins it will throw an error. You should use LazyResult#then() instead.
+         */
+        root: Root;
+        /**
+         * Processes input CSS through synchronous plugins and calls Result#warnings().
+         * This property will work only with synchronous plugins. If processor
+         * contains any asynchronous plugins it will throw a error. You should use
+         * LazyResult#then()  instead.
+         */
+        warnings(): ResultMessage[];
+        /**
+         * Processes input CSS through synchronous plugins. This property will work
+         * only with synchronous plugins. If processor contains any asynchronous
+         * plugins it will throw an error. You should use LazyResult#then() instead.
+         */
+        messages: ResultMessage[];
+        /**
+         * @returns A processor used for CSS transformations.
+         */
+        processor: Processor;
+        /**
+         * @returns Options from the Processor#process(css, opts) call that produced
+         * this Result instance.
+         */
+        opts: ResultOptions;
+    }
+    /**
+     * Provides the result of the PostCSS transformations.
+     */
+    interface Result {
+        /**
+         * Alias for css property.
+         */
+        toString(): string;
+        /**
+         * Creates a Warning and adds it to messages.
+         * @param message Used in the text property of the message object.
+         * @param options Properties for Message object.
+         */
+        warn(message: string, options?: WarningOptions): void;
+        /**
+         * @returns Warnings from plugins, filtered from messages.
+         */
+        warnings(): ResultMessage[];
+        /**
+         * A CSS string representing this Result's Root instance.
+         */
+        css: string;
+        /**
+         * Alias for css property to use with syntaxes that generate non-CSS output.
+         */
+        content: string;
+        /**
+         * An instance of the SourceMapGenerator class from the source-map library,
+         * representing changes to the Result's Root instance.
+         * This property will have a value only if the user does not want an inline
+         * source map. By default, PostCSS generates inline source maps, written
+         * directly into the processed CSS. The map property will be empty by default.
+         * An external source map will be generated — and assigned to map — only if
+         * the user has set the map.inline option to false, or if PostCSS was passed
+         * an external input source map.
+         */
+        map: ResultMap;
+        /**
+         * Contains Root node after all transformations.
+         */
+        root: Root;
+        /**
+         * Contains messages from plugins. For example, warnings or custom messages to
+         * plugins communication. Add a warning using Result#warn() and get all warnings
+         * using Result#warnings() method.
+         */
+        messages: ResultMessage[];
+        /**
+         * The Processor instance used for this transformation.
+         */
+        processor: Processor;
+        /**
+         * Options from the Processor#process(css, opts) or Root#toResult(opts) call
+         * that produced this Result instance.
+         */
+        opts: ResultOptions;
+    }
+    interface ResultOptions extends ProcessOptions {
+        /**
+         * The CSS node that was the source of the warning.
+         */
+        node?: postcss.Node;
+        /**
+         * Name of plugin that created this warning. Result#warn() will fill it
+         * automatically with plugin.postcssPlugin value.
+         */
+        plugin?: string;
+    }
+    interface ResultMap {
+        /**
+         * Add a single mapping from original source line and column to the generated
+         * source's line and column for this source map being created. The mapping
+         * object should have the following properties:
+         * @param mapping
+         * @returns {}
+         */
+        addMapping(mapping: {
+            generated: {
+                line: number;
+                column: number;
+            };
+            original: {
+                line: number;
+                column: number;
+            };
+            /**
+             * The original source file (relative to the sourceRoot).
+             */
+            source: string;
+            name?: string;
+        }): void;
+        /**
+         * Set the source content for an original source file.
+         * @param sourceFile The URL of the original source file.
+         * @param sourceContent The content of the source file.
+         */
+        setSourceContent(sourceFile: string, sourceContent: string): void;
+        /**
+         * Applies a SourceMap for a source file to the SourceMap. Each mapping to
+         * the supplied source file is rewritten using the supplied SourceMap.
+         * Note: The resolution for the resulting mappings is the minimium of this
+         * map and the supplied map.
+         * @param sourceMapConsumer The SourceMap to be applied.
+         * @param sourceFile The filename of the source file. If omitted, sourceMapConsumer
+         * file will be used, if it exists. Otherwise an error will be thrown.
+         * @param sourceMapPath The dirname of the path to the SourceMap to be applied.
+         * If relative, it is relative to the SourceMap. This parameter is needed when
+         * the two SourceMaps aren't in the same directory, and the SourceMap to be
+         * applied contains relative source paths. If so, those relative source paths
+         * need to be rewritten relative to the SourceMap.
+         * If omitted, it is assumed that both SourceMaps are in the same directory;
+         * thus, not needing any rewriting (Supplying '.' has the same effect).
+         */
+        applySourceMap(sourceMapConsumer: any, sourceFile?: string, sourceMapPath?: string): void;
+        /**
+         * Renders the source map being generated to JSON.
+         */
+        toJSON: () => any;
+        /**
+         * Renders the source map being generated to a string.
+         */
+        toString: () => string;
+    }
+    interface ResultMessage {
+        type: string;
+        text?: string;
+        plugin?: string;
+        browsers?: string[];
+    }
+    /**
+     * Warning from plugins. It can be created using Result#warn().
+     */
+    interface Warning {
+        /**
+         * @returns Error position, message.
+         */
+        toString(): string;
+        /**
+         * Contains the warning message.
+         */
+        text: string;
+        /**
+         * Contains name of plugin that created this warning. When you call
+         * Result#warn(), it will fill this property automatically.
+         */
+        plugin: string;
+        /**
+         * The CSS node that caused the warning.
+         */
+        node: Node;
+        /**
+         * Line in input file with this warning source.
+         */
+        line: number;
+        /**
+         * Column in input file with this warning source.
+         */
+        column: number;
+    }
+    interface WarningOptions extends ResultOptions {
+        /**
+         * A word inside a node's string that should be highlighted as source
+         * of warning.
+         */
+        word?: string;
+        /**
+         * The index inside a node's string that should be highlighted as
+         * source of warning.
+         */
+        index?: number;
+    }
+    /**
+     * The CSS parser throws this error for broken CSS.
+     */
+    interface CssSyntaxError extends InputOrigin {
+        name: string;
+        /**
+         * @returns Error position, message and source code of broken part.
+         */
+        toString(): string;
+        /**
+         * @param color Whether arrow should be colored red by terminal color codes.
+         * By default, PostCSS will use process.stdout.isTTY and
+         * process.env.NODE_DISABLE_COLORS.
+         * @returns A few lines of CSS source that caused the error. If CSS has
+         * input source map without sourceContent this method will return an empty
+         * string.
+         */
+        showSourceCode(color?: boolean): string;
+        /**
+         * Contains full error text by GNU error format.
+         */
+        message: string;
+        /**
+         * Contains only the error description.
+         */
+        reason: string;
+        /**
+         * Contains PostCSS plugin name if error did not come from CSS parser.
+         */
+        plugin?: string;
+        input?: InputOrigin;
+    }
+    interface InputOrigin {
+        /**
+         * If parser's from option is set, contains absolute path to broken file.
+         * PostCSS will use the input source map to detect the original error
+         * location. If you wrote a Sass file, then compiled it to CSS and
+         * parsed it with PostCSS, PostCSS will show the original position in
+         * the Sass file. If you need the position in PostCSS input
+         * (e.g., to debug previous compiler), use error.input.file.
+         */
+        file?: string;
+        /**
+         * Contains source line of error. PostCSS will use the input source map
+         * to detect the original error location. If you wrote a Sass file, then
+         * compiled it to CSS and parsed it with PostCSS, PostCSS will show the
+         * original position in the Sass file. If you need position in PostCSS
+         * input (e.g., to debug previous compiler), use error.input.line.
+         */
+        line?: number;
+        /**
+         * Contains the source column of the error. PostCSS will use input
+         * source map to detect the original error location. If you wrote a Sass
+         * file, then compiled it to CSS and parsed it with PostCSS, PostCSS
+         * will show the original position in the Sass file. If you need
+         * position in PostCSS input (e.g., to debug previous compiler), use
+         * error.input.column.
+         */
+        column?: number;
+        /**
+         * Contains source code of broken file. PostCSS will use input source
+         * map to detect the original error location. If you wrote a Sass file,
+         * then compiled it to CSS and parsed it with PostCSS, PostCSS will show
+         * the original position in the Sass file. If you need position in
+         * PostCSS input (e.g., to debug previous compiler), use
+         * error.input.source.
+         */
+        source?: string;
+    }
+    /**
+     * Represents the source CSS.
+     */
+    interface Input {
+        /**
+         * The absolute path to the CSS source file defined with the "from" option.
+         */
+        file: string;
+        /**
+         * The unique ID of the CSS source. Used if "from" option is not provided
+         * (because PostCSS does not know the file path).
+         */
+        id: string;
+        /**
+         * The CSS source identifier. Contains input.file if the user set the
+         * "from" option, or input.id if he/she did not.
+         */
+        from: string;
+        /**
+         * Represents the input source map passed from a compilation step before
+         * PostCSS (for example, from the Sass compiler).
+         */
+        map: PreviousMap;
+        /**
+         * Reads the input source map.
+         * @returns A symbol position in the input source (e.g., in a Sass file
+         * that was compiled to CSS before being passed to PostCSS):
+         */
+        origin(line: number, column: number): InputOrigin;
+    }
+    interface Node {
+        /**
+         * Returns a string representing the node's type. Possible values are
+         * root, atrule, rule, decl or comment.
+         */
+        type: string;
+        /**
+         * Returns the node's parent node.
+         */
+        parent: Container;
+        /**
+         * Returns the input source of the node. The property is used in source map
+         * generation. If you create a node manually (for example, with
+         * postcss.decl() ), that node will not have a  source  property and will
+         * be absent from the source map. For this reason, the plugin developer
+         * should consider cloning nodes to create new ones (in which case the new
+         * node's source will reference the original, cloned node) or setting the
+         * source property manually.
+         */
+        source: NodeSource;
+        /**
+         * Contains information to generate byte-to-byte equal node string as it
+         * was in origin input.
+         */
+        raws: NodeRaws;
+        /**
+         * @returns A CSS string representing the node.
+         */
+        toString(): string;
+        /**
+         * This method produces very useful error messages. If present, an input
+         * source map will be used to get the original position of the source, even
+         * from a previous compilation step (e.g., from Sass compilation).
+         * @returns The original position of the node in the source, showing line
+         * and column numbers and also a small excerpt to facilitate debugging.
+         */
+        error(
+            /**
+             * Error description.
+             */
+            message: string, options?: NodeErrorOptions): CssSyntaxError;
+        /**
+         * Creates a Warning and adds it to messages. This method is provided as
+         * a convenience wrapper for Result#warn.
+         * @param result The result that will receive the warning.
+         * @param message Error description.
+         */
+        warn(result: Result, message: string): void;
+        /**
+         * @returns The next child of the node's parent; or, returns undefined if
+         * the current node is the last child.
+         */
+        next(): Node;
+        /**
+         * @returns The previous child of the node's parent; or, returns undefined
+         * if the current node is the first child.
+         */
+        prev(): Node;
+        /**
+         * @returns The Root instance of the node's tree.
+         */
+        root(): Root;
+        /**
+         * Removes the node from its parent and cleans the parent property in the
+         * node and its children.
+         * @returns This node for chaining.
+         */
+        remove(): Node;
+        /**
+         * Inserts nodes before the current node and removes the current node.
+         * @returns This node for chaining.
+         */
+        replaceWith(...nodes: (Node | Object)[]): Node;
+        /**
+         * @param overrides New properties to override in the clone.
+         * @returns A clone of this node. The node and its (cloned) children will
+         * have a clean parent and code style properties.
+         */
+        clone(overrides?: Object): Node;
+        /**
+         * Shortcut to clone the node and insert the resulting cloned node before
+         * the current node.
+         * @param overrides New Properties to override in the clone.
+         * @returns The cloned node.
+         */
+        cloneBefore(overrides?: Object): Node;
+        /**
+         * Shortcut to clone the node and insert the resulting cloned node after
+         * the current node.
+         * @param overrides New Properties to override in the clone.
+         * @returns The cloned node.
+         */
+        cloneAfter(overrides?: Object): Node;
+        /**
+         * Removes the node from its current parent and inserts it at the end of
+         * newParent. This will clean the before and after code style properties
+         * from the node, and replace them with the indentation style of newParent.
+         * It will also clean the between property if newParent is in another Root.
+         * @param newParent Where the current node will be moved.
+         * @returns This node for chaining.
+         */
+        moveTo(newParent: Container): Node;
+        /**
+         * Removes the node from its current parent and inserts it into a new
+         * parent before otherNode. This will also clean the node's code style
+         * properties just as node.moveTo(newParent) does.
+         * @param otherNode Will be after the current node after moving.
+         * @returns This node for chaining.
+         */
+        moveBefore(otherNode: Node): Node;
+        /**
+         * Removes the node from its current parent and inserts it into a new
+         * parent after otherNode. This will also clean the node's code style
+         * properties just as node.moveTo(newParent) does.
+         * @param otherNode Will be before the current node after moving.
+         * @returns This node for chaining.
+         */
+        moveAfter(otherNode: Node): Node;
+        /**
+         * @param prop Name or code style property.
+         * @param defaultType Name of default value. It can be easily missed if the
+         * value is the same as prop.
+         * @returns A code style property value. If the node is missing the code
+         * style property (because the node was manually built or cloned), PostCSS
+         * will try to autodetect the code style property by looking at other nodes
+         * in the tree.
+         */
+        raw(prop: string, defaultType?: string): any;
+    }
+    interface NodeNewProps {
+    }
+    interface NodeRaws {
+        /**
+         * The space symbols before the node. It also stores any non-standard
+         * symbols before the declaration like "_" from IE hack.
+         */
+        before?: string;
+        /**
+         * The space symbols after the last child of the node to the end of
+         * the node.
+         */
+        after?: string;
+        /**
+         * The symbols between the property and value for declarations,
+         * selector and "{" for rules, last parameter and "{" for at-rules.
+         */
+        between?: string;
+        /**
+         * True if last child has (optional) semicolon.
+         */
+        semicolon?: boolean;
+        /**
+         * The space between the at-rule's name and parameters.
+         */
+        afterName?: string;
+        /**
+         * The space symbols between "/*" and comment's text.
+         */
+        left?: string;
+        /**
+         * The space symbols between comment's text and "*\/".
+         */
+        right?: string;
+        /**
+         * The content of important statement, if it is not just "!important".
+         */
+        important?: string;
+    }
+    interface NodeSource {
+        input: Input;
+        /**
+         * The starting position of the node's source.
+         */
+        start?: {
+            column: number;
+            line: number;
+        };
+        /**
+         * The ending position of the node's source.
+         */
+        end?: {
+            column: number;
+            line: number;
+        };
+    }
+    interface NodeErrorOptions {
+        /**
+         * Plugin name that created this error. PostCSS will set it automatically.
+         */
+        plugin?: string;
+        /**
+         * A word inside a node's string, that should be highlighted as source
+         * of error.
+         */
+        word?: string;
+        /**
+         * An index inside a node's string that should be highlighted as source
+         * of error.
+         */
+        index?: number;
+    }
+    interface JsonNode {
+        /**
+         * Returns a string representing the node's type. Possible values are
+         * root, atrule, rule, decl or comment.
+         */
+        type?: string;
+        /**
+         * Returns the node's parent node.
+         */
+        parent?: JsonContainer;
+        /**
+         * Returns the input source of the node. The property is used in source map
+         * generation. If you create a node manually (for example, with
+         * postcss.decl() ), that node will not have a  source  property and will
+         * be absent from the source map. For this reason, the plugin developer
+         * should consider cloning nodes to create new ones (in which case the new
+         * node's source will reference the original, cloned node) or setting the
+         * source property manually.
+         */
+        source?: NodeSource;
+        /**
+         * Contains information to generate byte-to-byte equal node string as it
+         * was in origin input.
+         */
+        raws?: NodeRaws;
+    }
+    /**
+     * Containers can store any content. If you write a rule inside a rule,
+     * PostCSS will parse it.
+     */
+    interface Container extends Node {
+        /**
+         * Returns the container's parent node.
+         */
+        parent: Container;
+        /**
+         * Contains the container's children.
+         */
+        nodes?: Node[];
+        /**
+         * @returns The container's first child.
+         */
+        first?: Node;
+        /**
+         * @returns The container's last child.
+         */
+        last?: Node;
+        /**
+         * @param overrides New properties to override in the clone.
+         * @returns A clone of this node. The node and its (cloned) children will
+         * have a clean parent and code style properties.
+         */
+        clone(overrides?: Object): Container;
+        /**
+         * @param child Child of current container.
+         * @returns The child's index within the container's "nodes" array.
+         */
+        index(child: Node | number): number;
+        /**
+         * Determines whether all child nodes satisfy the specified test.
+         * @param callback A function that accepts up to three arguments. The
+         * every method calls the callback function for each node until the
+         * callback returns false, or until the end of the array.
+         * @returns True if the callback returns true for all of the container's
+         * children.
+         */
+        every(callback: (node: Node, index: number, nodes: Node[]) => any, thisArg?: any): boolean;
+        /**
+         * Determines whether the specified callback returns true for any child node.
+         * @param callback A function that accepts up to three arguments. The some
+         * method calls the callback for each node until the callback returns true,
+         * or until the end of the array.
+         * @param thisArg An object to which the this keyword can refer in the
+         * callback function. If thisArg is omitted, undefined is used as the
+         * this value.
+         * @returns True if callback returns a true value for (at least) one of the
+         * container's children.
+         */
+        some(callback: (node: Node, index: number, nodes: Node[]) => boolean, thisArg?: any): boolean;
+        /**
+         * Iterates through the container's immediate children, calling the
+         * callback function for each child. If you need to recursively iterate
+         * through all the container's nodes, use container.eachInside(). Unlike
+         * the for {} -cycle or Array#forEach() this iterator is safe if you are
+         * mutating the array of child nodes during iteration.
+         * @param callback Iterator. Returning false will break iteration. Safe
+         * if you are mutating the array of child nodes during iteration. PostCSS
+         * will adjust the current index to match the mutations.
+         * @returns False if the callback returns false during iteration.
+         */
+        each(callback: (node: Node, index: number) => any): boolean | void;
+        /**
+         * Recursively iterates through the container's children, those children's
+         * children, etc., calling callback for each. Like container.each(), this
+         * method is safe to use if you are mutating arrays during iteration. If
+         * you only need to iterate through the container’s immediate children, use
+         * container.each().
+         * @param callback Iterator.
+         */
+        eachInside(callback: (node: Node, index: number) => any): boolean | void;
+        /**
+         * Recursively iterates through all declaration nodes within the container.
+         * Like container.each(), this method is safe to use if you are mutating
+         * arrays during iteration.
+         * @param propFilter Filters declarations by property name. Only those
+         * declarations whose property matches propFilter will be iterated over.
+         * @param callback Called for each declaration node within the container.
+         */
+        eachDecl(propFilter: string | RegExp, callback?: (decl: Declaration, index: number) => any): boolean | void;
+        eachDecl(callback: (decl: Declaration, index: number) => any): boolean | void;
+        /**
+         * Recursively iterates through all at-rule nodes. Like container.each(),
+         * this method is safe to use if you are mutating arrays during iteration.
+         * @param nameFilter Filters at-rules by name. Only those at-rules whose
+         * name matches filter will be iterated over.
+         * @param callback Iterator called for each at-rule node within the
+         * container.
+         */
+        eachAtRule(nameFilter: string | RegExp, callback: (atRule: AtRule, index: number) => any): boolean | void;
+        eachAtRule(callback: (atRule: AtRule, index: number) => any): boolean | void;
+        /**
+         * Recursively iterates through all rule nodes within the container.
+         * Like container.each(), this method is safe to use if you are mutating
+         * arrays during iteration.
+         * @param selectorFilter Filters rules by selector. Only those rules whose
+         * name matches the filter will be iterated over.
+         * @param callback Iterator called for each rule node within the
+         * container.
+         */
+        eachRule(selectorFilter: string | RegExp, callback: (atRule: Rule, index: number) => any): boolean | void;
+        eachRule(callback: (atRule: Rule, index: number) => any): boolean | void;
+        eachRule(selectorFilter: any, callback?: (atRule: Rule, index: number) => any): boolean | void;
+        /**
+         * Recursively iterates through all comment nodes within the container.
+         * Like container.each(), this method is safe to use if you are mutating
+         * arrays during iteration.
+         * @param callback Iterator called for each comment node within the container.
+         */
+        eachComment(callback: (comment: Comment, indexed: number) => any): void | boolean;
+        /**
+         * Passes all declaration values within the container that match pattern
+         * through the callback, replacing those values with the returned result of
+         * callback. This method is useful if you are using a custom unit or
+         * function and need to iterate through all values.
+         * @param pattern Pattern that we need to replace.
+         * @param options Options to speed up the search.
+         * @param callbackOrReplaceValue String to replace pattern or callback
+         * that will return a new value. The callback will receive the same
+         * arguments as those passed to a function parameter of String#replace.
+         */
+        replaceValues(pattern: string | RegExp, options: {
+            /**
+             * Property names. The method will only search for values that match
+             * regexp  within declarations of listed properties.
+             */
+            props?: string[];
+            /**
+             * Used to narrow down values and speed up the regexp search. Searching
+             * every single value with a regexp can be slow. If you pass a fast
+             * string, PostCSS will first check whether the value contains the fast
+             * string; and only if it does will PostCSS check that value against
+             * regexp. For example, instead of just checking for /\d+rem/ on all
+             * values, set fast: 'rem' to first check whether a value has the rem
+             * unit, and only if it does perform the regexp check.
+             */
+            fast?: string;
+        }, callbackOrReplaceValue: string | {
+            (substring: string, ...args: any[]): string;
+        }): Container;
+        replaceValues(pattern: string | RegExp, callbackOrReplaceValue: string | {
+            (substring: string, ...args: any[]): string;
+        }): Container;
+        /**
+         * Inserts new nodes to the beginning of the container.
+         * Because each node class is identifiable by unique properties, use the
+         * following shortcuts to create nodes in insert methods:
+         *     root.prepend({ name: '@charset', params: '"UTF-8"' }); // at-rule
+         *     root.prepend({ selector: 'a' });                       // rule
+         *     rule.prepend({ prop: 'color', value: 'black' });       // declaration
+         *     rule.prepend({ text: 'Comment' })                      // comment
+         * A string containing the CSS of the new element can also be used. This
+         * approach is slower than the above shortcuts.
+         *     root.prepend('a {}');
+         *     root.first.prepend('color: black; z-index: 1');
+         * @param nodes New nodes.
+         * @returns This container for chaining.
+         */
+        prepend(...nodes: (Node | Object | string)[]): Container;
+        /**
+         * Inserts new nodes to the end of the container.
+         * Because each node class is identifiable by unique properties, use the
+         * following shortcuts to create nodes in insert methods:
+         *     root.append({ name: '@charset', params: '"UTF-8"' }); // at-rule
+         *     root.append({ selector: 'a' });                       // rule
+         *     rule.append({ prop: 'color', value: 'black' });       // declaration
+         *     rule.append({ text: 'Comment' })                      // comment
+         * A string containing the CSS of the new element can also be used. This
+         * approach is slower than the above shortcuts.
+         *     root.append('a {}');
+         *     root.first.append('color: black; z-index: 1');
+         * @param nodes New nodes.
+         * @returns This container for chaining.
+         */
+        append(...nodes: (Node | Object | string)[]): Container;
+        /**
+         * Insert newNode before oldNode within the container.
+         * @param oldNode Child or child's index.
+         * @returns This container for chaining.
+         */
+        insertBefore(oldNode: Node | number, newNode: Node | Object | string): Container;
+        /**
+         * Insert newNode after oldNode within the container.
+         * @param oldNode Child or child's index.
+         * @returns This container for chaining.
+         */
+        insertAfter(oldNode: Node | number, newNode: Node | Object | string): Container;
+        /**
+         * Removes the container from its parent and cleans the parent property in the
+         * container and its children.
+         * @returns This container for chaining.
+         */
+        remove(): Container;
+        /**
+         * Removes child from the container, and the parent properties of node and
+         * its children.
+         * @param child Child or child's index.
+         * @returns This container for chaining.
+         */
+        removeChild(child: Node | number): Container;
+        /**
+         * Removes all children from the container and cleans their parent
+         * properties.
+         * @returns This container for chaining.
+         */
+        removeAll(): Container;
+    }
+    interface ContainerNewProps extends NodeNewProps {
+        /**
+         * Contains the container's children.
+         */
+        nodes?: Node[];
+    }
+    interface ContainerRaws extends NodeRaws {
+    }
+    interface JsonContainer extends JsonNode {
+        /**
+         * Contains the container's children.
+         */
+        nodes?: Node[];
+        /**
+         * @returns The container's first child.
+         */
+        first?: Node;
+        /**
+         * @returns The container's last child.
+         */
+        last?: Node;
+    }
+    /**
+     * Represents a CSS file and contains all its parsed nodes.
+     */
+    interface Root extends Container {
+        /**
+         * Inherited from Container. Should always be undefined for a Root node.
+         */
+        parent: Container;
+        /**
+         * @param overrides New properties to override in the clone.
+         * @returns A clone of this node. The node and its (cloned) children will
+         * have a clean parent and code style properties.
+         */
+        clone(overrides?: Object): Root;
+        /**
+         * @returns A Result instance representing the root's CSS.
+         */
+        toResult(options?: {
+            /**
+             * The path where you'll put the output CSS file. You should always
+             * set "to" to generate correct source maps.
+             */
+            to?: string;
+            map?: SourceMapOptions;
+        }): Result;
+        /**
+         * Deprecated. Use Root#removeChild.
+         */
+        remove(child?: Node | number): Root;
+        /**
+         * Removes child from the root node, and the parent properties of node and
+         * its children.
+         * @param child Child or child's index.
+         * @returns This root node for chaining.
+         */
+        removeChild(child: Node | number): Root;
+    }
+    interface RootNewProps extends ContainerNewProps {
+    }
+    interface JsonRoot extends JsonContainer {
+    }
+    /**
+     * Represents an at-rule. This node will have a nodes property,
+     * representing its children, if it is followed in the CSS by a {} block.
+     */
+    interface AtRule extends Container {
+        /**
+         * The identifier that immediately follows the @.
+         */
+        name: string;
+        /**
+         * These are the values that follow the at-rule's name, but precede any {}
+         * block. The spec refers to this area as the at-rule's "prelude".
+         */
+        params: string;
+        /**
+         * @param overrides New properties to override in the clone.
+         * @returns A clone of this node. The node and its (cloned) children will
+         * have a clean parent and code style properties.
+         */
+        clone(overrides?: Object): AtRule;
+    }
+    interface AtRuleNewProps extends ContainerNewProps {
+        /**
+         * The identifier that immediately follows the @.
+         */
+        name?: string;
+        /**
+         * These are the values that follow the at-rule's name, but precede any {}
+         * block. The spec refers to this area as the at-rule's "prelude".
+         */
+        params?: string | number;
+    }
+    interface AtRuleRaws extends NodeRaws {
+        params?: string;
+    }
+    interface JsonAtRule extends JsonContainer {
+        /**
+         * The identifier that immediately follows the @.
+         */
+        name?: string;
+        /**
+         * These are the values that follow the at-rule's name, but precede any {}
+         * block. The spec refers to this area as the at-rule's "prelude".
+         */
+        params?: string;
+    }
+    /**
+     * Represents a CSS rule: a selector followed by a declaration block.
+     */
+    interface Rule extends Container {
+        /**
+         * Returns the rule's parent node.
+         */
+        parent: Container;
+        /**
+         * The rule's full selector. If there are multiple comma-separated selectors,
+         * the entire group will be included.
+         */
+        selector: string;
+        /**
+         * An array containing the rule's individual selectors.
+         * Groups of selectors are split at commas.
+         */
+        selectors?: string[];
+        /**
+         * @param overrides New properties to override in the clone.
+         * @returns A clone of this node. The node and its (cloned) children will
+         * have a clean parent and code style properties.
+         */
+        clone(overrides?: Object): Rule;
+    }
+    interface RuleNewProps extends ContainerNewProps {
+        /**
+         * The rule's full selector. If there are multiple comma-separated selectors,
+         * the entire group will be included.
+         */
+        selector?: string;
+    }
+    interface RuleRaws extends ContainerRaws {
+        /**
+        * The rule's full selector. If there are multiple comma-separated selectors,
+        * the entire group will be included.
+        */
+        selector?: string;
+    }
+    interface JsonRule extends JsonContainer {
+        /**
+         * The rule's full selector. If there are multiple comma-separated selectors,
+         * the entire group will be included.
+         */
+        selector?: string;
+        /**
+         * An array containing the rule's individual selectors.
+         * Groups of selectors are split at commas.
+         */
+        selectors?: string[];
+    }
+    /**
+     * Represents a CSS declaration.
+     */
+    interface Declaration extends Node {
+        /**
+         * The declaration's property name.
+         */
+        prop: string;
+        /**
+         * The declaration's value. This value will be cleaned of comments. If the
+         * source value contained comments, those comments will be available in the
+         * _value.raws property. If you have not changed the value, the result of
+         * decl.toString() will include the original raws value (comments and all).
+         */
+        value: string;
+        /**
+         * True if the declaration has an !important annotation.
+         */
+        important: boolean;
+        /**
+         * @param overrides New properties to override in the clone.
+         * @returns A clone of this node. The node and its (cloned) children will
+         * have a clean parent and code style properties.
+         */
+        clone(overrides?: Object): Declaration;
+    }
+    interface DeclarationNewProps {
+        /**
+         * The declaration's property name.
+         */
+        prop?: string;
+        /**
+         * The declaration's value. This value will be cleaned of comments. If the
+         * source value contained comments, those comments will be available in the
+         * _value.raws property. If you have not changed the value, the result of
+         * decl.toString() will include the original raws value (comments and all).
+         */
+        value?: string;
+    }
+    interface DeclarationRaws extends NodeRaws {
+        /**
+         * The declaration's value. This value will be cleaned of comments.
+         * If the source value contained comments, those comments will be
+         * available in the _value.raws property. If you have not changed the value, the result of
+         * decl.toString() will include the original raws value (comments and all).
+         */
+        value?: string;
+    }
+    interface JsonDeclaration extends JsonNode {
+        /**
+         * True if the declaration has an !important annotation.
+         */
+        important?: boolean;
+    }
+    /**
+     * Represents a comment between declarations or statements (rule and at-rules).
+     * Comments inside selectors, at-rules parameters, or declaration values will
+     * be stored in the Node#raws properties.
+     */
+    interface Comment extends Node {
+        /**
+         * The comment's text.
+         */
+        text: string;
+        /**
+         * @param overrides New properties to override in the clone.
+         * @returns A clone of this node. The node and its (cloned) children will
+         * have a clean parent and code style properties.
+         */
+        clone(overrides?: Object): Comment;
+    }
+    interface CommentNewProps {
+        /**
+         * The comment's text.
+         */
+        text?: string;
+    }
+    interface JsonComment extends JsonNode {
+    }
+}
+export default postcss;

--- a/d.ts/previous-map.d.ts
+++ b/d.ts/previous-map.d.ts
@@ -1,0 +1,15 @@
+export default class PreviousMap {
+    private inline;
+    annotation: string;
+    root: string;
+    private consumerCache;
+    text: string;
+    file: string;
+    constructor(css: any, opts: any);
+    consumer(): any;
+    withContent(): boolean;
+    startWith(string: any, start: any): boolean;
+    loadAnnotation(css: any): void;
+    decodeInline(text: any): any;
+    loadMap(file: any, prev: any): any;
+}

--- a/d.ts/processor.d.ts
+++ b/d.ts/processor.d.ts
@@ -1,0 +1,31 @@
+import LazyResult from './lazy-result';
+import postcss from './postcss';
+import Result from './result';
+export default class Processor implements postcss.Processor {
+    /**
+     * Contains current version of PostCSS (e.g., "4.0.5").
+     */
+    version: string;
+    /**
+     * Contains plugins added to this processor.
+     */
+    plugins: postcss.Plugin<any>[];
+    constructor(plugins?: (typeof postcss.acceptedPlugin)[]);
+    /**
+     * Adds a plugin to be used as a CSS processor. Plugins can also be
+     * added by passing them as arguments when creating a postcss instance.
+     */
+    use(plugin: typeof postcss.acceptedPlugin): Processor;
+    /**
+     * Parses source CSS. Because some plugins can be asynchronous it doesn't
+     * make any transformations. Transformations will be applied in LazyResult's
+     * methods.
+     * @param css Input CSS or any object with toString() method, like a file
+     * stream. If a Result instance is passed the processor will take the
+     * existing Root parser from it.
+     */
+    process(css: string | {
+        toString(): string;
+    } | Result, options?: postcss.ProcessOptions): LazyResult;
+    private normalize(plugins);
+}

--- a/d.ts/result.d.ts
+++ b/d.ts/result.d.ts
@@ -1,0 +1,83 @@
+import Processor from './processor';
+import postcss from './postcss';
+import Root from './root';
+export default class Result implements postcss.Result {
+    /**
+     * The Processor instance used for this transformation.
+     */
+    processor: Processor;
+    /**
+     * Contains Root node after all transformations.
+     */
+    root: Root;
+    /**
+     * Options from the Processor#process(css, opts) or Root#toResult(opts) call
+     * that produced this Result instance.
+     */
+    opts: postcss.ResultOptions;
+    /**
+     * A CSS string representing this Result's Root instance.
+     */
+    css: string;
+    /**
+     * An instance of the SourceMapGenerator class from the source-map library,
+     * representing changes to the Result's Root instance.
+     * This property will have a value only if the user does not want an inline
+     * source map. By default, PostCSS generates inline source maps, written
+     * directly into the processed CSS. The map property will be empty by default.
+     * An external source map will be generated — and assigned to map — only if
+     * the user has set the map.inline option to false, or if PostCSS was passed
+     * an external input source map.
+     */
+    map: postcss.ResultMap;
+    /**
+     * Contains messages from plugins. For example, warnings or custom messages to
+     * plugins communication. Add a warning using Result#warn() and get all warnings
+     * using Result#warnings() method.
+     */
+    messages: postcss.ResultMessage[];
+    lastPlugin: postcss.Transformer;
+    /**
+     * Provides the result of the PostCSS transformations.
+     */
+    constructor(
+        /**
+         * The Processor instance used for this transformation.
+         */
+        processor?: Processor, 
+        /**
+         * Contains Root node after all transformations.
+         */
+        root?: Root, 
+        /**
+         * Options from the Processor#process(css, opts) or Root#toResult(opts) call
+         * that produced this Result instance.
+         */
+        opts?: postcss.ResultOptions);
+    /**
+     * Alias for css property.
+     */
+    toString(): string;
+    /**
+     * Creates a Warning and adds it to messages.
+     * @param message Used in the text property of the message object.
+     * @param options Properties for Message object.
+     */
+    warn(message: string, options?: postcss.WarningOptions): void;
+    /**
+     * @returns Warnings from plugins, filtered from messages.
+     */
+    warnings(): postcss.ResultMessage[];
+    /**
+     * Alias for css property to use with syntaxes that generate non-CSS output.
+     */
+    content: string;
+    /**
+     * Deprecated and will be removed in 5.0. Use result.opts.from instead.
+     */
+    from: string;
+    /**
+     * Deprecated and will be removed in 5.0. Use result.opts.to instead.
+     */
+    to: string;
+}

--- a/d.ts/root.d.ts
+++ b/d.ts/root.d.ts
@@ -1,0 +1,46 @@
+import PreviousMap from './previous-map';
+import Container from './container';
+import postcss from './postcss';
+import Result from './result';
+import Node from './node';
+export default class Root extends Container implements postcss.Root {
+    prevMap: PreviousMap;
+    rawCache: {
+        [key: string]: any;
+    };
+    /**
+     * Represents a CSS file and contains all its parsed nodes.
+     */
+    constructor(defaults?: postcss.RootNewProps);
+    /**
+     * @param overrides New properties to override in the clone.
+     * @returns A clone of this node. The node and its (cloned) children will
+     * have a clean parent and code style properties.
+     */
+    clone(overrides?: Object): Root;
+    toJSON(): postcss.JsonRoot;
+    /**
+     * Deprecated. Use Root#removeChild.
+     */
+    remove(child?: Node | number): Root;
+    /**
+     * Removes child from the root node, and the parent properties of node and
+     * its children.
+     * @param child Child or child's index.
+     * @returns This root node for chaining.
+     */
+    removeChild(child: Node | number): Root;
+    protected normalize(node: Node | string, sample: Node, type?: string): Node[];
+    protected normalize(props: postcss.AtRuleNewProps | postcss.RuleNewProps | postcss.DeclarationNewProps | postcss.CommentNewProps, sample: Node, type?: string): Node[];
+    /**
+     * @returns A Result instance representing the root's CSS.
+     */
+    toResult(options?: {
+        /**
+         * The path where you'll put the output CSS file. You should always
+         * set "to" to generate correct source maps.
+         */
+        to?: string;
+        map?: postcss.SourceMapOptions;
+    }): Result;
+}

--- a/d.ts/rule.d.ts
+++ b/d.ts/rule.d.ts
@@ -1,0 +1,31 @@
+import Container from './container';
+import postcss from './postcss';
+export default class Rule extends Container implements postcss.Rule {
+    /**
+     * Contains information to generate byte-to-byte equal node string as it
+     * was in origin input.
+     */
+    raws: postcss.RuleRaws;
+    /**
+     * The rule's full selector. If there are multiple comma-separated selectors,
+     * the entire group will be included.
+     */
+    selector: string;
+    /**
+     * Represents a CSS rule: a selector followed by a declaration block.
+     */
+    constructor(defaults?: postcss.RuleNewProps);
+    /**
+     * @param overrides New properties to override in the clone.
+     * @returns A clone of this node. The node and its (cloned) children will
+     * have a clean parent and code style properties.
+     */
+    clone(overrides?: Object): Rule;
+    toJSON(): postcss.JsonRule;
+    /**
+     * @returns An array containing the rule's individual selectors.
+     * Groups of selectors are split at commas.
+     */
+    selectors: string[];
+    _selector: string;
+}

--- a/d.ts/stringifier.d.ts
+++ b/d.ts/stringifier.d.ts
@@ -1,0 +1,31 @@
+import Node from './node';
+declare class Stringifier {
+    builder: Stringifier.Builder;
+    constructor(builder?: Stringifier.Builder);
+    stringify(node: Node, semicolon?: boolean): void;
+    root(node: any): void;
+    comment(node: any): void;
+    decl(node: any, semicolon: any): void;
+    rule(node: any): void;
+    atrule(node: any, semicolon: any): void;
+    body(node: any): void;
+    block(node: any, start: any): void;
+    raw(node: Node, own: string, detect?: string): any;
+    rawSemicolon(root: any): any;
+    rawEmptyBody(root: any): any;
+    rawIndent(root: any): any;
+    rawBeforeComment(root: any, node: any): any;
+    rawBeforeDecl(root: any, node: any): any;
+    rawBeforeRule(root: any): any;
+    rawBeforeClose(root: any): any;
+    rawBeforeOpen(root: any): any;
+    rawColon(root: any): any;
+    beforeAfter(node: any, detect: any): any;
+    rawValue(node: any, prop: any): any;
+}
+declare module Stringifier {
+    interface Builder {
+        (str: string, node?: Node, str2?: string): void;
+    }
+}
+export default Stringifier;

--- a/d.ts/stringify.d.ts
+++ b/d.ts/stringify.d.ts
@@ -1,0 +1,11 @@
+import Stringifier from './stringifier';
+import postcss from './postcss';
+import Node from './node';
+/**
+ * Default function to convert nodes tree to CSS string.
+ */
+declare function stringify(node: Node, builder: Stringifier.Builder): void;
+declare module stringify {
+    var stringify: postcss.Syntax | postcss.Stringify;
+}
+export default stringify;

--- a/d.ts/tokenize.d.ts
+++ b/d.ts/tokenize.d.ts
@@ -1,0 +1,1 @@
+export default function tokenize(input: any): any[];

--- a/d.ts/vendor.d.ts
+++ b/d.ts/vendor.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Contains helpers for working with vendor prefixes.
+ */
+declare module Vendor {
+    /**
+     * @returns The vendor prefix extracted from the input string.
+     */
+    function prefix(prop: string): string;
+    /**
+     * @returns The input string stripped of its vendor prefix.
+     */
+    function unprefixed(prop: string): string;
+}
+export default Vendor;

--- a/d.ts/warn-once.d.ts
+++ b/d.ts/warn-once.d.ts
@@ -1,0 +1,2 @@
+declare var _default: (message: string) => void;
+export default _default;

--- a/d.ts/warning.d.ts
+++ b/d.ts/warning.d.ts
@@ -1,0 +1,38 @@
+import postcss from './postcss';
+import Node from './node';
+export default class Warning implements postcss.Warning {
+    /**
+     * Contains the warning message.
+     */
+    text: string;
+    type: string;
+    /**
+     * Contains name of plugin that created this warning. When you call
+     * Node#warn(), it will fill this property automatically.
+     */
+    plugin: string;
+    /**
+     * The CSS node that caused the warning.
+     */
+    node: Node;
+    /**
+     * Line in input file with this warning source.
+     */
+    line: number;
+    /**
+     * Column in input file with this warning source.
+     */
+    column: number;
+    /**
+     * Warning from plugins. It can be created using Node#warn().
+     */
+    constructor(
+        /**
+         * Contains the warning message.
+         */
+        text: string, options?: postcss.WarningOptions);
+    /**
+     * @returns Error position, message.
+     */
+    toString(): string;
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,15 @@ The `postcss` function is the main entry point for PostCSS.
 var postcss = require('postcss');
 ```
 
+For those using [TypeScript](http://www.typescriptlang.org/) with an
+[ES6 compile target](https://github.com/Microsoft/TypeScript/wiki/tsconfig.json),
+you can import the PostCSS API like so:
+
+```ts
+///<reference path="node_modules/postcss/postcss.d.ts" />
+import * as postcss from 'postcss';
+```
+
 ### `postcss(plugins)`
 
 Returns a new [`Processor`] instance that will apply `plugins`

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -52,7 +52,7 @@ module.exports = function (css, opts) {
 ### Main Theory
 
 There are many books about parses. But do not scary, CSS syntax is very easy,
-so parser will be much simplier, than usual.
+so parser will be much simpler than usual.
 
 The default PostCSS parser contains two steps:
 
@@ -66,17 +66,17 @@ Look at this parts for a parser example.
 [Tokenizer]: https://github.com/postcss/postcss/blob/master/lib/tokenize.es6
 [Parser]:    https://github.com/postcss/postcss/blob/master/lib/parser.es6
 
-### Perfomance
+### Performance
 
 Parsing input is a longest task in CSS usual processor. So it is very important
 to have fast parser.
 
-The main rule of optimization: there is no perfomance without benchmark.
-You can look at [PostCSS benchmakrs] as example.
+The main rule of optimization: there is no performance without benchmark.
+You can look at [PostCSS benchmarks] as example.
 
-If we will look deeper, tokenize step will be a longest part of parsing.
-So you should focus only on tokenizer perfomance. Other parts could be
-well written maiintable code.
+If we will look deeper, the tokenize step will be a longest part of parsing.
+So you should focus only on tokenizer performance. Other parts could be
+well written maintainable code.
 
 Unfortunately, classes, functions and high level structures can slow down
 your tokenizer. Be ready to write dirty code with code repeating.
@@ -110,7 +110,7 @@ next = regexp.lastIndex;
 Parser can be well written class. So there is no need in copy-paste and
 hardcore optimization there. You can safely extend default class.
 
-[PostCSS benchmakrs]: https://github.com/postcss/benchmark
+[PostCSS benchmarks]: https://github.com/postcss/benchmark
 
 ### Node Source
 
@@ -122,7 +122,7 @@ So your tokenizer should provide token type, content and positions.
 
 [`Input`]: https://github.com/postcss/postcss/blob/master/lib/input.es6
 
-### Raw Valus
+### Raw Values
 
 Good PostCSS parser should provide all information (including spaces symbols)
 to generate byte-to-byte equal output. It is not so difficult, but respectful
@@ -174,7 +174,7 @@ PostCSS [default stringifier] is just a class with method for each node type
 and many methods to detect raw properties (if node was built manually)
 by other nodes.
 
-In most cases it will be enouch just to extent this class,
+In most cases it will be enough just to extent this class,
 like in [SCSS stringifier].
 
 [default stringifier]: https://github.com/postcss/postcss/blob/master/lib/stringifier.es6

--- a/postcss.d.ts
+++ b/postcss.d.ts
@@ -1,0 +1,4 @@
+declare module 'postcss' {
+	import postcss from 'd.ts/postcss';
+	export = postcss;
+}


### PR DESCRIPTION
Based on https://github.com/postcss/postcss/pull/489

This PR introduces [TypeScript](http://www.typescriptlang.org/) definitions, of particular interest to PostCSS plugin developers using [Visual Studio](https://www.visualstudio.com/), now [free for open source developers](https://www.visualstudio.com/products/visual-studio-community-vs) and [available across platforms](https://www.visualstudio.com/products/code-vs). Using these definitions, you gain in-editor insight into the PostCSS API via [Intellisense](https://en.wikipedia.org/wiki/Intelligent_code_completion#IntelliSense) w/o the need to pull up documentation in a separate browser window.

![postcss-intellisense](https://cloud.githubusercontent.com/assets/1058243/9286679/5e7e055e-42be-11e5-803d-4e2bf2158e41.png)

The definitions for this project expose only public API members. Everything else is hidden from you, so you can relax, knowing you are following the golden path.

Even though you can't, for example, touch the `Rule` class directly, you do have access to the `postcss.Rule` interface, which should give you everything you need. For example, you can create a callback function that is called with a rule instance like so:

```ts
function callback(rule: postcss.Rule) {
    rule.eachDecl(decl => {
        // do stuff...
    });
}
```
