### PR TITLE
Rename recursive `each` methods to `walk` methods

### DIFF
--- a/d.ts/container.d.ts
+++ b/d.ts/container.d.ts
@@ -25,7 +25,7 @@ export default class Container extends Node implements postcss.Container {
     /**
      * Iterates through the container's immediate children, calling the
      * callback function for each child. If you need to recursively iterate
-     * through all the container's nodes, use container.eachInside(). Unlike
+     * through all the container's nodes, use container.walk(). Unlike
      * the for {} -cycle or Array#forEach() this iterator is safe if you are
      * mutating the array of child nodes during iteration.
      * @param callback Iterator. Returning false will break iteration. Safe
@@ -33,53 +33,58 @@ export default class Container extends Node implements postcss.Container {
      * will adjust the current index to match the mutations.
      */
     each(callback: (node: Node, index: number) => any): boolean | void;
+    eachInside(callback: any): any;
     /**
-     * Recursively iterates through the container's children, those children's
-     * children, etc., calling callback for each. Like container.each(), this
-     * method is safe to use if you are mutating arrays during iteration. If
-     * you only need to iterate through the container's immediate children, use
-     * container.each().
+     * Traverses the container's descendant nodes, calling `callback` for each
+     * node. Like container.each(), this method is safe to use if you are
+     * mutating arrays during iteration. If you only need to iterate through
+     * the container's immediate children, use container.each().
      * @param callback Iterator.
      */
-    eachInside(callback: (node: Node, index: number) => any): boolean | void;
+    walk(callback: (node: Node, index: number) => any): boolean | void;
+    eachDecl(propFilter: any, callback?: any): any;
     /**
-     * Recursively iterates through all declaration nodes within the container.
-     * Like container.each(), this method is safe to use if you are mutating
-     * arrays during iteration.
+     * Traverses the container's descendant nodes, calling `callback` for each
+     * declaration. Like container.each(), this method is safe to use if you
+     * are mutating arrays during iteration.
      * @param propFilter Filters declarations by property name. Only those
      * declarations whose property matches propFilter will be iterated over.
      * @param callback Called for each declaration node within the container.
      */
-    eachDecl(propFilter: string | RegExp, callback?: (decl: postcss.Declaration, index: number) => any): boolean | void;
-    eachDecl(callback: (decl: postcss.Declaration, index: number) => any): boolean | void;
+    walkDecls(propFilter: string | RegExp, callback?: (decl: postcss.Declaration, index: number) => any): boolean | void;
+    walkDecls(callback: (decl: postcss.Declaration, index: number) => any): boolean | void;
+    eachRule(selectorFilter: any, callback?: any): any;
     /**
-     * Recursively iterates through all rule nodes within the container.
-     * Like container.each(), this method is safe to use if you are mutating
-     * arrays during iteration.
+     * Traverses the container's descendant nodes, calling `callback` for each
+     * rule. Like container.each(), this method is safe to use if you are
+     * mutating arrays during iteration.
      * @param selectorFilter Filters rules by selector. Only those rules whose
      * name matches the filter will be iterated over.
      * @param callback Iterator called for each rule node within the
      * container.
      */
-    eachRule(selectorFilter: string | RegExp, callback: (atRule: Rule, index: number) => any): boolean | void;
-    eachRule(callback: (atRule: Rule, index: number) => any): boolean | void;
+    walkRules(selectorFilter: string | RegExp, callback: (atRule: Rule, index: number) => any): boolean | void;
+    walkRules(callback: (atRule: Rule, index: number) => any): boolean | void;
+    eachAtRule(nameFilter: any, callback?: any): any;
     /**
-     * Recursively iterates through all at-rule nodes. Like container.each(),
-     * this method is safe to use if you are mutating arrays during iteration.
+     * Traverses the container's descendant nodes, calling `callback` for each
+     * at-rule. Like container.each(), this method is safe to use if you are
+     * mutating arrays during iteration.
      * @param nameFilter Filters at-rules by name. Only those at-rules whose
      * name matches filter will be iterated over.
      * @param callback Iterator called for each at-rule node within the
      * container.
      */
-    eachAtRule(nameFilter: string | RegExp, callback: (atRule: AtRule, index: number) => any): boolean | void;
-    eachAtRule(callback: (atRule: AtRule, index: number) => any): boolean | void;
+    walkAtRules(nameFilter: string | RegExp, callback: (atRule: AtRule, index: number) => any): boolean | void;
+    walkAtRules(callback: (atRule: AtRule, index: number) => any): boolean | void;
+    eachComment(selectorFilter: any, callback?: any): any;
     /**
-     * Recursively iterates through all comment nodes within the container.
-     * Like container.each(), this method is safe to use if you are mutating
-     * arrays during iteration.
+     * Traverses the container's descendant nodes, calling `callback` for each
+     * commennt. Like container.each(), this method is safe to use if you are
+     * mutating arrays during iteration.
      * @param callback Iterator called for each comment node within the container.
      */
-    eachComment(callback: (comment: Comment, indexed: number) => any): void | boolean;
+    walkComments(callback: (comment: Comment, indexed: number) => any): void | boolean;
     /**
      * Inserts new nodes to the end of the container.
      * Because each node class is identifiable by unique properties, use the

--- a/d.ts/postcss.d.ts
+++ b/d.ts/postcss.d.ts
@@ -830,7 +830,7 @@ declare module postcss {
         /**
          * Iterates through the container's immediate children, calling the
          * callback function for each child. If you need to recursively iterate
-         * through all the container's nodes, use container.eachInside(). Unlike
+         * through all the container's nodes, use container.walk(). Unlike
          * the for {} -cycle or Array#forEach() this iterator is safe if you are
          * mutating the array of child nodes during iteration.
          * @param callback Iterator. Returning false will break iteration. Safe
@@ -840,53 +840,53 @@ declare module postcss {
          */
         each(callback: (node: Node, index: number) => any): boolean | void;
         /**
-         * Recursively iterates through the container's children, those children's
-         * children, etc., calling callback for each. Like container.each(), this
-         * method is safe to use if you are mutating arrays during iteration. If
-         * you only need to iterate through the container’s immediate children, use
-         * container.each().
+         * Traverses the container's descendant nodes, calling `callback` for each
+         * node. Like container.each(), this method is safe to use if you are
+         * mutating arrays during iteration. If you only need to iterate through
+         * the container's immediate children, use container.each().
          * @param callback Iterator.
          */
-        eachInside(callback: (node: Node, index: number) => any): boolean | void;
+        walk(callback: (node: Node, index: number) => any): boolean | void;
         /**
-         * Recursively iterates through all declaration nodes within the container.
-         * Like container.each(), this method is safe to use if you are mutating
-         * arrays during iteration.
+         * Traverses the container's descendant nodes, calling `callback` for each
+         * declaration. Like container.each(), this method is safe to use if you
+         * are mutating arrays during iteration.
          * @param propFilter Filters declarations by property name. Only those
          * declarations whose property matches propFilter will be iterated over.
          * @param callback Called for each declaration node within the container.
          */
-        eachDecl(propFilter: string | RegExp, callback?: (decl: Declaration, index: number) => any): boolean | void;
-        eachDecl(callback: (decl: Declaration, index: number) => any): boolean | void;
+        walkDecls(propFilter: string | RegExp, callback?: (decl: Declaration, index: number) => any): boolean | void;
+        walkDecls(callback: (decl: Declaration, index: number) => any): boolean | void;
         /**
-         * Recursively iterates through all at-rule nodes. Like container.each(),
-         * this method is safe to use if you are mutating arrays during iteration.
+         * Traverses the container's descendant nodes, calling `callback` for each
+         * at-rule. Like container.each(), this method is safe to use if you are
+         * mutating arrays during iteration.
          * @param nameFilter Filters at-rules by name. Only those at-rules whose
          * name matches filter will be iterated over.
          * @param callback Iterator called for each at-rule node within the
          * container.
          */
-        eachAtRule(nameFilter: string | RegExp, callback: (atRule: AtRule, index: number) => any): boolean | void;
-        eachAtRule(callback: (atRule: AtRule, index: number) => any): boolean | void;
+        walkAtRules(nameFilter: string | RegExp, callback: (atRule: AtRule, index: number) => any): boolean | void;
+        walkAtRules(callback: (atRule: AtRule, index: number) => any): boolean | void;
         /**
-         * Recursively iterates through all rule nodes within the container.
-         * Like container.each(), this method is safe to use if you are mutating
-         * arrays during iteration.
+         * Traverses the container's descendant nodes, calling `callback` for each
+         * rule. Like container.each(), this method is safe to use if you are
+         * mutating arrays during iteration.
          * @param selectorFilter Filters rules by selector. Only those rules whose
          * name matches the filter will be iterated over.
          * @param callback Iterator called for each rule node within the
          * container.
          */
-        eachRule(selectorFilter: string | RegExp, callback: (atRule: Rule, index: number) => any): boolean | void;
-        eachRule(callback: (atRule: Rule, index: number) => any): boolean | void;
-        eachRule(selectorFilter: any, callback?: (atRule: Rule, index: number) => any): boolean | void;
+        walkRules(selectorFilter: string | RegExp, callback: (atRule: Rule, index: number) => any): boolean | void;
+        walkRules(callback: (atRule: Rule, index: number) => any): boolean | void;
+        walkRules(selectorFilter: any, callback?: (atRule: Rule, index: number) => any): boolean | void;
         /**
-         * Recursively iterates through all comment nodes within the container.
-         * Like container.each(), this method is safe to use if you are mutating
-         * arrays during iteration.
+         * Traverses the container's descendant nodes, calling `callback` for each
+         * comment. Like container.each(), this method is safe to use if you are
+         * mutating arrays during iteration.
          * @param callback Iterator called for each comment node within the container.
          */
-        eachComment(callback: (comment: Comment, indexed: number) => any): void | boolean;
+        walkComments(callback: (comment: Comment, indexed: number) => any): void | boolean;
         /**
          * Passes all declaration values within the container that match pattern
          * through the callback, replacing those values with the returned result of

--- a/docs/api.md
+++ b/docs/api.md
@@ -80,7 +80,7 @@ Creates a PostCSS plugin with a standard API.
 var remove = postcss.plugin('postcss-remove', function (opts) {
     var filter = opts.prop || 'z-index';
     return function (css, result) {
-        css.eachDecl(filter, function (decl) {
+        css.walkDecls(filter, function (decl) {
             decl.remove();
         });
     };
@@ -146,7 +146,7 @@ Add warnings using the [`Node#warn()`] method.
 ```js
 postcss.plugin('postcss-caniuse-test', function () {
     return function (css, result) {
-        css.eachDecl(function (decl) {
+        css.walkDecls(function (decl) {
             if ( !caniuse.support(decl.prop) ) {
                 decl.warn(result,
                   'Some browsers do not support ' + decl.prop);
@@ -500,7 +500,7 @@ Creates [`Warning`] and adds it to [`Result#messages`].
 ```js
 var plugin = postcss.plugin('postcss-important', function () {
     return function (css, result) {
-        css.eachDecl(function (decl) {
+        css.walkDecls(function (decl) {
             if ( decl.important ) {
                 result.warn('Try to avoid !important', { node: decl });
             }
@@ -1099,7 +1099,7 @@ This method is provided as a convenience wrapper for [`Result#warn()`].
 ```js
 var plugin = postcss.plugin('postcss-deprecated', function () {
     return function (css, result) {
-        css.eachDecl('bad', function (decl) {
+        css.walkDecls('bad', function (decl) {
             decl.warn(result, 'Deprecated property bad');
         });
     };
@@ -1350,16 +1350,15 @@ rule.each(function (decl) {
 
 `container.each()` only iterates through the container’s immediate children.
 If you need to recursively iterate through all the container’s nodes,
-use `container.eachInside()`.
+use `container.walk()`.
 
-### `container.eachInside(callback)`
+### `container.walk(callback)`
 
-Recursively iterates through the container’s children,
-those children’s children, etc., calling `callback` for each.
+Traverses the container’s descendant nodes, calling `callback` for each node.
 
 ```js
-root.eachInside(function (node) {
-    // Will be iterate through all nodes
+root.walk(function (node) {
+    // Traverses all descendant nodes.
 });
 ```
 
@@ -1373,13 +1372,13 @@ if you are mutating arrays during iteration.
 If you only need to iterate through the container’s immediate children,
 use `container.each()`.
 
-### `container.eachDecl([propFilter,] callback)`
+### `container.walkDecls([propFilter,] callback)`
 
-Recursively iterates through all declaration nodes within the container,
-calling `callback` for each.
+Traverses the container’s descendant nodes, calling `callback` for each
+declaration node.
 
 ```js
-root.eachDecl(function (decl) {
+root.walkDecls(function (decl) {
     if ( decl.prop.match(/^-webkit-/) ) {
         decl.remove();
     }
@@ -1397,10 +1396,10 @@ If you pass a `propFilter`, only those declarations whose property matches
 
 ```js
 // Make flat design
-root.eachDecl('border-radius', function (decl) {
+root.walkDecls('border-radius', function (decl) {
     decl.remove();
 });
-root.eachDecl(/^background/, function (decl) {
+root.walkDecls(/^background/, function (decl) {
     decl.value = takeFirstColorFromGradient(decl.value);
 });
 ```
@@ -1408,14 +1407,13 @@ root.eachDecl(/^background/, function (decl) {
 Like `container.each()`, this method is safe to use if you are mutating
 arrays during iteration.
 
-### `container.eachAtRule([nameFilter,] callback)`
+### `container.walkAtRules([nameFilter,] callback)`
 
-Recursively iterates through all at-rule nodes within the container,
-calling `callback` for each.
-
+Traverses the container’s descendant nodes, calling `callback` for each
+at-rule node.
 
 ```js
-root.eachAtRule(function (rule) {
+root.walkAtRules(function (rule) {
     if ( rule.name.match(/^-webkit-/) ) rule.remove();
 });
 ```
@@ -1431,7 +1429,7 @@ will be iterated over.
 
 ```js
 var first = false;
-root.eachAtRule('charset', function (rule) {
+root.walkAtRules('charset', function (rule) {
     if ( !first ) {
         first = true;
     } else {
@@ -1443,14 +1441,14 @@ root.eachAtRule('charset', function (rule) {
 Like `container.each()`, this method is safe to use if you are mutating arrays
 during iteration.
 
-### `container.eachRule([selectorFilter,] callback)`
+### `container.walkRules([selectorFilter,] callback)`
 
-Recursively iterates through all rule nodes within the container, calling
-`callback` for each.
+Traverses the container’s descendant nodes, calling `callback` for each
+rule node.
 
 ```js
 var selectors = [];
-root.eachRule(function (rule) {
+root.walkRules(function (rule) {
     selectors.push(rule.selector);
 });
 console.log('You CSS uses ' + selectors.length + ' selectors');
@@ -1468,13 +1466,13 @@ If you pass a `selectorFilter`, only those rules whose selector matches
 Like `container.each()`, this method is safe to use if you are mutating arrays
 during iteration.
 
-### `container.eachComment(callback)`
+### `container.walkComments(callback)`
 
-Recursively iterates through all comment nodes within the container, calling
-`callback` for each.
+Traverses the container’s descendant nodes, calling `callback` for each
+comment node.
 
 ```js
-root.eachComment(function (comment) {
+root.walkComments(function (comment) {
     comment.remove();
 });
 ```

--- a/lib/container.es6
+++ b/lib/container.es6
@@ -38,11 +38,17 @@ export default class Container extends Node {
     }
 
     eachInside(callback) {
+        warnOnce('Container#eachInside is deprecated. ' +
+                 'Use Container#walk instead.');
+        return this.walk(callback);
+    }
+
+    walk(callback) {
         return this.each( (child, i) => {
             let result = callback(child, i);
 
-            if ( result !== false && child.eachInside ) {
-                result = child.eachInside(callback);
+            if ( result !== false && child.walk ) {
+                result = child.walk(callback);
             }
 
             if ( result === false ) return result;
@@ -50,23 +56,29 @@ export default class Container extends Node {
     }
 
     eachDecl(prop, callback) {
+        warnOnce('Container#eachDecl is deprecated. ' +
+                 'Use Container#walkDecls instead.');
+        return this.walkDecls(prop, callback);
+    }
+
+    walkDecls(prop, callback) {
         if ( !callback ) {
             callback = prop;
-            return this.eachInside( (child, i) => {
+            return this.walk( (child, i) => {
                 if ( child.type === 'decl' ) {
                     let result = callback(child, i);
                     if ( result === false ) return result;
                 }
             });
         } else if ( prop instanceof RegExp ) {
-            return this.eachInside( (child, i) => {
+            return this.walk( (child, i) => {
                 if ( child.type === 'decl' && prop.test(child.prop) ) {
                     let result = callback(child, i);
                     if ( result === false ) return result;
                 }
             });
         } else {
-            return this.eachInside( (child, i) => {
+            return this.walk( (child, i) => {
                 if ( child.type === 'decl' && child.prop === prop ) {
                     let result = callback(child, i);
                     if ( result === false ) return result;
@@ -76,24 +88,30 @@ export default class Container extends Node {
     }
 
     eachRule(selector, callback) {
+        warnOnce('Container#eachRule is deprecated. ' +
+                 'Use Container#walkRules instead.');
+        return this.walkRules(selector, callback);
+    }
+
+    walkRules(selector, callback) {
         if ( !callback ) {
             callback = selector;
 
-            return this.eachInside( (child, i) => {
+            return this.walk( (child, i) => {
                 if ( child.type === 'rule' ) {
                     let result = callback(child, i);
                     if ( result === false ) return result;
                 }
             });
         } else if ( selector instanceof RegExp ) {
-            return this.eachInside( (child, i) => {
+            return this.walk( (child, i) => {
                 if ( child.type === 'rule' && selector.test(child.selector) ) {
                     let result = callback(child, i);
                     if ( result === false ) return result;
                 }
             });
         } else {
-            return this.eachInside( (child, i) => {
+            return this.walk( (child, i) => {
                 if ( child.type === 'rule' && child.selector === selector ) {
                     let result = callback(child, i);
                     if ( result === false ) return result;
@@ -103,23 +121,29 @@ export default class Container extends Node {
     }
 
     eachAtRule(name, callback) {
+        warnOnce('Container#eachAtRule is deprecated. ' +
+                 'Use Container#walkAtRules instead.');
+        return this.walkRules(name, callback);
+    }
+
+    walkAtRules(name, callback) {
         if ( !callback ) {
             callback = name;
-            return this.eachInside( (child, i) => {
+            return this.walk( (child, i) => {
                 if ( child.type === 'atrule' ) {
                     let result = callback(child, i);
                     if ( result === false ) return result;
                 }
             });
         } else if ( name instanceof RegExp ) {
-            return this.eachInside( (child, i) => {
+            return this.walk( (child, i) => {
                 if ( child.type === 'atrule' && name.test(child.name) ) {
                     let result = callback(child, i);
                     if ( result === false ) return result;
                 }
             });
         } else {
-            return this.eachInside( (child, i) => {
+            return this.walk( (child, i) => {
                 if ( child.type === 'atrule' && child.name === name ) {
                     let result = callback(child, i);
                     if ( result === false ) return result;
@@ -129,7 +153,13 @@ export default class Container extends Node {
     }
 
     eachComment(callback) {
-        return this.eachInside( (child, i) => {
+        warnOnce('Container#eachComment is deprecated. ' +
+                 'Use Container#walkComments instead.');
+        return this.walkRules(callback);
+    }
+
+    walkComments(callback) {
+        return this.walk( (child, i) => {
             if ( child.type === 'comment' ) {
                 let result = callback(child, i);
                 if ( result === false ) return result;
@@ -231,7 +261,7 @@ export default class Container extends Node {
             opts = { };
         }
 
-        this.eachDecl((decl) => {
+        this.walkDecls((decl) => {
             if ( opts.props && opts.props.indexOf(decl.prop) === -1 ) return;
             if ( opts.fast  && decl.value.indexOf(opts.fast) === -1 ) return;
 

--- a/lib/map-generator.es6
+++ b/lib/map-generator.es6
@@ -22,7 +22,7 @@ export default class {
     previous() {
         if ( !this.previousMaps ) {
             this.previousMaps = [];
-            this.root.eachInside( (node) => {
+            this.root.walk( (node) => {
                 if ( node.source && node.source.input.map ) {
                     let map = node.source.input.map;
                     if ( this.previousMaps.indexOf(map) === -1 ) {
@@ -78,7 +78,7 @@ export default class {
 
     setSourcesContent() {
         let already = { };
-        this.root.eachInside( (node) => {
+        this.root.walk( (node) => {
             if ( node.source ) {
                 let from = node.source.input.from;
                 if ( from && !already[from] ) {

--- a/lib/stringifier.es6
+++ b/lib/stringifier.es6
@@ -141,7 +141,7 @@ export default class Stringifier {
             if ( this[method] ) {
                 value = this[method](root, node);
             } else {
-                root.eachInside( (i) => {
+                root.walk( (i) => {
                     value = i.raws[own];
                     if ( typeof value !== 'undefined' ) return false;
                 });
@@ -156,7 +156,7 @@ export default class Stringifier {
 
     rawSemicolon(root) {
         let value;
-        root.eachInside( (i) => {
+        root.walk( (i) => {
             if ( i.nodes && i.nodes.length && i.last.type === 'decl' ) {
                 value = i.raws.semicolon;
                 if ( typeof value !== 'undefined' ) return false;
@@ -167,7 +167,7 @@ export default class Stringifier {
 
     rawEmptyBody(root) {
         let value;
-        root.eachInside( (i) => {
+        root.walk( (i) => {
             if ( i.nodes && i.nodes.length === 0 ) {
                 value = i.raws.after;
                 if ( typeof value !== 'undefined' ) return false;
@@ -178,7 +178,7 @@ export default class Stringifier {
 
     rawIndent(root) {
         let value;
-        root.eachInside( (i) => {
+        root.walk( (i) => {
             let p = i.parent;
             if ( p && p !== root && p.parent && p.parent === root ) {
                 if ( typeof i.raws.before !== 'undefined' ) {
@@ -194,7 +194,7 @@ export default class Stringifier {
 
     rawBeforeComment(root, node) {
         let value;
-        root.eachComment( (i) => {
+        root.walkComments( (i) => {
             if ( typeof i.raws.before !== 'undefined' ) {
                 value = i.raws.before;
                 if ( value.indexOf('\n') !== -1 ) {
@@ -211,7 +211,7 @@ export default class Stringifier {
 
     rawBeforeDecl(root, node) {
         let value;
-        root.eachDecl( (i) => {
+        root.walkDecls( (i) => {
             if ( typeof i.raws.before !== 'undefined' ) {
                 value = i.raws.before;
                 if ( value.indexOf('\n') !== -1 ) {
@@ -228,7 +228,7 @@ export default class Stringifier {
 
     rawBeforeRule(root) {
         let value;
-        root.eachInside( (i) => {
+        root.walk( (i) => {
             if ( i.nodes && (i.parent !== root || root.first !== i) ) {
                 if ( typeof i.raws.before !== 'undefined' ) {
                     value = i.raws.before;
@@ -244,7 +244,7 @@ export default class Stringifier {
 
     rawBeforeClose(root) {
         let value;
-        root.eachInside( (i) => {
+        root.walk( (i) => {
             if ( i.nodes && i.nodes.length > 0 ) {
                 if ( typeof i.raws.after !== 'undefined' ) {
                     value = i.raws.after;
@@ -260,7 +260,7 @@ export default class Stringifier {
 
     rawBeforeOpen(root) {
         let value;
-        root.eachInside( (i) => {
+        root.walk( (i) => {
             if ( i.type !== 'decl' ) {
                 value = i.raws.between;
                 if ( typeof value !== 'undefined' ) return false;
@@ -271,7 +271,7 @@ export default class Stringifier {
 
     rawColon(root) {
         let value;
-        root.eachDecl( (i) => {
+        root.walkDecls( (i) => {
             if ( typeof i.raws.between !== 'undefined' ) {
                 value = i.raws.between.replace(/[^\s:]/g, '');
                 return false;

--- a/test/container.es6
+++ b/test/container.es6
@@ -169,13 +169,13 @@ describe('Container', () => {
 
     });
 
-    describe('eachInside()', () => {
+    describe('walk()', () => {
 
         it('iterates', () => {
             let types   = [];
             let indexes = [];
 
-            let result = parse(example).eachInside( (node, i) => {
+            let result = parse(example).walk( (node, i) => {
                 types.push(node.type);
                 indexes.push(i);
             });
@@ -190,7 +190,7 @@ describe('Container', () => {
         it('breaks iteration', () => {
             let indexes = [];
 
-            let result = parse(example).eachInside( (decl, i) => {
+            let result = parse(example).walk( (decl, i) => {
                 indexes.push(i);
                 return false;
             });
@@ -201,13 +201,13 @@ describe('Container', () => {
 
     });
 
-    describe('eachDecl()', () => {
+    describe('walkDecls()', () => {
 
         it('iterates', () => {
             let props   = [];
             let indexes = [];
 
-            let result = parse(example).eachDecl( (decl, i) => {
+            let result = parse(example).walkDecls( (decl, i) => {
                 props.push(decl.prop);
                 indexes.push(i);
             });
@@ -219,7 +219,7 @@ describe('Container', () => {
 
         it('iterates with changes', () => {
             let size = 0;
-            parse(example).eachDecl( (decl, i) => {
+            parse(example).walkDecls( (decl, i) => {
                 decl.parent.removeChild(i);
                 size += 1;
             });
@@ -229,7 +229,7 @@ describe('Container', () => {
         it('breaks iteration', () => {
             let indexes = [];
 
-            let result = parse(example).eachDecl( (decl, i) => {
+            let result = parse(example).walkDecls( (decl, i) => {
                 indexes.push(i);
                 return false;
             });
@@ -242,7 +242,7 @@ describe('Container', () => {
             let css  = parse('@page{a{one:1}}b{one:1;two:2}');
             let size = 0;
 
-            css.eachDecl('one', (decl) => {
+            css.walkDecls('one', (decl) => {
                 expect(decl.prop).to.eql('one');
                 size += 1;
             });
@@ -254,20 +254,20 @@ describe('Container', () => {
             let css  = parse('@page{a{one:1}}b{one-x:1;two:2}');
             let size = 0;
 
-            css.eachDecl(/one(-x)?/, () => size += 1 );
+            css.walkDecls(/one(-x)?/, () => size += 1 );
 
             expect(size).to.eql(2);
         });
 
     });
 
-    describe('eachComment()', () => {
+    describe('walkComments()', () => {
 
         it('iterates', () => {
             let texts   = [];
             let indexes = [];
 
-            let result = parse(example).eachComment( (comment, i) => {
+            let result = parse(example).walkComments( (comment, i) => {
                 texts.push(comment.text);
                 indexes.push(i);
             });
@@ -279,7 +279,7 @@ describe('Container', () => {
 
         it('iterates with changes', () => {
             let size = 0;
-            parse(example).eachComment( (comment, i) => {
+            parse(example).walkComments( (comment, i) => {
                 comment.parent.removeChild(i);
                 size += 1;
             });
@@ -289,7 +289,7 @@ describe('Container', () => {
         it('breaks iteration', () => {
             let indexes = [];
 
-            let result = parse(example).eachComment( (comment, i) => {
+            let result = parse(example).walkComments( (comment, i) => {
                 indexes.push(i);
                 return false;
             });
@@ -300,13 +300,13 @@ describe('Container', () => {
 
     });
 
-    describe('eachRule()', () => {
+    describe('walkRules()', () => {
 
         it('iterates', () => {
             let selectors = [];
             let indexes   = [];
 
-            let result = parse(example).eachRule( (rule, i) => {
+            let result = parse(example).walkRules( (rule, i) => {
                 selectors.push(rule.selector);
                 indexes.push(i);
             });
@@ -318,7 +318,7 @@ describe('Container', () => {
 
         it('iterates with changes', () => {
             let size = 0;
-            parse(example).eachRule( (rule, i) => {
+            parse(example).walkRules( (rule, i) => {
                 rule.parent.removeChild(i);
                 size += 1;
             });
@@ -328,7 +328,7 @@ describe('Container', () => {
         it('breaks iteration', () => {
             let indexes = [];
 
-            let result = parse(example).eachRule( (rule, i) => {
+            let result = parse(example).walkRules( (rule, i) => {
                 indexes.push(i);
                 return false;
             });
@@ -339,13 +339,13 @@ describe('Container', () => {
 
     });
 
-    describe('eachAtRule()', () => {
+    describe('walkAtRules()', () => {
 
         it('iterates', () => {
             let names   = [];
             let indexes = [];
 
-            let result = parse(example).eachAtRule( (atrule, i) => {
+            let result = parse(example).walkAtRules( (atrule, i) => {
                 names.push(atrule.name);
                 indexes.push(i);
             });
@@ -357,7 +357,7 @@ describe('Container', () => {
 
         it('iterates with changes', () => {
             let size = 0;
-            parse(example).eachAtRule( (atrule, i) => {
+            parse(example).walkAtRules( (atrule, i) => {
                 atrule.parent.removeChild(i);
                 size += 1;
             });
@@ -367,7 +367,7 @@ describe('Container', () => {
         it('breaks iteration', () => {
             let indexes = [];
 
-            let result = parse(example).eachAtRule( (atrule, i) => {
+            let result = parse(example).walkAtRules( (atrule, i) => {
                 indexes.push(i);
                 return false;
             });
@@ -380,7 +380,7 @@ describe('Container', () => {
             let css  = parse('@page{@page 2{}}@media print{@page{}}');
             let size = 0;
 
-            css.eachAtRule('page', (atrule) => {
+            css.walkAtRules('page', (atrule) => {
                 expect(atrule.name).to.eql('page');
                 size += 1;
             });
@@ -392,7 +392,7 @@ describe('Container', () => {
             let css  = parse('@page{@page 2{}}@media print{@page{}}');
             let size = 0;
 
-            css.eachAtRule(/page/, () => size += 1 );
+            css.walkAtRules(/page/, () => size += 1 );
 
             expect(size).to.eql(3);
         });

--- a/test/map.es6
+++ b/test/map.es6
@@ -16,10 +16,10 @@ let read = function (result) {
 let dir = path.join(__dirname, 'fixtures');
 
 let doubler = postcss( (css) => {
-    css.eachDecl( decl => decl.parent.prepend(decl.clone()) );
+    css.walkDecls( decl => decl.parent.prepend(decl.clone()) );
 });
 let lighter = postcss( (css) => {
-    css.eachDecl( decl => decl.value = 'white' );
+    css.walkDecls( decl => decl.value = 'white' );
 });
 
 describe('source maps', () => {
@@ -39,10 +39,10 @@ describe('source maps', () => {
     it('generate right source map', () => {
         let css       = 'a {\n  color: black;\n  }';
         let processor = postcss( (root) => {
-            root.eachRule( (rule) => {
+            root.walkRules( (rule) => {
                 rule.selector = 'strong';
             });
-            root.eachDecl( (decl) => {
+            root.walkDecls( (decl) => {
                 decl.parent.prepend( decl.clone({ prop: 'background' }) );
             });
         });

--- a/test/postcss.es6
+++ b/test/postcss.es6
@@ -34,7 +34,7 @@ describe('postcss()', () => {
     it('supports injecting additional processors at runtime', (done) => {
         let plugin1 = postcss.plugin('one', () => {
             return css => {
-                css.eachDecl(decl => {
+                css.walkDecls(decl => {
                     decl.value = 'world';
                 });
             };
@@ -56,7 +56,7 @@ describe('postcss()', () => {
         it('creates plugin', () => {
             let plugin = postcss.plugin('test', (filter) => {
                 return function (css) {
-                    css.eachDecl(filter || 'two', function (decl) {
+                    css.walkDecls(filter || 'two', function (decl) {
                         decl.remove();
                     });
                 };
@@ -80,7 +80,7 @@ describe('postcss()', () => {
         it('creates a shortcut to process css', (done) => {
             let plugin = postcss.plugin('test', (str = 'bar') => {
                 return function (css) {
-                    css.eachDecl( i => i.value = str );
+                    css.walkDecls( i => i.value = str );
                 };
             });
 

--- a/test/processor.es6
+++ b/test/processor.es6
@@ -81,7 +81,7 @@ describe('Processor', () => {
         });
 
         let beforeFix = new Processor([ (css) => {
-            css.eachRule( (rule) => {
+            css.walkRules( (rule) => {
                 if ( !rule.selector.match(/::(before|after)/) ) return;
                 if ( !rule.some( i => i.prop === 'content' ) ) {
                     rule.prepend({ prop: 'content', value: '""' });


### PR DESCRIPTION
Fixes #487 

No rush, just trying to get a head start on this one.

Deprecates `each` methods in favor of similarly-named `walk` methods.