### PR TITLE
Allow options passing to Result#warn from Node#warn.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1099,7 +1099,7 @@ Arguments:
   * `index` (number): an index inside a node’s string that should be highlighted
     as the source of the error.
 
-### `node.warn(result, message)`
+### `node.warn(result, text, opts)`
 
 This method is provided as a convenience wrapper for [`Result#warn()`].
 
@@ -1116,7 +1116,17 @@ var plugin = postcss.plugin('postcss-deprecated', function () {
 Arguments:
 
 * `result`: The [`Result`] instance that will receive the warning.
-* `message (string)`: error description.
+* `text (string)`: warning message. It will be used in the `text` property of
+  the message object.
+* `opts (object) optional`: properties to assign to the message object.
+  * `word (string)`: word inside a node’s string that should be highlighted
+    as the source of the warning.
+  * `index` (number): index inside a node’s string that should be highlighted
+    as the source of the warning.
+  * `plugin`: name of the plugin that created this warning. `Result#warn()` will
+    automatically fill it with the `plugin.postcssPlugin` value.
+
+Note that `opts.node` is automatically passed to [`Result#warn()`] for you.
 
 ### `node.next()` and `node.prev()`
 

--- a/lib/node.es6
+++ b/lib/node.es6
@@ -46,8 +46,8 @@ export default class Node {
         }
     }
 
-    warn(result, message) {
-        return result.warn(message, { node: this });
+    warn(result, text, opts) {
+        return result.warn(text, { node: this, ...opts });
     }
 
     remove() {

--- a/test/node.es6
+++ b/test/node.es6
@@ -68,6 +68,19 @@ describe('Node', () => {
             expect(result.warnings()[0].text).to.eql('FIRST!');
             expect(result.warnings()[0].plugin).to.eql('warner');
         });
+
+        it('accepts options', () => {
+            let warner = postcss.plugin('warner', () => {
+                return (css, result) => {
+                    css.first.warn(result, 'FIRST!', { index: 1 });
+                };
+            });
+
+            let result = postcss([ warner() ]).process('a{}');
+            expect(result.warnings().length).to.eql(1);
+            expect(result.warnings()[0].index).to.eql(1);
+        });
+
     });
 
     describe('remove()', () => {


### PR DESCRIPTION
Perhaps just an oversight from when I first implemented this method.

This change makes it easier to implement this feature - https://github.com/ben-eb/stylehacks/issues/4.