### PR TITLE
Fix untrimmed decl.value

### DIFF
--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -353,7 +353,7 @@ export default class Parser {
         let value = '';
         let clean = true;
         for ( let i = 0, length = tokens.length; i < length; i += 1 ) {
-            let token = tokens[i];
+            token = tokens[i];
             if ( token[0] === 'comment' || token[0] === 'space' && i === length - 1 ) {
                 clean = false;
             } else {

--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -352,8 +352,9 @@ export default class Parser {
         let token;
         let value = '';
         let clean = true;
-        for ( token of tokens ) {
-            if ( token[0] === 'comment' ) {
+        for ( let i = 0, length = tokens.length; i < length; i += 1 ) {
+            let token = tokens[i];
+            if ( token[0] === 'comment' || token[0] === 'space' && i === length - 1 ) {
                 clean = false;
             } else {
                 value += token[1];


### PR DESCRIPTION
Some decision. But how to restore the space before semicolon? Does it need?

fix #566 