### PR TITLE
Added postcss-esplit plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -113,6 +113,7 @@ See also [`cssnext`] plugins pack to add future CSS syntax by one line of code.
 * [`cssgrace`] provides various helpers and transpiles CSS 3 for IE
   and other old browsers.
 * [`pixrem`] generates pixel fallbacks for `rem` units.
+* [`postcss-esplit`] splits your CSS exceeding 4095 selectors for IE.
 
 See also [`oldie`] plugins pack.
 
@@ -580,6 +581,7 @@ See also plugins in modular minifier [`cssnano`].
 [`mq4-hover-shim`]:                    https://github.com/twbs/mq4-hover-shim
 [`postcss-atroot`]:                    https://github.com/OEvgeny/postcss-atroot
 [`postcss-layout`]:                    https://github.com/arccoza/postcss-layout
+[`postcss-esplit`]:                    https://github.com/vitaliyr/postcss-esplit
 [`postcss-focus`]:                     https://github.com/postcss/postcss-focus
 [`postcss-apply`]:                     https://github.com/pascalduez/postcss-apply
 [`css2modernizr`]:                     https://github.com/vovanbo/css2modernizr

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -92,6 +92,7 @@ See also [`cssnext`] plugins pack to add future CSS syntax by one line of code.
 
 * [`postcss-color-rgba-fallback`] transforms `rgba()` to hexadecimal.
 * [`postcss-epub`] adds the `-epub-` prefix to relevant properties.
+* [`postcss-esplit`] splits your CSS exceeding 4095 selectors for IE.
 * [`postcss-fallback`] adds `fallback` function to avoid duplicate declarations.
 * [`postcss-filter-gradient`] adds gradient filter for the old IE.
 * [`postcss-flexibility`] adds `-js-` prefix for [`Flexibility polyfill`].
@@ -113,7 +114,6 @@ See also [`cssnext`] plugins pack to add future CSS syntax by one line of code.
 * [`cssgrace`] provides various helpers and transpiles CSS 3 for IE
   and other old browsers.
 * [`pixrem`] generates pixel fallbacks for `rem` units.
-* [`postcss-esplit`] splits your CSS exceeding 4095 selectors for IE.
 
 See also [`oldie`] plugins pack.
 


### PR DESCRIPTION
Hello. I've created and polished [postcss-esplit](http://github.com/vitaliyr/postcss-esplit) plugin - and decided to add it to readme. 

The idea inside it that we were used in our project blesscss tool which just doing the same job. But it doesn't have support for source maps. Also we though to move our project to use postcss so I decided to wrote a plugin for postcss which would do just the same thing blesscss doing but with support of sourcemaps.

What do you think? 

(Duplicate pulls/806, but changes are in correct file)