### PR TITLE
Replace yaspeller command with gulp task

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -43,6 +43,11 @@ gulp.task('lint', () => {
         .pipe(eslint.failAfterError());
 });
 
+gulp.task('spellcheck', () => {
+    let run = require('gulp-run');
+        .pipe(run('yaspeller <%= file.path %>'));
+});
+
 // Tests
 
 gulp.task('test', ['compile'], () => {
@@ -93,4 +98,4 @@ gulp.task('api', ['clean'], done => {
 
 gulp.task('offline', ['version', 'lint', 'test', 'api']);
 
-gulp.task('default', ['offline', 'integration']);
+gulp.task('default', ['offline', 'spellcheck', 'integration']);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-babel":                        "6.1.2",
     "strip-ansi":                        "3.0.1",
     "yaspeller":                         "2.8.0",
+    "gulp-run":                          "1.7.1",
     "gulp-ava":                          "0.12.1",
     "fs-extra":                          "0.30.0",
     "docdash":                           "0.4.0",
@@ -52,7 +53,7 @@
     "del":                               "2.2.0"
   },
   "scripts": {
-    "test": "gulp && yaspeller *.md docs/**/*.md"
+    "test": "gulp"
   },
   "main": "lib/postcss"
 }


### PR DESCRIPTION
This should resolve any issues with running the builds on different platforms. 