### PR TITLE
Fix a typo

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -133,7 +133,7 @@ to generate byte-to-byte equal output. It is not so difficult, but respectful
 for user input and allow integration smoke tests.
 
 A parser should save all additional symbols to [`node.raws`] object.
-It is a open structure for you, you can add additional keys.
+It is an open structure for you, you can add additional keys.
 For example, [SCSS parser] saves comment types (`/* */` or `//`)
 in `node.raws.inline`.
 


### PR DESCRIPTION
minor English tweak, replace `a` with `an`