### PR TITLE
Update TypeScript support

### DIFF
--- a/d.ts/at-rule.d.ts
+++ b/d.ts/at-rule.d.ts
@@ -32,8 +32,10 @@ export default class AtRule extends Container implements postcss.AtRule {
      */
     clone(overrides?: Object): AtRule;
     toJSON(): postcss.JsonAtRule;
-    append(...children: any[]): Container;
-    prepend(...children: any[]): Container;
+    append(...children: any[]): this;
+    prepend(...children: any[]): this;
+    insertBefore(oldNode: any, newNode: any): this;
+    insertAfter(oldNode: any, newNode: any): this;
     afterName: string;
     _params: string;
 }

--- a/d.ts/container.d.ts
+++ b/d.ts/container.d.ts
@@ -20,7 +20,7 @@ export default class Container extends Node implements postcss.Container {
      */
     clone(overrides?: Object): any;
     toJSON(): postcss.JsonContainer;
-    push(child: any): Container;
+    push(child: any): this;
     /**
      * Iterates through the container's immediate children, calling the
      * callback function for each child. If you need to recursively iterate
@@ -94,7 +94,7 @@ export default class Container extends Node implements postcss.Container {
      * @param nodes New nodes.
      * @returns This container for chaining.
      */
-    append(...nodes: (Node | Object | string)[]): Container;
+    append(...nodes: (Node | Object | string)[]): this;
     /**
      * Inserts new nodes to the beginning of the container.
      * Because each node class is identifiable by unique properties, use the
@@ -110,20 +110,20 @@ export default class Container extends Node implements postcss.Container {
      * @param nodes New nodes.
      * @returns This container for chaining.
      */
-    prepend(...nodes: (Node | Object | string)[]): Container;
+    prepend(...nodes: (Node | Object | string)[]): this;
     cleanRaws(keepBetween?: boolean): void;
     /**
      * Insert newNode before oldNode within the container.
      * @param oldNode Child or child's index.
      * @returns This container for chaining.
      */
-    insertBefore(oldNode: Node | number, newNode: Node | Object | string): Container;
+    insertBefore(oldNode: Node | number, newNode: Node | Object | string): this;
     /**
      * Insert newNode after oldNode within the container.
      * @param oldNode Child or child's index.
      * @returns This container for chaining.
      */
-    insertAfter(oldNode: Node | number, newNode: Node | Object | string): Container;
+    insertAfter(oldNode: Node | number, newNode: Node | Object | string): this;
     /**
      * Removes the container from its parent and cleans the parent property in the
      * container and its children.
@@ -136,13 +136,13 @@ export default class Container extends Node implements postcss.Container {
      * @param child Child or child's index.
      * @returns This container for chaining.
      */
-    removeChild(child: Node | number): Container;
+    removeChild(child: Node | number): this;
     /**
      * Removes all children from the container and cleans their parent
      * properties.
      * @returns This container for chaining.
      */
-    removeAll(): Container;
+    removeAll(): this;
     /**
      * Passes all declaration values within the container that match pattern
      * through the callback, replacing those values with the returned result of

--- a/d.ts/css-syntax-error.d.ts
+++ b/d.ts/css-syntax-error.d.ts
@@ -116,6 +116,7 @@ export default class CssSyntaxError implements postcss.CssSyntaxError, SyntaxErr
      * string.
      */
     showSourceCode(color?: boolean): string;
+    private setMozillaProps();
     /**
      *
      * @returns Error position, message and source code of broken part.

--- a/d.ts/node.d.ts
+++ b/d.ts/node.d.ts
@@ -2,7 +2,6 @@ import Container from './container';
 import CssSyntaxError from './css-syntax-error';
 import postcss from './postcss';
 import Result from './result';
-import Root from './root';
 export default class Node implements postcss.Node {
     /**
      * Returns a string representing the node's type. Possible values are
@@ -47,7 +46,7 @@ export default class Node implements postcss.Node {
      * @param result The result that will receive the warning.
      * @param message Error description.
      */
-    warn(result: Result, message: string): void;
+    warn(result: Result, message: string): any;
     /**
      * Deprecated. Use Node#remove.
      */
@@ -57,8 +56,8 @@ export default class Node implements postcss.Node {
      * node and its children.
      * @returns This node for chaining.
      */
-    remove(): Node;
-    replace(nodes: any): Node;
+    remove(): this;
+    replace(nodes: any): this;
     /**
      * @returns A CSS string representing the node.
      */
@@ -87,7 +86,7 @@ export default class Node implements postcss.Node {
      * Inserts node(s) before the current node and removes the current node.
      * @returns This node for chaining.
      */
-    replaceWith(...nodes: (Node | Object)[]): Node;
+    replaceWith(...nodes: (Node | Object)[]): this;
     /**
      * Removes the node from its current parent and inserts it at the end of
      * newParent. This will clean the before and after code style properties
@@ -96,7 +95,7 @@ export default class Node implements postcss.Node {
      * @param newParent Where the current node will be moved.
      * @returns This node for chaining.
      */
-    moveTo(newParent: Container): Node;
+    moveTo(newParent: Container): this;
     /**
      * Removes the node from its current parent and inserts it into a new
      * parent before otherNode. This will also clean the node's code style
@@ -104,7 +103,7 @@ export default class Node implements postcss.Node {
      * @param otherNode Will be after the current node after moving.
      * @returns This node for chaining.
      */
-    moveBefore(otherNode: Node): Node;
+    moveBefore(otherNode: Node): this;
     /**
      * Removes the node from its current parent and inserts it into a new
      * parent after otherNode. This will also clean the node's code style
@@ -112,7 +111,7 @@ export default class Node implements postcss.Node {
      * @param otherNode Will be before the current node after moving.
      * @returns This node for chaining.
      */
-    moveAfter(otherNode: Node): Node;
+    moveAfter(otherNode: Node): this;
     /**
      * @returns The next child of the node's parent; or, returns undefined if
      * the current node is the last child.
@@ -137,7 +136,7 @@ export default class Node implements postcss.Node {
     /**
      * @returns The Root instance of the node's tree.
      */
-    root(): Root;
+    root(): any;
     cleanRaws(keepBetween?: boolean): void;
     positionInside(index: number): {
         line: number;

--- a/d.ts/parser.d.ts
+++ b/d.ts/parser.d.ts
@@ -26,6 +26,7 @@ export default class Parser {
     spacesFromStart(tokens: any): string;
     stringFrom(tokens: any, from: any): string;
     colon(tokens: any): number | boolean;
+    unknownDecl(node: any, token: any): void;
     unclosedBracket(bracket: any): void;
     unknownWord(start: any): void;
     unexpectedClose(token: any): void;

--- a/d.ts/postcss.d.ts
+++ b/d.ts/postcss.d.ts
@@ -679,6 +679,7 @@ declare module postcss {
         raw(prop: string, defaultType?: string): any;
     }
     interface NodeNewProps {
+        raws?: NodeRaws;
     }
     interface NodeRaws {
         /**
@@ -1126,6 +1127,11 @@ declare module postcss {
          * the entire group will be included.
          */
         selector?: string;
+        /**
+         * An array containing the rule's individual selectors. Groups of selectors
+         * are split at commas.
+         */
+        selectors?: string[];
     }
     interface RuleRaws extends ContainerRaws {
         /**

--- a/d.ts/processor.d.ts
+++ b/d.ts/processor.d.ts
@@ -15,7 +15,7 @@ export default class Processor implements postcss.Processor {
      * Adds a plugin to be used as a CSS processor. Plugins can also be
      * added by passing them as arguments when creating a postcss instance.
      */
-    use(plugin: typeof postcss.acceptedPlugin): Processor;
+    use(plugin: typeof postcss.acceptedPlugin): this;
     /**
      * Parses source CSS. Because some plugins can be asynchronous it doesn't
      * make any transformations. Transformations will be applied in LazyResult's

--- a/d.ts/root.d.ts
+++ b/d.ts/root.d.ts
@@ -29,7 +29,7 @@ export default class Root extends Container implements postcss.Root {
      * @param child Child or child's index.
      * @returns This root node for chaining.
      */
-    removeChild(child: Node | number): Root;
+    removeChild(child: Node | number): this;
     protected normalize(node: Node | string, sample: Node, type?: string): Node[];
     protected normalize(props: postcss.AtRuleNewProps | postcss.RuleNewProps | postcss.DeclarationNewProps | postcss.CommentNewProps, sample: Node, type?: string): Node[];
     /**

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,15 +25,19 @@ The `postcss` function is the main entry point for PostCSS.
 var postcss = require('postcss');
 ```
 
-For those using TypeScript with an [ES6 compile target], you can import
-the PostCSS API like so:
+For those using [TypeScript][], typings are already provided in this package.
+Simply, import PostCSS as you would normally.
 
 ```ts
-///<reference path="node_modules/postcss/postcss.d.ts" />
 import * as postcss from 'postcss';
 ```
 
-[ES6 compile target]: https://github.com/Microsoft/TypeScript/wiki/tsconfig.json
+This will give you a true [IntelliSense][] experience. You can try it out in
+[Visual Studio Code][] for free!
+
+[TypeScript]: http://www.typescriptlang.org/
+[IntelliSense]: http://code.visualstudio.com/Docs/editor/editingevolved#_intellisense
+[Visual Studio Code]: http://code.visualstudio.com/
 
 ### `postcss(plugins)`
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -36,6 +36,7 @@ gulp.task('build:package', ['clean'], () => {
     return gulp.src('./package.json')
         .pipe(editor( json => {
             json.main = 'lib/postcss';
+            json.typings = 'd.ts/postcss.d.ts';
             for ( let i of builders ) {
                 json.devDependencies[i] = json.dependencies[i];
                 delete json.dependencies[i];

--- a/postcss.d.ts
+++ b/postcss.d.ts
@@ -1,4 +1,0 @@
-declare module 'postcss' {
-	import postcss from 'd.ts/postcss';
-	export default postcss;
-}


### PR DESCRIPTION
I recompiled [my typescript branch](https://github.com/jedmao/postcss/tree/typescript) with the newly-released [TypeScript 1.8.2](https://github.com/Microsoft/TypeScript/releases/tag/v1.8.2) and fixed the errors that popped up.

Also, TypeScript now supports a new `typings` field in the package.json file, which points to the type definitions for postcss. This is now the golden path and I like it very much compared to what we had before!

