### PR TITLE
Reverse token adding in spacesFromEnd

### DIFF
--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -365,11 +365,12 @@ export default class Parser {
     }
 
     spacesFromEnd(tokens) {
-        let next;
+        let lastTokenType;
         let spaces = '';
         while ( tokens.length ) {
-            next = tokens[tokens.length - 1][0];
-            if ( next !== 'space' && next !== 'comment' ) break;
+            lastTokenType = tokens[tokens.length - 1][0];
+            if ( lastTokenType !== 'space' &&
+                lastTokenType !== 'comment' ) break;
             spaces = tokens.pop()[1] + spaces;
         }
         return spaces;

--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -370,7 +370,7 @@ export default class Parser {
         while ( tokens.length ) {
             next = tokens[tokens.length - 1][0];
             if ( next !== 'space' && next !== 'comment' ) break;
-            spaces += tokens.pop()[1];
+            spaces = tokens.pop()[1] + spaces;
         }
         return spaces;
     }

--- a/test/rule.es6
+++ b/test/rule.es6
@@ -43,6 +43,11 @@ describe('Rule', () => {
             expect(rule.selector).to.eql('em,\nstrong');
         });
 
+        it('saves raw string between selector and block', () => {
+            let root = parse('a /*x*/\n{}');
+            expect(root.first.raw('between')).to.eql(' /*x*/\n');
+        });
+
         it('uses between to detect separator', () => {
             let rule = new Rule({ selector: 'b', raws: { between: '' } });
             rule.selectors = ['b', 'strong'];


### PR DESCRIPTION
I ran into a strange bug while trying to fix this: https://github.com/stylelint/stylelint/issues/1148

Turns out the rule's `raws.between` seemed to have its tokens reversed. From the source code 

```css
a /*x*/
{}
```` 

I'd expect the rule's `raws.between` to be `" /*x*/\n"`. But instead I was getting `"\n/*x*/ "`.

I was able to reproduce this with a test in PostCSS. And I found what I think may have been a logic flaw in the `spacesFromEnd` function that is used to create `raws.between`. I adjusted that logic to get my test to pass, and all existing tests continue to pass. (The build failure seems to be related to code coverage reporting.)