### PR TITLE
Add postcss-filter-tint plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -238,6 +238,7 @@ See also [`precss`] plugins pack to add them by one line of code.
 * [`postcss-write-svg`] write inline SVGs in CSS.
 * [`postcss-inline-svg`] inline SVG images and customize their styles.
 * [`webpcss`] adds URLs for WebP images for browsers that support WebP.
+* [`postcss-filter-tint`] adds a tint filter to images.
 
 ## Grids
 
@@ -667,3 +668,4 @@ See also plugins in modular minifier [`cssnano`].
 [`rtlcss`]:                               https://github.com/MohammadYounes/rtlcss
 [`short`]:                                https://github.com/jonathantneal/postcss-short
 [`lost`]:                                 https://github.com/corysimmons/lost
+[`postcss-filter-tint`]:                  https://github.com/alexlibby/postcss-filter-tint


### PR DESCRIPTION
I've created a simple PostCSS plugin to add a tint filter to elements, such as images - I'd love it if it could be included in the list.

Feedback welcome.