### PR TITLE
Provide result.map even when options.map.inline is true

### DIFF
--- a/lib/map-generator.es6
+++ b/lib/map-generator.es6
@@ -157,11 +157,7 @@ export default class MapGenerator {
         if ( this.previous().length > 0 ) this.applyPrevMaps();
         if ( this.isAnnotation() )        this.addAnnotation();
 
-        if ( this.isInline() ) {
-            return [this.css];
-        } else {
-            return [this.css, this.map];
-        }
+        return [this.css, this.map];
     }
 
     relative(file) {


### PR DESCRIPTION
**Current:** Right now, when `options.map.inline` is true (or more accurately, when [`MapGenerator#isInline()`](https://github.com/postcss/postcss/blob/7bbb1e4d623636b833aace0f62a1731e41a3e825/lib/map-generator.es6#L38-L53) returns true), the source map is annotated in the CSS, but [`result.map`](https://github.com/postcss/postcss/blob/7bbb1e4d623636b833aace0f62a1731e41a3e825/lib/map-generator.es6#L160-L164) will then be empty.

```js
const postcss = require('postcss');
const processor = postcss(require('postcss-color-function'));
const src = 'a { color: color(red a(90%)) }';
const options = {
  from: 'a.css',
  to: 'a.out.css',
  map: {}
};

options.map.inline = false;
processor.process(src, options).stringify().map
// => SourceMapGenerator { ... }

options.map.inline = true;
processor.process(src, options).stringify().map
// => undefined
```

**Expected:** In both cases above, `.map` is an instance of `SourceMapGenerator`.

**Prior discussions:** https://github.com/postcss/postcss/issues/31#issuecomment-36077662 suggests always specifying `inline: false`, and if inline annotation needed, generate the annotation myself.

**So doesn't that solve the problem?** I'm developing a module that allows users to use PostCSS as a "transformer," where users are free to specify options for `process()`. As such, I want two things:

1. the source map object, provided by `.map`
2. the resultant CSS, conforming to user's specification of inlining (or in case the user does not specify a preference, the default behavior of PostCSS)

When `options.map.inline` is defined, I can quite easily follow https://github.com/postcss/postcss/issues/31#issuecomment-36077662. But the problem is that when `options.map.inline` is undefined, PostCSS uses a set of default [heuristics](https://github.com/postcss/postcss/blob/7bbb1e4d623636b833aace0f62a1731e41a3e825/lib/map-generator.es6#L43-L52) to determine whether inlining should be turned on. As a transformer, I'd like to interfere with PostCSS internals as little as possible, and that means that I don't want to set `inline: false` and then duplicate PostCSS's heuristics (which can change version-to-version) to determine if the annotation needs to be re-added, myself.

Plus, by Occam's Razor (aka KISS), when removing 4 loc achieves the same as adding much more than 4 loc in heuristics and annotation generation, removing should be preferred.