### PR TITLE
Add postcss-fallback to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ See also [`cssnext`] plugins pack to add future CSS syntax by one line of code.
 
 * [`postcss-color-rgba-fallback`] transforms `rgba()` to hexadecimal.
 * [`postcss-epub`] adds the `-epub-` prefix to relevant properties.
+* [`postcss-fallback`] adds `fallback` function to avoid duplicate declarations.
 * [`postcss-mqwidth-to-class`] converts min/max-width media queries to classes.
 * [`postcss-opacity`] adds opacity filter for IE8.
 * [`postcss-pseudoelements`] Convert `::` selectors into `:` selectors
@@ -625,6 +626,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-colormin`]:                https://github.com/ben-eb/colormin
 [`postcss-cssstats`]:                https://github.com/cssstats/postcss-cssstats
 [`postcss-currency`]:                https://github.com/talgautb/postcss-currency
+[`postcss-fallback`]:                https://github.com/MadLittleMods/postcss-fallback
 [`postcss-imperial`]:                https://github.com/cbas/postcss-imperial
 [`postcss-position`]:                https://github.com/seaneking/postcss-position
 [`postcss-spiffing`]:                https://github.com/HashanP/postcss-spiffing


### PR DESCRIPTION
Add [`postcss-fallback`](https://github.com/MadLittleMods/postcss-fallback) to readme.

> PostCSS plugin to provide fallback values for properties without having duplicate declarations.

---

### Example:

Input:

```css
.foo {
    display: fallback(flex, inline-block);
    width: fallback(45vh, 450px);

    background-color: fallback(rgba(0, 0, 0, 0.5), #555555);
    foo: fallback(bar, baz, qux, corge);
}
```

Output:
```css
.foo {
    display: inline-block;
    display: flex;
    width: 450px;
    width: 45vh;

    background-color: #555555;
    background-color: rgba(0, 0, 0, 0.5);
    foo: corge;
    foo: qux;
    foo: baz;
    foo: bar;
}
```