### PR TITLE
Fix `postcss.vendor.unprefixed` & `postcss.vendor.prefix`

### DIFF
--- a/lib/vendor.es6
+++ b/lib/vendor.es6
@@ -20,9 +20,8 @@ let vendor = {
      * postcss.vendor.prefix('tab-size')      //=> ''
      */
     prefix(prop) {
-        if ( prop[0] === '-' ) {
-            let sep = prop.indexOf('-', 1);
-            return prop.substr(0, sep + 1);
+        if ( /^(-\w+-)/.test(prop) ) {
+            return RegExp.$1;
         } else {
             return '';
         }
@@ -39,12 +38,7 @@ let vendor = {
      * postcss.vendor.unprefixed('-moz-tab-size') //=> 'tab-size'
      */
     unprefixed(prop) {
-        if ( prop[0] === '-' ) {
-            let sep = prop.indexOf('-', 1);
-            return prop.substr(sep + 1);
-        } else {
-            return prop;
-        }
+        return prop.replace(/^-\w+-/, '');
     }
 
 };

--- a/test/vendor.js
+++ b/test/vendor.js
@@ -2,12 +2,16 @@ import vendor from '../lib/vendor';
 
 import test from 'ava';
 
+const value = '-1px -1px 1px rgba(0, 0, 0, 0.2) inset';
+
 test('returns prefix', t => {
+    t.deepEqual(vendor.prefix(value), '');
     t.deepEqual(vendor.prefix('-moz-color'), '-moz-');
     t.deepEqual(vendor.prefix('color'     ), '');
 });
 
 test('returns unprefixed version', t => {
+    t.deepEqual(vendor.unprefixed(value), value);
     t.deepEqual(vendor.unprefixed('-moz-color'), 'color');
     t.deepEqual(vendor.unprefixed('color'     ), 'color');
 });


### PR DESCRIPTION
#919
Support test cases `-1px -1px 1px rgba(0, 0, 0, 0.2) inset`
