### PR TITLE
Fix postcss.d.ts export

### DIFF
--- a/postcss.d.ts
+++ b/postcss.d.ts
@@ -1,4 +1,4 @@
 declare module 'postcss' {
 	import postcss from 'd.ts/postcss';
-	export = postcss;
+	export default postcss;
 }


### PR DESCRIPTION
This fixes an error when trying to `import postcss from 'postcss';`:

```
19:06 $tsc
lib/plugin.ts(2,8): error TS1192: Module ''postcss'' has no default export.
```

The previous export was the old way, this is the new (ES6) way.