### PR TITLE
Fix missing type causing TypeScript compiler error with noImplicitAny.

### DIFF
--- a/d.ts/postcss.d.ts
+++ b/d.ts/postcss.d.ts
@@ -23,7 +23,7 @@ declare module postcss {
     interface Plugin<T> extends Transformer {
         (opts?: T): Transformer;
         postcss: Transformer;
-        process: (css, opts?: any) => LazyResult;
+        process: (css: any, opts?: any) => LazyResult;
     }
     interface Transformer extends TransformCallback {
         postcssPlugin?: string;


### PR DESCRIPTION
TypeScript compiler run with `tsc --noImplicitAny` prints:

`node_modules/postcss/d.ts/postcss.d.ts(26,19): error TS7006: Parameter 'css' implicitly has an 'any' type.`

Adding the `any` type explicitly fixes the error.
