### PR TITLE
Avoid calls to path.relative when the input file name is not available

### DIFF
--- a/lib/map-generator.es6
+++ b/lib/map-generator.es6
@@ -166,6 +166,7 @@ export default class MapGenerator {
 
     relative(file) {
         if ( /^\w+:\/\//.test(file) ) return file;
+        if ( file.indexOf('<input css ') === 0 ) return file;
 
         let from = this.opts.to ? path.dirname(this.opts.to) : '.';
 


### PR DESCRIPTION
Does it make sense to call `path.relative` when the input style does not have associated a path (eg it's `<input css 1>`)?
I'm not 100% sure about this fix, but in my brand new [PHP port of PostCSS](https://github.com/mlocati/postcss) the integration test with bootstrap.css (tokenize it and re-create it) has a huge performance improvement (about 2x fast)...