### PR TITLE
added postcss-material-shadow-helper plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 * [`rtlcss`] mirrors styles for right-to-left locales.
 
 [PostCSS plugin development]: https://github.com/postcss/postcss/blob/master/docs/writing-a-plugin.md
+[`postcss-material-shadow-helper`]: https://github.com/HarrisRobin/postcss-material-shadow-helper.git
 [`postcss-inline-svg`]:       https://github.com/TrySound/postcss-inline-svg
 [`react-css-modules`]:        https://github.com/gajus/react-css-modules
 [`postcss-autoreset`]:        https://github.com/maximkoretskiy/postcss-autoreset


### PR DESCRIPTION
This is my first postcss plugin, let me know if I did anything wrong.

This is a simple plugin to provide a helper to create shadows based on google material design specs. The values are taken from here:
https://medium.com/@Florian/freebie-google-material-design-shadow-helper-2a0501295a2d#.3a8cnueb0