### PR TITLE
Use CommonJS TypeScript export

### DIFF
--- a/d.ts/postcss.d.ts
+++ b/d.ts/postcss.d.ts
@@ -1242,4 +1242,4 @@ declare module postcss {
     interface JsonComment extends JsonNode {
     }
 }
-export default postcss;
+export = postcss;

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -21,17 +21,21 @@ gulp.task('build:lib', ['compile'], () => {
     return gulp.src('lib/*.js').pipe(gulp.dest('build/lib'));
 });
 
+gulp.task('build:typings', ['clean'], () => {
+    return gulp.src(['d.ts/**/*.d.ts']).pipe(gulp.dest('build/d.ts'));
+});
+
 gulp.task('build:docs', ['clean'], () => {
     let ignore = require('fs').readFileSync('.npmignore').toString()
         .trim().split(/\n+/)
-        .concat(['.npmignore', 'index.js', 'lib/*', 'test/*',
+        .concat(['.npmignore', 'index.js', 'lib/*', 'test/*', 'd.ts/*',
                  'node_modules/**/*'])
         .map( i => '!' + i );
     return gulp.src(['**/*'].concat(ignore))
         .pipe(gulp.dest('build'));
 });
 
-gulp.task('build', ['build:lib', 'build:docs']);
+gulp.task('build', ['build:typings', 'build:lib', 'build:docs']);
 
 // Lint
 
@@ -56,7 +60,7 @@ gulp.task('test', ['compile'], () => {
     return gulp.src('test/*.js', { read: false }).pipe(ava());
 });
 
-gulp.task('integration', ['build:lib'], done => {
+gulp.task('integration', ['build:typings', 'build:lib'], done => {
     let postcss = require('./build/lib/postcss');
     let real    = require('postcss-parser-tests/real');
     real(done, css => {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-core":                        "6.8.0",
     "gulp-babel":                        "6.1.2",
     "strip-ansi":                        "3.0.1",
+    "typescript":                        "1.8.10",
     "gulp-shell":                        "0.5.2",
     "yaspeller":                         "2.6.0",
     "gulp-ava":                          "0.11.0",

--- a/test/typings.js
+++ b/test/typings.js
@@ -1,0 +1,109 @@
+import ts from 'typescript';
+import { runInNewContext } from 'vm';
+import { join as joinPath, relative } from 'path';
+import { readFileSync } from 'fs';
+import test from 'ava';
+
+import postcss from '../lib/postcss';
+
+const compilerOptions = {
+    module:           ts.ModuleKind.CommonJS,
+    moduleResolution: ts.ModuleResolutionKind.NodeJs,
+    target:           ts.ScriptTarget.ES5
+};
+
+function run(code) {
+    const context = {
+        require(path) {
+            if (path === 'postcss')
+                return postcss;
+
+            throw new Error('Could not find module:' + path);
+        }
+    };
+
+    runInNewContext(code, context);
+}
+
+// based on http://blog.scottlogic.com/2015/01/20/typescript-compiler-api.html
+class MockLanguageServiceHost {
+    constructor(compilationSettings, files) {
+        this.files = Object.assign({}, files);
+        this.getCompilationSettings = () => compilationSettings;
+
+        for (const key in this.files) {
+            if (!this.files.hasOwnProperty(key)) continue;
+            this.files[key] = ts.ScriptSnapshot.fromString(this.files[key]);
+        }
+    }
+
+    log() {}
+    trace() {}
+    error() {}
+
+    getScriptIsOpen() {
+        return true;
+    }
+
+    getCurrentDirectory() {
+        return '';
+    }
+
+    getDefaultLibFileName() {
+        return 'lib';
+    }
+
+    getScriptVersion() {
+        return '0';
+    }
+
+    getScriptSnapshot(fileName) {
+        if (fileName.indexOf('/node_modules/postcss/') === 0) {
+            try {
+                const relPath = relative('/node_modules/postcss/', fileName);
+                const newPath = joinPath(__dirname, '..', relPath);
+                const file = readFileSync(newPath, 'utf8');
+                return ts.ScriptSnapshot.fromString(file);
+            } catch (err) {
+                return null;
+            }
+        }
+
+
+        return this.files[fileName];
+    }
+
+    getScriptFileNames() {
+        return Object.keys(this.files);
+    }
+}
+
+function createLanguageService(files) {
+    const host = new MockLanguageServiceHost(compilerOptions, files);
+    return ts.createLanguageService(host, ts.createDocumentRegistry());
+}
+
+const src = `
+    import * as postcss from 'postcss';
+    postcss.plugin('foobar', () => () => null);
+`;
+
+test('TypeScript Typings', t => {
+    const path = '/script.ts';
+    const langSvc = createLanguageService({ [path]: src });
+
+    const result = ts.transpileModule(src, {
+        reportDiagnostics: true,
+        compilerOptions
+    });
+
+    let compileOutput = result.outputText;
+
+    let diagnostics = langSvc.getSemanticDiagnostics(path)
+        .concat(langSvc.getSyntacticDiagnostics(path))
+        .concat(result.diagnostics);
+
+    t.deepEqual(diagnostics.map(d => d.messageText), [], 'compiles correctly');
+
+    t.notThrows(() => run(compileOutput), Error, 'links correctly');
+});


### PR DESCRIPTION
This PR changes the type definition export from and ES6 export (`export default`) to a CommonJS export (`export =`). This is necessary because of the `add-module-exports` babel plugin, which appends `module.exports = exports['default']` to the main file. Because of this, TypeScript's translation of `import postcss from 'postcss'` becomes `var postcss = require('postcss').default` and does not work. Babel users don't have this problem because Babel equates `module.exports` with `exports.default` when it doesn't see the `___es6Module` flag.

## Test Cases

I've included an integration test that compiles a simple piece of TypeScript against the library and attempts to run it. 

With `export default postcss`, the following cases do **not** work.

```ts
import postcss from 'postcss';
```

```
  1) TypeScript Typings links correctly:
     AssertionError: expected [Function] to not throw an error but [TypeError: Cannot read property 'plugin' of undefined] was thrown
      at expectToRun (typings.es6:23:5)
      at Context.<anonymous> (typings.es6:122:33)
```

```ts
 import * as postcss from 'postcss';
```

```
  1) TypeScript Typings has no compile errors:
     AssertionError: One or more errors were reported.
- Property 'plugin' does not exist on type 'typeof "/node_modules/postcss/d.ts/postcss"'.
      at expectDiagnosticsEmpty (typings.es6:33:15)
      at Context.<anonymous> (typings.es6:120:15)
```
```ts
import postcss = require('postcss');
```

```
  1) TypeScript Typings has no compile errors:
     AssertionError: One or more errors were reported.
- Property 'plugin' does not exist on type 'typeof "/node_modules/postcss/d.ts/postcss"'.
      at expectDiagnosticsEmpty (typings.es6:33:15)
      at Context.<anonymous> (typings.es6:120:15)
```

With `export = postcss`, the following case does **not** work.

```ts
import postcss from 'postcss';
```

```
  1) TypeScript Typings has no compile errors:
     AssertionError: One or more errors were reported.
- Module '"/node_modules/postcss/d.ts/postcss"' has no default export.
      at expectDiagnosticsEmpty (typings.es6:33:15)
      at Context.<anonymous> (typings.es6:120:15)

  2) TypeScript Typings links correctly:
     AssertionError: expected [Function] to not throw an error but [TypeError: Cannot read property 'plugin' of undefined] was thrown
      at expectToRun (typings.es6:23:5)
      at Context.<anonymous> (typings.es6:122:33)
```

With `export = postcss`, the following cases **do** work.

```ts
import * as postcss from 'postcss';
```

```ts
import postcss = require('postcss');
```