### PR TITLE
Adding support / discussion link so new users know where to ask questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ But PostCSS is modular, 3-30 times faster, and much more powerful.
 
 Twitter account: [@postcss](https://twitter.com/postcss).
 VK.com page:     [postcss](https://vk.com/postcss).
+Support / Discussion: [gitter](https://gitter.im/postcss/postcss).
 
 [appveyor-img]: https://img.shields.io/appveyor/ci/ai/postcss.svg?label=windows
 [travis-img]:   https://img.shields.io/travis/postcss/postcss.svg?label=unix

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ But PostCSS is modular, 3-30 times faster, and much more powerful.
 
 Twitter account: [@postcss](https://twitter.com/postcss).
 VK.com page:     [postcss](https://vk.com/postcss).
+
 Support / Discussion: [gitter](https://gitter.im/postcss/postcss).
 
 [appveyor-img]: https://img.shields.io/appveyor/ci/ai/postcss.svg?label=windows


### PR DESCRIPTION
As a new user, I was unsure where to get help or ask questions.  The github main page doesn't give people a place to go.  It might make sense to post the link to the gitter.im room somewhere on the site to encourage new users to learn how the internals work.