### PR TITLE
Add postcss-rgb-plz to list of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ See also [`precss`] plugins pack to add them by one line of code.
 * [`postcss-colorblind`] transforms colors using filters to simulate
   colorblindness.
 * [`postcss-hexrgba`] adds shorthand hex `rgba(hex, alpha)` method.
+* [`postcss-rgb-plz`] converts 3 or 6 digit hex values to `rgb`.
 
 ### Images and Fonts
 
@@ -553,6 +554,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-reporter`]:                https://github.com/postcss/postcss-reporter
 [`postcss-easings`]:                 https://github.com/postcss/postcss-easings
 [`postcss-hexrgba`]:                 https://github.com/seaneking/postcss-hexrgba
+[`postcss-rgb-plz`]:                 https://github.com/himynameisdave/postcss-rgb-plz
 [`postcss-opacity`]:                 https://github.com/iamvdo/postcss-opacity
 [`postcss-pointer`]:                 https://github.com/markgoodyear/postcss-pointer
 [`postcss-pxtorem`]:                 https://github.com/cuth/postcss-pxtorem


### PR DESCRIPTION
Attempt no. 2 at getting [`postcss-rgb-plz`](https://github.com/himynameisdave/postcss-rgb-plz) added to the list of plugins.

`postcss-rgb-plz` is a super simple plugin that converts basic 3/6 digit hex values to their rgb counterpart. We use it at my work to maintain consistency between alpha'd and non-alpha'd colours in our outputted CSS. So for instance we don't want our stylesheets to be jumping around between `#fff` and `rgba( 255, 255, 255, 0.5 )`, we'd rather just use `rgb( 255, 255, 255 )` instead of the hex value altogether. It's really just a consistency thing, there's not some hidden performance improvement.

Although some developers have pointed out that this is silly, the plugin does meet all the plugin requirements and I would like to add it to the "official" list. Mostly just for the sake of it potentially being of some use to some other developers beyond me and my team.

Thanks guys!