### PR TITLE
Track newlines within strings; fixes #727

### DIFF
--- a/lib/tokenize.es6
+++ b/lib/tokenize.es6
@@ -143,11 +143,26 @@ export default function tokenize(input) {
                 }
             } while ( escaped );
 
+            content = css.slice(pos, next + 1);
+            lines   = content.split('\n');
+            last    = lines.length - 1;
+
+            if ( last > 0 ) {
+                nextLine   = line + last;
+                nextOffset = next - lines[last].length;
+            } else {
+                nextLine   = line;
+                nextOffset = offset;
+            }
+
             tokens.push(['string', css.slice(pos, next + 1),
                 line, pos  - offset,
-                line, next - offset
+                nextLine, next - nextOffset
             ]);
-            pos = next;
+
+            offset = nextOffset;
+            line   = nextLine;
+            pos    = next;
             break;
 
         case AT:

--- a/test/tokenize.es6
+++ b/test/tokenize.es6
@@ -98,6 +98,13 @@ describe('tokenize', () => {
         test('"\\\\"', [ ['string', '"\\\\"', 1, 1, 1, 4] ]);
     });
 
+    it('changes lines in strings', () => {
+        test('"\n\n""\n\n"', [
+            ['string', '"\n\n"', 1, 1, 3, 1],
+            ['string', '"\n\n"', 3, 2, 5, 1]
+        ]);
+    });
+
     it('tokenizes at-word', () => {
         test('@word ', [ ['at-word', '@word', 1, 1, 1, 5], ['space', ' '] ]);
     });


### PR DESCRIPTION
I believe that the issue causing #727 is that the tokenizer was not registering newlines within strings. So whatever came after the string was thought to be on the same line as the string's opening --- which in this instance was not the case. 

I copied some logic from the tokenization of comments and verified that it works with a test. I also verified that the particular issue in #727 (the syntax error having a weird position) is fixed by this.