### PR TITLE
added postcss-parent-selector to docs/plugins.md

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -699,3 +699,4 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-pie`]:                          https://github.com/gucong3000/postcss-pie
 [`postcss-color-hsl`]:                    https://github.com/dmarchena/postcss-color-hsl
 [`postcss-color-rgb`]:                    https://github.com/dmarchena/postcss-color-rgb
+[`postcss-parent-selector`]:              https://github.com/domwashburn/postcss-parent-selector

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -319,6 +319,7 @@ See also plugins in modular minifier [`cssnano`].
 * [`postcss-hidden`] allows for easy ways to hide elements.
 * [`postcss-input-style`] adds new pseudo-elements for cross-browser styling
   of inputs.
+* [`postcss-parent-selector`] adds a parent selector to the beginning of all rules.
 * [`postcss-position`] adds shorthand declarations for position attributes.
 * [`postcss-property-lookup`] allows referencing property values without
   a variable.


### PR DESCRIPTION
 `postcss-parent-selector` adds a parent selector to the beginning of all rules.