### PR TITLE
Use package.json version in the processor

### DIFF
--- a/lib/processor.es6
+++ b/lib/processor.es6
@@ -1,8 +1,9 @@
 import LazyResult  from './lazy-result';
+import { version } from '../package.json';
 
 export default class Processor {
 
-    version = '5.0.14';
+    version = version;
 
     constructor(plugins = []) {
         this.plugins = this.normalize(plugins);


### PR DESCRIPTION
Hi,

In this way there is only one source for the version, and it doesn't have to be changed manually for each bump. Hope it helps.

Cheers