### PR TITLE
Add `map.from` option

### DIFF
--- a/docs/source-maps.md
+++ b/docs/source-maps.md
@@ -65,4 +65,8 @@ option as an object with the following parameters:
 
   If you have set `inline: true`, annotation cannot be disabled.
 
+* `from` string: by default, PostCSS will set the `sources` property of the map
+  to the value of the `from` option. If you want to override this behaviour, you
+  can use `map.from` to explicitly set the source map's `sources` property.
+
 [source maps]: http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/

--- a/lib/map-generator.es6
+++ b/lib/map-generator.es6
@@ -181,6 +181,10 @@ export default class {
     }
 
     sourcePath(node) {
+        if ( this.mapOpts.from ) {
+            return this.mapOpts.from;
+        }
+
         return this.relative(node.source.input.from);
     }
 

--- a/test/map.es6
+++ b/test/map.es6
@@ -508,4 +508,14 @@ describe('source maps', () => {
         expect(result.css).to.include('a {\r\n}\r\n/*# sourceMappingURL=');
     });
 
+    it('`map.from` should override the source map sources', () => {
+        let result = postcss().process('a{}', {
+            map: {
+                inline: false,
+                from:   'file:///dir/a.css'
+            }
+        });
+        expect(result.map.toJSON().sources).to.eql(['file:///dir/a.css']);
+    });
+
 });


### PR DESCRIPTION
This allows overrides of a source map's `sources` property.

re: postcss#758 

@ai this should be added to the next minor release