### PR TITLE
add engine restriction since native Promise is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "postcss",
   "version": "5.0.6",
   "description": "Tool for transforming styles with JS plugins",
+  "engines": {
+    "node": ">=0.12"
+  },
   "keywords": [
     "css",
     "postcss",


### PR DESCRIPTION
While people are using lower version of node, `Promise is not defined` error occured