### PR TITLE
Update postcss.d.ts for Input interface

### DIFF
--- a/d.ts/postcss.d.ts
+++ b/d.ts/postcss.d.ts
@@ -550,6 +550,11 @@ declare module postcss {
          * that was compiled to CSS before being passed to PostCSS):
          */
         origin(line: number, column: number): InputOrigin;
+        
+        /**
+        * Save input css file
+        */
+        css: string;
     }
     interface Node {
         /**


### PR DESCRIPTION
Example
```typescript
import { plugin, Container, Result } from "postcss";
export default plugin("postcss-test", function() {
   return function(css: Container) {
      const input = css.source.input;
      console.log(input.css);       // haven't access to css property in typescript
                                    // but valid in javascript
   };
});
```