### PR TITLE
Allow passing a previous map with no mappings (empty string)

### DIFF
--- a/lib/previous-map.es6
+++ b/lib/previous-map.es6
@@ -92,6 +92,7 @@ export default class PreviousMap {
 
     isMap(map) {
         if ( typeof map !== 'object' ) return false;
-        return map.mappings || map._mappings;
+        return typeof map.mappings === 'string' ||
+            typeof map._mappings === 'string';
     }
 }

--- a/test/previous-map.es6
+++ b/test/previous-map.es6
@@ -11,7 +11,7 @@ let mapObj = {
     file:     null,
     sources:  [],
     names:    [],
-    mappings: []
+    mappings: ''
 };
 let map = JSON.stringify(mapObj);
 
@@ -50,7 +50,7 @@ describe('PreviousMap', () => {
             file:     'b',
             sources:  ['a'],
             names:    [],
-            mappings: []
+            mappings: ''
         };
 
         let opts = { map: { prev: map2 } };
@@ -118,7 +118,7 @@ describe('PreviousMap', () => {
             version:  3,
             sources:  ['a'],
             names:    [],
-            mappings: []
+            mappings: ''
         };
 
         let opts = { map: { prev: map2 } };
@@ -129,4 +129,13 @@ describe('PreviousMap', () => {
         expect(file1).to.not.eql(file2);
     });
 
+    it('should accept an empty mappings string', () => {
+        let emptyMap = {
+            version:  3,
+            sources:  [],
+            names:    [],
+            mappings: ''
+        };
+        parse('body{}', { map: { prev: emptyMap } } );
+    });
 });


### PR DESCRIPTION
Also, stop passing mappings:[] in tests -- that was source map rev. 2 syntax, and the source-map package doesn't support those.