### PR TITLE
remove Node 0.12 requirement in guidelines

### DIFF
--- a/docs/guidelines/plugin.md
+++ b/docs/guidelines/plugin.md
@@ -69,7 +69,7 @@ module.exports = postcss.plugin('plugin-name', function (opts) {
 ### 2.1. Plugin must be tested
 
 A CI service like [Travis] is also recommended for testing code in
-different environments. You should test in (at least) Node.js 0.12 and stable.
+different environments. You should test in (at least) Node.js [active LTS](https://github.com/nodejs/LTS) and current stable version.
 
 [Travis]: https://travis-ci.org/
 


### PR DESCRIPTION
As discussed on Gitter

Node 0.12 ends maintenance support at the end of this year. I think we should drop this requirement in the plugin guidelines and replace it by the active LTS, which would be an intemporal statement. Currently this means Node v4

I'm not sure if it is useful to update the boilerplate too, or let the plugin author decide which older versions of Node he wants to support.