### PR TITLE
Add Camelcaser to plugins.

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -358,6 +358,7 @@ See also plugins in modular minifier [`cssnano`].
   but inline (adding just what you need).
 * [`rtlcss`] mirrors styles for right-to-left locales.
 * [`stylefmt`] modern CSS formatter that works well with `stylelint`.
+* [`postcss-camelcaser`] changes all your selectors to camel case.
 
 [flexbox bugs]: https://github.com/philipwalton/flexbugs
 


### PR DESCRIPTION
Added a url to my plugin which transforms css selectors to camelcase.

https://github.com/GMchris/postcss-camelcaser/commits?author=GMchris