### PR TITLE
add postcss-bidirectional to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 * [`cssnano`] is a modular CSS minifier.
 * [`lost`] is a feature-rich `calc()` grid system.
 * [`rtlcss`] mirrors styles for right-to-left locales.
+* [`postcss-bidirectional`] use proposed CSS standard properties to generate left-to-right and right-to-left styles.
 
 [PostCSS plugin development]: https://github.com/postcss/postcss/blob/master/docs/writing-a-plugin.md
 [`postcss-inline-svg`]:       https://github.com/TrySound/postcss-inline-svg


### PR DESCRIPTION
`postcss-bidirectional` is planed to be used for firefox devtools debugger to provide cross browser RTL support.

https://github.com/gasolin/postcss-bidirection/issues/1