### PR TITLE
Introduce code coverage with Isparta/Istanbul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log
 
 build/
 /postcss.js
+
+coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,5 @@ appveyor.yml
 
 gulpfile.babel.js
 logo.svg
+
+coverage/

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -71,12 +71,6 @@ gulp.task('integration', ['build:lib', 'build:package'], (done) => {
     });
 });
 
-gulp.task('test', () => {
-    require('./');
-    let mocha = require('gulp-mocha');
-    return gulp.src('test/*.es6', { read: false }).pipe(mocha());
-});
-
 // Common
 
-gulp.task('default', ['lint', 'spellcheck', 'test', 'integration']);
+gulp.task('default', ['lint', 'spellcheck', 'integration']);

--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
     "babel-eslint":           "4.0.10",
     "gulp-eslint":            "1.0.0",
     "gulp-babel":             "5.2.1",
-    "gulp-mocha":             "2.1.3",
     "strip-ansi":             "3.0.0",
     "yaspeller":              "2.5.0",
     "gulp-util":              "3.0.6",
     "gulp-run":               "1.6.10",
     "fs-extra":               "0.23.1",
+    "istanbul":               "0.3.18",
+    "isparta":                "3.0.3",
     "eslint":                 "1.2.1",
     "sinon":                  "1.16.1",
     "mocha":                  "2.2.5",
@@ -46,6 +47,8 @@
     "del":                    "1.2.1"
   },
   "scripts": {
-    "test": "gulp"
+    "check-coverage": "istanbul check-coverage --statements 89.12 --branches 81.85 --functions 87.29 --lines 91.71",
+    "cover":          "isparta cover node_modules/mocha/bin/_mocha -i lib/*.es6",
+    "test":           "gulp && npm run cover && npm run check-coverage"
   }
 }


### PR DESCRIPTION
Fixes #501 

Note the `--statements 89.12 --branches 81.85 --functions 87.29 --lines 91.71` are all locked at the current coverage values. We can increase these numbers as more tests are written.

![image](https://cloud.githubusercontent.com/assets/1058243/9401098/ba9d1d54-478f-11e5-9086-afc90753a8eb.png)
