### PR TITLE
parse nested at-rules without trailing semicolon

### DIFF
--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -275,6 +275,9 @@ export default class Parser {
             } else if ( token[0] === '{' ) {
                 open = true;
                 break;
+            } else if ( token[0] === '}') {
+                this.end(token);
+                break;
             } else {
                 params.push(token);
             }

--- a/test/parse.es6
+++ b/test/parse.es6
@@ -63,6 +63,12 @@ describe('postcss.parse()', () => {
         expect(root.first.first.value).to.eql('())');
     });
 
+    it('parses nested at-rules without trailing semicolon', () => {
+        let root = parse('a { @import "a.css" }');
+        expect(root.first.first.name).to.eql('import');
+        expect(root.first.first.params).to.eql('"a.css"');
+    });
+
     describe('errors', () => {
 
         it('throws on unclosed blocks', () => {


### PR DESCRIPTION
Code changes from postcss/postcss-scss#8. Fixes postcss/postcss-scss#7