### PR TITLE
Improve syntax highlight (sync with babel-code-frame)

### DIFF
--- a/lib/css-syntax-error.es6
+++ b/lib/css-syntax-error.es6
@@ -160,7 +160,7 @@ class CssSyntaxError {
 
         let css = this.source;
         if ( typeof color === 'undefined' ) color = supportsColor;
-        if ( color ) css = terminalHighlight(css, this.line, this.column);
+        if ( color ) css = terminalHighlight(css);
 
         let lines = css.split(/\r?\n/);
         let start = Math.max(this.line - 3, 0);

--- a/lib/terminal-highlight.es6
+++ b/lib/terminal-highlight.es6
@@ -10,6 +10,8 @@ const HIGHLIGHT_THEME = {
     'at-word':  colors.cyan,
     'comment':  colors.gray,
     'string':   colors.green,
+    'class':    colors.yellow,
+    'hash':     colors.magenta,
     '{':        colors.yellow,
     '}':        colors.yellow,
     '[':        colors.yellow,
@@ -18,11 +20,23 @@ const HIGHLIGHT_THEME = {
     ';':        colors.yellow
 };
 
+function getTokenType([type, value]) {
+    if (type === 'word') {
+        if (value[0] === '.') {
+            return 'class';
+        }
+        if (value[0] === '#') {
+            return 'hash';
+        }
+    }
+    return type;
+}
+
 function terminalHighlight(css) {
     let tokens = tokenize(new Input(css), { ignoreErrors: true });
     let result = [];
     for ( let token of tokens ) {
-        let color = HIGHLIGHT_THEME[token[0]];
+        let color = HIGHLIGHT_THEME[getTokenType(token)];
         if ( color ) {
             result.push(token[1].split(/\r?\n/)
               .map( i => color(i) )

--- a/lib/terminal-highlight.es6
+++ b/lib/terminal-highlight.es6
@@ -8,10 +8,13 @@ let colors = new chalk.constructor({ enabled: true });
 const HIGHLIGHT_THEME = {
     'brackets': colors.cyan,
     'at-word':  colors.cyan,
+    'call':     colors.cyan,
     'comment':  colors.gray,
     'string':   colors.green,
     'class':    colors.yellow,
     'hash':     colors.magenta,
+    '(':        colors.cyan,
+    ')':        colors.cyan,
     '{':        colors.yellow,
     '}':        colors.yellow,
     '[':        colors.yellow,
@@ -20,7 +23,7 @@ const HIGHLIGHT_THEME = {
     ';':        colors.yellow
 };
 
-function getTokenType([type, value]) {
+function getTokenType([type, value], index, tokens) {
     if (type === 'word') {
         if (value[0] === '.') {
             return 'class';
@@ -29,23 +32,27 @@ function getTokenType([type, value]) {
             return 'hash';
         }
     }
+
+    let nextToken = tokens[index + 1];
+    if (nextToken && (nextToken[0] === 'brackets' || nextToken[0] === '(')) {
+        return 'call';
+    }
+
     return type;
 }
 
 function terminalHighlight(css) {
     let tokens = tokenize(new Input(css), { ignoreErrors: true });
-    let result = [];
-    for ( let token of tokens ) {
-        let color = HIGHLIGHT_THEME[getTokenType(token)];
+    return tokens.map((token, index) => {
+        let color = HIGHLIGHT_THEME[getTokenType(token, index, tokens)];
         if ( color ) {
-            result.push(token[1].split(/\r?\n/)
+            return token[1].split(/\r?\n/)
               .map( i => color(i) )
-              .join('\n'));
+              .join('\n');
         } else {
-            result.push(token[1]);
+            return token[1];
         }
-    }
-    return result.join('');
+    }).join('');
 }
 
 export default terminalHighlight;

--- a/lib/terminal-highlight.es6
+++ b/lib/terminal-highlight.es6
@@ -7,41 +7,22 @@ let colors = new chalk.constructor({ enabled: true });
 
 const HIGHLIGHT_THEME = {
     'brackets': colors.cyan,
-    'invalid':  colors.white.bgRed.bold,
-    'at-word':  colors.red,
+    'at-word':  colors.cyan,
     'comment':  colors.gray,
-    'string':   colors.red,
-    '{':        colors.green,
-    '}':        colors.green,
-    ':':        colors.bold,
-    ';':        colors.bold,
-    '(':        colors.bold,
-    ')':        colors.bold
+    'string':   colors.green,
+    '{':        colors.yellow,
+    '}':        colors.yellow,
+    '[':        colors.yellow,
+    ']':        colors.yellow,
+    ':':        colors.yellow,
+    ';':        colors.yellow
 };
 
-function inside(token, line, column) {
-    if ( !line || !column ) {
-        return false;
-    } else if ( token.length >= 6 ) {
-        return token[2] <= line && token[3] <= column &&
-               token[4] >= line && token[5] >= column;
-    } else if ( token.length === 4 ) {
-        return token[2] === line && token[3] === column;
-    } else {
-        return false;
-    }
-}
-
-function terminalHighlight(css, line, column) {
+function terminalHighlight(css) {
     let tokens = tokenize(new Input(css), { ignoreErrors: true });
     let result = [];
     for ( let token of tokens ) {
         let color = HIGHLIGHT_THEME[token[0]];
-        if ( inside(token, line, column) ) {
-            color = HIGHLIGHT_THEME.invalid;
-        } else {
-            color = HIGHLIGHT_THEME[token[0]];
-        }
         if ( color ) {
             result.push(token[1].split(/\r?\n/)
               .map( i => color(i) )


### PR DESCRIPTION
Before:

![screenshot from 2016-09-29 21-43-09](https://cloud.githubusercontent.com/assets/2142817/18969691/7391f33c-868e-11e6-8f45-cc08d78e8c4e.png)

After:

![screenshot from 2016-09-29 21-42-38](https://cloud.githubusercontent.com/assets/2142817/18969683/6abd6c3c-868e-11e6-8d4a-365bfc3b5140.png)

See each commit for more details.

I also have a more crazy branch where I:

- Post-process the `tokens` array to create `,` tokens in some cases, to be able
  to highlight some commas.
- Try to highlight property names, without false positives for pseudo-classes.

The code of that crazy branch is really ugly. I don't think it's worth it. Here's what it looks like:

![screenshot from 2016-09-29 21-46-54](https://cloud.githubusercontent.com/assets/2142817/18969661/5930c84c-868e-11e6-9061-4a16e12eab67.png)