### PR TITLE
Fix Root#toResult(opts) link

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1789,7 +1789,7 @@ var comment.text //=> 'Empty file'
 [source map options]: https://github.com/postcss/postcss/blob/master/docs/source-maps.md
 
 [`Processor#process(css, opts)`]: #processorprocesscss-opts
-[`Root#toResult(opts)`]:          #roottoresult-opts
+[`Root#toResult(opts)`]:          #roottoresultopts
 [`LazyResult#then()`]:            #lazythenonfulfilled-onrejected
 [`postcss(plugins)`]:             #postcssplugins
 [`postcss.plugin()`]:             #postcsspluginname-initializer


### PR DESCRIPTION
Remove extra dash.
It is generated without dash as you can see below.

![hash from root.toResult(opts)](http://s.csssr.ru/2016-02-28-0026-a04wqvfbyw.png)