### PR TITLE
Added postcss-mqwidth-to-class plugin under Fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ See also [`cssnext`] plugins pack to add future CSS syntax by one line of code.
 
 * [`postcss-color-rgba-fallback`] transforms `rgba()` to hexadecimal.
 * [`postcss-epub`] adds the `-epub-` prefix to relevant properties.
+* [`postcss-mqwidth-to-class`] converts min/max-width media queries to classes.
 * [`postcss-opacity`] adds opacity filter for IE8.
 * [`postcss-pseudoelements`] Convert `::` selectors into `:` selectors
   for IE 8 compatibility.
@@ -564,6 +565,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-hexrgba`]:                 https://github.com/seaneking/postcss-hexrgba
 [`postcss-initial`]:                 https://github.com/maximkoretskiy/postcss-initial
 [`postcss-rgb-plz`]:                 https://github.com/himynameisdave/postcss-rgb-plz
+[`postcss-mqwidth-to-class`]:        https://github.com/notacouch/postcss-mqwidth-to-class
 [`postcss-opacity`]:                 https://github.com/iamvdo/postcss-opacity
 [`postcss-pointer`]:                 https://github.com/markgoodyear/postcss-pointer
 [`postcss-pxtorem`]:                 https://github.com/cuth/postcss-pxtorem


### PR DESCRIPTION
While Respond.js is an excellent solution for media queries in IE8, instead of extracting and reintroducing actual CSS rules from style tags and stylesheets why not just let the browser do the heavy lifting? 

Converting `min-width` and `max-width` `@media` queries to `.min-width-#px` and `.max-width-#px` classes allows for the browser to have critical CSS of some sorts without having to watch crazy redraws esp. as stylesheets get larger for bigger projects.