### PR TITLE
Enabling source maps to handle odd urls

### DIFF
--- a/docs/source-maps.md
+++ b/docs/source-maps.md
@@ -65,4 +65,8 @@ option as an object with the following parameters:
 
   If you have set `inline: true`, annotation cannot be disabled.
 
+* `from` string: by default, PostCSS will set the `sources` property of the map
+  to the value of the `from` option. If you want to override this behaviour, you
+  can use `map.from` to explicitly set the source map's `sources` property.
+
 [source maps]: http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/

--- a/lib/map-generator.es6
+++ b/lib/map-generator.es6
@@ -165,6 +165,10 @@ export default class {
     }
 
     relative(file) {
+        if ( file.match(/https?:\/\/|file:\/\//) ) {
+            return file;
+        }
+
         let from = this.opts.to ? path.dirname(this.opts.to) : '.';
 
         if ( typeof this.mapOpts.annotation === 'string' ) {
@@ -181,6 +185,9 @@ export default class {
     }
 
     sourcePath(node) {
+        if ( this.mapOpts.from ) {
+            return this.mapOpts.from;
+        }
         return this.relative(node.source.input.from);
     }
 

--- a/test/map.es6
+++ b/test/map.es6
@@ -508,4 +508,23 @@ describe('source maps', () => {
         expect(result.css).to.include('a {\r\n}\r\n/*# sourceMappingURL=');
     });
 
+    it('preserves absolute urls in `to`', () => {
+        let result = postcss().process('a{}', {
+            from: '/dir/to/a.css',
+            to:   'http://example.com/a.css',
+            map:  { inline: false }
+        });
+        expect(result.map.toJSON().file).to.eql('http://example.com/a.css');
+    });
+
+    it('`map.from` should override the source map sources', () => {
+        let result = postcss().process('a{}', {
+            map: {
+                inline: false,
+                from:   'file:///dir/a.css'
+            }
+        });
+        expect(result.map.toJSON().sources).to.eql(['file:///dir/a.css']);
+    });
+
 });


### PR DESCRIPTION
This adds two options to the `map` options available:
- `preservePaths` which forces early escapes in the `relative(...)` function. This enables cross-protocol urls to function as expected.
- `sourcePath` an optional override for the relative path generated during processing 

This would fix #757 