### PR TITLE
[WIP] Porting csstree tokenizer

### DIFF
--- a/lib/character.es6
+++ b/lib/character.es6
@@ -1,0 +1,18 @@
+/* Single chacracter structure */
+export class Character {
+    constructor(type, value, start, end, position) {
+        this.type = type;
+        this.value = value;
+        this.start = start;
+        this.end = end;
+        this.position = position;
+    }
+
+    /* Get character position */
+    getPosition() {
+        return {
+            line: this.position.line,
+            column: this.position.column
+        };
+    }
+}

--- a/lib/new-tokenizer.es6
+++ b/lib/new-tokenizer.es6
@@ -32,7 +32,7 @@ const RE_BAD_BRACKET = /.[\\\/\("'\n]/;
 export class Tokenizer {
     constructor(input, options = {}) {
         this.scanner = new Scanner(input.css.valueOf(), options);
-        this.currentChar = {};
+        this.currentChar = null;
         this.currentToken = null;
         this.buffer = [];
     }

--- a/lib/new-tokenizer.es6
+++ b/lib/new-tokenizer.es6
@@ -1,0 +1,159 @@
+/* eslint no-unused-vars: 0, no-undef: 0 */ // turning off only for now
+
+import { Scanner } from './scanner';
+import { Character } from './character';
+
+const SINGLE_QUOTE      = '\''.charCodeAt(0);
+const DOUBLE_QUOTE      =  '"'.charCodeAt(0);
+const BACKSLASH         = '\\'.charCodeAt(0);
+const SLASH             =  '/'.charCodeAt(0);
+const NEWLINE           = '\n'.charCodeAt(0);
+const SPACE             =  ' '.charCodeAt(0);
+const FEED              = '\f'.charCodeAt(0);
+const TAB               = '\t'.charCodeAt(0);
+const CR                = '\r'.charCodeAt(0);
+const OPEN_SQUARE       =  '['.charCodeAt(0);
+const CLOSE_SQUARE      =  ']'.charCodeAt(0);
+const OPEN_PARENTHESES  =  '('.charCodeAt(0);
+const CLOSE_PARENTHESES =  ')'.charCodeAt(0);
+const OPEN_CURLY        =  '{'.charCodeAt(0);
+const CLOSE_CURLY       =  '}'.charCodeAt(0);
+const SEMICOLON         =  ';'.charCodeAt(0);
+const ASTERISK          =  '*'.charCodeAt(0);
+const COLON             =  ':'.charCodeAt(0);
+const AT                =  '@'.charCodeAt(0);
+
+const RE_AT_END      = /[ \n\t\r\f\{\(\)'"\\;/\[\]#]/g;
+const RE_WORD_END    = /[ \n\t\r\f\(\)\{\}:;@!'"\\\]\[#]|\/(?=\*)/g;
+const RE_BAD_BRACKET = /.[\\\/\("'\n]/;
+
+
+/* Base tokenizer class */
+export class Tokenizer {
+    constructor(input, options = {}) {
+        this.scanner = new Scanner(input.css.valueOf(), options);
+        this.currentChar = {};
+        this.currentToken = null;
+        this.buffer = [];
+    }
+
+    /* Helper for reading character */
+    getCharacter() {
+        this.scanner.getNext();
+        let position = this.scanner.getLocation(this.scanner.tokenStart);
+
+        const char = new Character(
+            this.scanner.tokenType,
+            this.scanner.tokenStart,
+            this.scanner.tokenEnd,
+            position
+        );
+
+        return char;
+    }
+
+    /* Read next value */
+    setNextCharacter() {
+        let buf = this.buffer;
+        this.currentChar = buf.length ? buf.shift() : this.getCharacter();
+    }
+
+    /* lookup next character */
+    lookAhead() {
+        const nextChar = this.getCharacter();
+        this.buffer.push(nextChar);
+        return nextChar;
+    }
+
+    readNextToken() {
+        this.setNextCharacter();
+        const code = this.currentChar.type;
+
+        // if ( code === NEWLINE || code === FEED ||
+        //      code === CR && css.charCodeAt(pos + 1) !== NEWLINE ) {
+        //     offset = pos;
+        //     line  += 1;
+        // }
+
+        switch ( code ) {
+        case NEWLINE:
+        case SPACE:
+        case TAB:
+        case CR:
+        case FEED:
+            do {
+                const lookup = this.lookAhead();
+                if ( lookup === NEWLINE ) {
+                    offset = next;
+                    line  += 1;
+                }
+            } while ( code === SPACE   ||
+                        code === NEWLINE ||
+                        code === TAB     ||
+                        code === CR      ||
+                        code === FEED );
+
+                // this.currentToken = ['space', css.slice(pos, next)];
+                // pos = next - 1;
+            break;
+
+        case OPEN_SQUARE:
+            this.currentToken = [
+                '[',
+                '[',
+                this.currentChar.position.line,
+                this.currentChar.position.column
+            ];
+            break;
+
+        case CLOSE_SQUARE:
+            this.currentToken = [
+                ']',
+                ']',
+                this.currentChar.position.line,
+                this.currentChar.position.column
+            ];
+            break;
+
+        case OPEN_CURLY:
+            this.currentToken = [
+                '{',
+                '{',
+                this.currentChar.position.line,
+                this.currentChar.position.column
+            ];
+            break;
+
+        case CLOSE_CURLY:
+            this.currentToken = [
+                '}',
+                '}',
+                this.currentChar.position.line,
+                this.currentChar.position.column
+            ];
+            break;
+
+        case COLON:
+            this.currentToken = [
+                ':',
+                ':',
+                this.currentChar.position.line,
+                this.currentChar.position.column
+            ];
+            break;
+
+        case SEMICOLON:
+            this.currentToken = [
+                ';',
+                ';',
+                this.currentChar.position.line,
+                this.currentChar.position.column
+            ];
+
+            break;
+
+        default:
+            break;
+        }
+    }
+}

--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -1,14 +1,16 @@
 import Declaration from './declaration';
-import tokenizer   from './tokenize';
+// import tokenizer   from './tokenize';
 import Comment     from './comment';
 import AtRule      from './at-rule';
 import Root        from './root';
 import Rule        from './rule';
+import { Tokenizer } from './tokenizer';
 
 export default class Parser {
-
     constructor(input) {
         this.input = input;
+
+        let css = input.css.valueOf();
 
         this.pos       = 0;
         this.root      = new Root();
@@ -16,20 +18,24 @@ export default class Parser {
         this.spaces    = '';
         this.semicolon = false;
 
+        this.tokenizer = new Tokenizer(css);
+        this.currentToken = null;
+
         this.root.source = { input, start: { line: 1, column: 1 } };
     }
 
-    tokenize() {
-        this.tokens = tokenizer(this.input);
+    /* Read next token value */
+    getNextToken() {
+        this.tokenizer.readNextToken();
+        this.currentToken = this.tokenizer.tokenType;
     }
 
-    loop() {
-        let token;
-        while ( this.pos < this.tokens.length ) {
-            token = this.tokens[this.pos];
-
+    /* Parser driver, parse full file, construct AST*/
+    parse() {
+        while (!this.tokenizer.eof) {
+            this.getNextToken();
+            const token = this.currentToken;
             switch ( token[0] ) {
-
             case 'space':
             case ';':
                 this.spaces += token[1];

--- a/lib/scanner.es6
+++ b/lib/scanner.es6
@@ -1,0 +1,504 @@
+/* eslint no-bitwise: 0 */
+
+import { CssSyntaxError } from './tokenizer-errors';
+import {
+    SYMBOL_CATEGORY,
+    IS_PUNCTUATION,
+    TokenType,
+    TokenName
+} from './token';
+
+let SYMBOL_CATEGORY_LENGTH = SYMBOL_CATEGORY.length;
+import { isHex, cmpStr } from './tokenizer-utils';
+
+let NULL = 0;
+let WHITESPACE = TokenType.Whitespace;
+let IDENTIFIER = TokenType.Identifier;
+let NUMBER = TokenType.Number;
+let STRING = TokenType.String;
+let COMMENT = TokenType.Comment;
+let PUNCTUATION = TokenType.Punctuation;
+
+let TAB = 9;
+let N = 10;
+let F = 12;
+let R = 13;
+let SPACE = 32;
+let STAR = 42;
+let SLASH = 47;
+let BACK_SLASH = 92;
+let FULLSTOP = TokenType.FullStop;
+let PLUSSIGN = TokenType.PlusSign;
+let HYPHENMINUS = TokenType.HyphenMinus;
+let E = 101; // 'e'.charCodeAt(0)
+
+let MIN_BUFFER_SIZE = 16 * 1024;
+let OFFSET_MASK = 0x00FFFFFF;
+let TYPE_OFFSET = 24;
+
+// fallback on Array when TypedArray is not supported
+const typedArrAvailable = typeof Uint32Array !== 'undefined';
+let SafeUint32Array = typedArrAvailable ? Uint32Array : Array;
+
+// some browser implementations have no TypedArray#lastIndexOf
+let lastIndexOf = Array.prototype.lastIndexOf;
+
+let offsetAndType = new SafeUint32Array(MIN_BUFFER_SIZE);
+let lines = null;
+
+function firstCharOffset(source) {
+    return source.charCodeAt(0) === 0xFEFF ? 1 : 0;
+}
+
+function isNumber(code) {
+    return code >= 48 && code <= 57;
+}
+
+function computeLines(scanner, source) {
+    let sourceLength = source.length;
+    let start = firstCharOffset(source);
+    let line = scanner.initLine;
+
+    if (lines === null || lines.length < sourceLength + 1) {
+        lines = new SafeUint32Array(
+            Math.max(sourceLength + 1024, MIN_BUFFER_SIZE)
+        );
+    }
+
+    let i;
+    for (i = start; i < sourceLength; i++) {
+        let code = source.charCodeAt(i);
+
+        lines[i] = line;
+
+        if (code === N || code === R || code === F) {
+            if (
+                code === R && i + 1 < sourceLength &&
+                source.charCodeAt(i + 1) === N
+            ) {
+                i++;
+                lines[i] = line;
+            }
+            line++;
+        }
+    }
+
+    lines[i] = line;
+
+    return lines;
+}
+
+function findLastNonSpaceLocation(scanner) {
+    let i;
+    for (i = scanner.source.length - 1; i >= 0; i--) {
+        let code = scanner.source.charCodeAt(i);
+
+        if (
+            code !== SPACE &&
+            code !== TAB &&
+            code !== R &&
+            code !== N &&
+            code !== F
+        ) {
+            break;
+        }
+    }
+
+    return scanner.getLocation(i + 1);
+}
+
+function isNewline(source, offset, code) {
+    if (code === N || code === F || code === R) {
+        if (
+            code === R && offset + 1 < source.length &&
+            source.charCodeAt(offset + 1) === N
+        ) {
+            return 2;
+        }
+
+        return 1;
+    }
+
+    return 0;
+}
+
+function findWhitespaceEnd(source, offset) {
+    for (; offset < source.length; offset++) {
+        let code = source.charCodeAt(offset);
+
+        if (
+            code !== SPACE && code !== TAB &&
+            code !== R && code !== N && code !== F
+        ) {
+            break;
+        }
+    }
+
+    return offset;
+}
+
+function findCommentEnd(source, offset) {
+    let commentEnd = source.indexOf('*/', offset);
+
+    if (commentEnd === -1) {
+        return source.length;
+    }
+
+    return commentEnd + 2;
+}
+
+function findStringEnd(source, offset, quote) {
+    for (; offset < source.length; offset++) {
+        let code = source.charCodeAt(offset);
+
+        // bad string
+        if (code === BACK_SLASH) {
+            offset++;
+        } else if (code === quote) {
+            offset++;
+            break;
+        }
+    }
+
+    return offset;
+}
+
+function findDecimalNumberEnd(source, offset) {
+    for (; offset < source.length; offset++) {
+        let code = source.charCodeAt(offset);
+
+        if (code < 48 || code > 57) {  // not a 0 .. 9
+            break;
+        }
+    }
+
+    return offset;
+}
+
+function findNumberEnd(source, offset, allowFraction) {
+    let code;
+
+    offset = findDecimalNumberEnd(source, offset);
+
+    // fraction: .\d+
+    if (
+        allowFraction && offset + 1 < source.length &&
+        source.charCodeAt(offset) === FULLSTOP
+    ) {
+        code = source.charCodeAt(offset + 1);
+
+        if (isNumber(code)) {
+            offset = findDecimalNumberEnd(source, offset + 1);
+        }
+    }
+
+    // exponent: e[+-]\d+
+    if (offset + 1 < source.length) {
+        // case insensitive check for `e`
+        if ((source.charCodeAt(offset) | 32) === E) {
+            code = source.charCodeAt(offset + 1);
+
+            if (code === PLUSSIGN || code === HYPHENMINUS) {
+                if (offset + 2 < source.length) {
+                    code = source.charCodeAt(offset + 2);
+                }
+            }
+
+            if (isNumber(code)) {
+                offset = findDecimalNumberEnd(source, offset + 2);
+            }
+        }
+    }
+
+    return offset;
+}
+
+// skip escaped unicode sequence that can ends with space
+// [0-9a-f]{1,6}(\r\n|[ \n\r\t\f])?
+function findEscaseEnd(source, offset) {
+    for (let i = 0; i < 7 && offset + i < source.length; i++) {
+        let code = source.charCodeAt(offset + i);
+
+        if (i !== 6 && isHex(code)) {
+            continue;
+        }
+
+        if (i > 0) {
+            offset += i - 1 + isNewline(source, offset + i, code);
+            if (code === SPACE || code === TAB) {
+                offset++;
+            }
+        }
+
+        break;
+    }
+
+    return offset;
+}
+
+function findIdentifierEnd(source, offset) {
+    for (; offset < source.length; offset++) {
+        let code = source.charCodeAt(offset);
+
+        if (code === BACK_SLASH) {
+            offset = findEscaseEnd(source, offset + 1);
+        } else if (
+            code < SYMBOL_CATEGORY_LENGTH &&
+            IS_PUNCTUATION[code] === PUNCTUATION
+        ) {
+            break;
+        }
+    }
+
+    return offset;
+}
+
+function tokenLayout(scanner, source, startPos) {
+    let sourceLength = source.length;
+    let tokenCount = 0;
+    let prevType = 0;
+    let offset = startPos;
+
+    if (offsetAndType.length < sourceLength + 1) {
+        offsetAndType = new SafeUint32Array(sourceLength + 1024);
+    }
+
+    while (offset < sourceLength) {
+        let code = source.charCodeAt(offset);
+        let lessThanSC = code < SYMBOL_CATEGORY_LENGTH;
+        let type = lessThanSC ? SYMBOL_CATEGORY[code] : IDENTIFIER;
+
+        switch (type) {
+        case WHITESPACE:
+            offset = findWhitespaceEnd(source, offset + 1);
+            break;
+
+        case PUNCTUATION:
+            if (code === STAR && prevType === SLASH) { // /*
+                type = COMMENT;
+                offset = findCommentEnd(source, offset + 1);
+                tokenCount--; // rewrite prev token
+            } else {
+                    // edge case for -.123 and +.123
+                if (
+                    code === FULLSTOP &&
+                    (prevType === PLUSSIGN || prevType === HYPHENMINUS)
+                ) {
+                    if (
+                        offset + 1 < sourceLength &&
+                        isNumber(source.charCodeAt(offset + 1))
+                    ) {
+                        type = NUMBER;
+                        offset = findNumberEnd(source, offset + 2, false);
+                        tokenCount--;
+                        break;
+                    }
+                }
+
+                type = code;
+                offset += 1;
+            }
+
+            break;
+
+        case NUMBER:
+            offset = findNumberEnd(source, offset + 1, prevType !== FULLSTOP);
+            if (prevType === FULLSTOP ||
+                    prevType === HYPHENMINUS ||
+                    prevType === PLUSSIGN) {
+                tokenCount--; // rewrite prev token
+            }
+            break;
+
+        case STRING:
+            offset = findStringEnd(source, offset + 1, code);
+            break;
+
+        default:
+            offset = findIdentifierEnd(source, offset);
+        }
+
+        offsetAndType[tokenCount++] = type << TYPE_OFFSET | offset;
+        prevType = type;
+    }
+
+    offsetAndType[tokenCount] = offset;
+
+    scanner.offsetAndType = offsetAndType;
+    scanner.tokenCount = tokenCount;
+}
+
+export class Scanner {
+    constructor(source, options = {}) {
+        let start = firstCharOffset(source);
+
+        this.ignore = options.ignoreErrors;
+
+        this.source = source;
+        this.initLine = options.initLine ? 1 : options.initLine;
+        this.initColumn = (options.initColumn ? 1 : options.initColumn) - start;
+        this.lastLocationLine = this.initLine;
+        this.lastLocationLineOffset = 1 - this.initColumn;
+        this.lines = null;
+
+        this.eof = false;
+        this.currentToken = -1;
+        this.tokenType = 0;
+        this.tokenStart = start;
+        this.tokenEnd = start;
+
+        tokenLayout(this, source, start);
+    }
+
+    lookupType(offset) {
+        offset += this.currentToken;
+
+        if (offset < this.tokenCount) {
+            return this.offsetAndType[offset] >> TYPE_OFFSET;
+        }
+
+        return NULL;
+    }
+
+
+    lookupValue(offset, referenceStr) {
+        offset += this.currentToken;
+
+        if (offset < this.tokenCount) {
+            return cmpStr(
+                this.source,
+                this.offsetAndType[offset - 1] & OFFSET_MASK,
+                this.offsetAndType[offset] & OFFSET_MASK,
+                referenceStr
+            );
+        }
+
+        return false;
+    }
+
+    getTokenValue() {
+        return this.source.substring(this.tokenStart, this.tokenEnd);
+    }
+
+    substrToCursor(start) {
+        return this.source.substring(start, this.tokenStart);
+    }
+
+    skip(tokenCount) {
+        let next = this.currentToken + tokenCount;
+
+        if (next < this.tokenCount) {
+            this.currentToken = next;
+            this.tokenStart = this.offsetAndType[next - 1] & OFFSET_MASK;
+            next = this.offsetAndType[next];
+            this.tokenType = next >> TYPE_OFFSET;
+            this.tokenEnd = next & OFFSET_MASK;
+        } else {
+            this.currentToken = this.tokenCount;
+            this.readNextToken();
+        }
+    }
+
+    getNext() {
+        let next = this.currentToken + 1;
+
+        if (next < this.tokenCount) {
+            this.currentToken = next;
+            this.tokenStart = this.tokenEnd;
+            next = this.offsetAndType[next];
+            this.tokenType = next >> TYPE_OFFSET;
+            this.tokenEnd = next & OFFSET_MASK;
+        } else {
+            this.currentToken = this.tokenCount;
+            this.eof = true;
+            this.tokenType = NULL;
+            this.tokenStart = this.tokenEnd = this.source.length;
+        }
+    }
+
+    eat(tokenType) {
+        if (this.tokenType !== tokenType) {
+            this.error(TokenName[tokenType] + ' is expected');
+        }
+
+        this.readNextToken();
+    }
+
+    expectIdentifier(name) {
+        if (
+            this.tokenType !== IDENTIFIER ||
+            cmpStr(this.source, this.tokenStart, this.tokenEnd, name) === false
+        ) {
+            this.error('Identifier `' + name + '` is expected');
+        }
+
+        this.readNextToken();
+    }
+
+    getLocation(offset, source) {
+        if (this.lines === null) {
+            this.lines = computeLines(this, this.source);
+        }
+
+        let line = this.lines[offset];
+        let column = offset;
+        let lineOffset;
+
+        if (line === this.initLine) {
+            column += this.initColumn;
+        } else {
+            // try get precomputed line offset
+            if (line === this.lastLocationLine) {
+                lineOffset = this.lastLocationLineOffset;
+            } else {
+                // try avoid to compute line offset
+                // since it's expensive for long lines
+                lineOffset = lastIndexOf.call(this.lines, line - 1, offset);
+                this.lastLocationLine = line;
+                this.lastLocationLineOffset = lineOffset;
+            }
+
+            column -= lineOffset;
+        }
+
+        return {
+            source,
+            offset,
+            line,
+            column
+        };
+    }
+
+    error(message, offset) {
+        let location;
+
+        if (offset && offset < this.source.length) {
+            location = this.getLocation(offset);
+        } else if (this.eof) {
+            location = findLastNonSpaceLocation(this);
+        } else {
+            location = this.getLocation(this.tokenStart);
+        }
+
+        throw new CssSyntaxError(
+            message || 'Unexpected input',
+            this.source,
+            location.offset,
+            location.line,
+            location.column
+        );
+    }
+
+    getTypes() {
+        // eslint-disable-next-line max-len
+        return Array.prototype.slice.call(this.offsetAndType, 0, this.tokenCount).map((item) => {
+            return TokenName[item >> TYPE_OFFSET];
+        });
+    }
+}
+
+// warm up scanner to elimitate code branches that never execute
+// fix soft deoptimizations (insufficient type feedback)
+
+// eslint-disable-next-line no-new, max-len
+new Scanner('\n\r\r\n\f//""\'\'/*\r\n\f*/1a;.\\31\t\+2{url(a);+1.2e3 -.4e-5 .6e+7}');

--- a/lib/token.es6
+++ b/lib/token.es6
@@ -1,0 +1,161 @@
+/**
+ * Port of csstree const
+ * Defines basic structures for tokenizer
+ */
+const WHITESPACE = 1;
+const IDENTIFIER = 2;
+const NUMBER = 3;
+const STRING = 4;
+const COMMENT = 5;
+const PUNCTUATION = 6;
+
+const TAB = 9;
+const N = 10;
+const F = 12;
+const R = 13;
+const SPACE = 32;
+
+/* List of all available token types */
+const TokenType = {
+    Whitespace:   WHITESPACE,
+    Identifier:   IDENTIFIER,
+    Number:           NUMBER,
+    String:           STRING,
+    Comment:         COMMENT,
+    Punctuation: PUNCTUATION,
+
+    ExclamationMark:    33,  // !
+    QuotationMark:      34,  // "
+    NumberSign:         35,  // #
+    DollarSign:         36,  // $
+    PercentSign:        37,  // %
+    Ampersand:          38,  // &
+    Apostrophe:         39,  // '
+    LeftParenthesis:    40,  // (
+    RightParenthesis:   41,  // )
+    Asterisk:           42,  // *
+    PlusSign:           43,  // +
+    Comma:              44,  // ,
+    HyphenMinus:        45,  // -
+    FullStop:           46,  // .
+    Solidus:            47,  // /
+    Colon:              58,  // :
+    Semicolon:          59,  // ;
+    LessThanSign:       60,  // <
+    EqualsSign:         61,  // =
+    GreaterThanSign:    62,  // >
+    QuestionMark:       63,  // ?
+    CommercialAt:       64,  // @
+    LeftSquareBracket:  91,  // [
+    RightSquareBracket: 93,  // ]
+    CircumflexAccent:   94,  // ^
+    LowLine:            95,  // _
+    LeftCurlyBracket:  123,  // {
+    VerticalLine:      124,  // |
+    RightCurlyBracket: 125,  // }
+    Tilde:             126   // ~
+};
+
+/* Map token names to token keys */
+const TokenName = Object.keys(TokenType).reduce((result, key) => {
+    result[TokenType[key]] = key;
+    return result;
+}, {});
+
+/* Punc tokens */
+const punctuation = [
+    TokenType.ExclamationMark,    // '!'
+    TokenType.QuotationMark,      // '"'
+    TokenType.NumberSign,         // '#'
+    TokenType.DollarSign,         // '$'
+    TokenType.PercentSign,        // '%'
+    TokenType.Ampersand,          // '&'
+    TokenType.Apostrophe,         // '\''
+    TokenType.LeftParenthesis,    // '('
+    TokenType.RightParenthesis,   // ')'
+    TokenType.Asterisk,           // '*'
+    TokenType.PlusSign,           // '+'
+    TokenType.Comma,              // ','
+    TokenType.HyphenMinus,        // '-'
+    TokenType.FullStop,           // '.'
+    TokenType.Solidus,            // '/'
+    TokenType.Colon,              // ':'
+    TokenType.Semicolon,          // ';'
+    TokenType.LessThanSign,       // '<'
+    TokenType.EqualsSign,         // '='
+    TokenType.GreaterThanSign,    // '>'
+    TokenType.QuestionMark,       // '?'
+    TokenType.CommercialAt,       // '@'
+    TokenType.LeftSquareBracket,  // '['
+    TokenType.RightSquareBracket, // ']'
+    TokenType.CircumflexAccent,   // '^'
+    TokenType.LeftCurlyBracket,   // '{'
+    TokenType.VerticalLine,       // '|'
+    TokenType.RightCurlyBracket,  // '}'
+    TokenType.Tilde               // '~'
+];
+
+const SYMBOL_CATEGORY_LENGTH = Math.max.apply(null, punctuation) + 1;
+const SYMBOL_CATEGORY = new Uint32Array(SYMBOL_CATEGORY_LENGTH);
+const IS_PUNCTUATION = new Uint32Array(SYMBOL_CATEGORY_LENGTH);
+
+for (let i = 0; i < SYMBOL_CATEGORY.length; i++) {
+    SYMBOL_CATEGORY[i] = IDENTIFIER;
+}
+
+// fill categories
+punctuation.forEach((key) => {
+    SYMBOL_CATEGORY[Number(key)] = PUNCTUATION;
+    IS_PUNCTUATION[Number(key)] = PUNCTUATION;
+}, SYMBOL_CATEGORY);
+
+IS_PUNCTUATION[TokenType.HyphenMinus] = 0;
+// whitespace is punctuator
+IS_PUNCTUATION[SPACE] = PUNCTUATION;
+IS_PUNCTUATION[TAB] = PUNCTUATION;
+IS_PUNCTUATION[N] = PUNCTUATION;
+IS_PUNCTUATION[R] = PUNCTUATION;
+IS_PUNCTUATION[F] = PUNCTUATION;
+
+for (let i = 48; i <= 57; i++) {
+    SYMBOL_CATEGORY[i] = NUMBER;
+}
+
+SYMBOL_CATEGORY[SPACE] = WHITESPACE;
+SYMBOL_CATEGORY[TAB] = WHITESPACE;
+SYMBOL_CATEGORY[N] = WHITESPACE;
+SYMBOL_CATEGORY[R] = WHITESPACE;
+SYMBOL_CATEGORY[F] = WHITESPACE;
+
+SYMBOL_CATEGORY[TokenType.Apostrophe] = STRING;
+SYMBOL_CATEGORY[TokenType.QuotationMark] = STRING;
+
+/* Base class for single token */
+class Token {
+    constructor(type, isPunctuator, value, startLoc, endLoc) {
+        this.type = type;
+        this.value = value;
+        this.isPunctuator = isPunctuator;
+        this.startLoc = startLoc;
+        this.endLoc = endLoc;
+    }
+
+    /* Check if token is punctuation token */
+    isPunctuator() {
+        return this.isPunctuator;
+    }
+
+    /* Get position of the current token */
+    getPosition() {
+        return this.position;
+    }
+}
+
+export {
+    TokenType,
+    TokenName,
+    Token,
+    SYMBOL_CATEGORY,
+    IS_PUNCTUATION
+};
+

--- a/lib/tokenize.es6
+++ b/lib/tokenize.es6
@@ -22,7 +22,7 @@ const RE_AT_END      = /[ \n\t\r\f\{\(\)'"\\;/\[\]#]/g;
 const RE_WORD_END    = /[ \n\t\r\f\(\)\{\}:;@!'"\\\]\[#]|\/(?=\*)/g;
 const RE_BAD_BRACKET = /.[\\\/\("'\n]/;
 
-export default function tokenize(input, options = { }) {
+export function tokenize(input, options = { }) {
     let tokens = [];
     let css    = input.css.valueOf();
 

--- a/lib/tokenizer-errors.es6
+++ b/lib/tokenizer-errors.es6
@@ -1,0 +1,65 @@
+/* Port of csstree error for tokenizer */
+const MAX_LINE_LENGTH = 100;
+const OFFSET_CORRECTION = 60;
+
+/* Get detailed source fragment */
+function getSourceFragment(error, extraLines) {
+    let lines = error.source.split(/\n|\r\n?|\f/),
+        column = error.column,
+        line = error.line,
+        startLine = Math.max(1, line - extraLines) - 1,
+        endLine = Math.min(line + extraLines, lines.length + 1),
+        maxNumLength = Math.max(4, String(endLine).length) + 1,
+        cutLeft = 0;
+
+    function processLines(start, end) {
+        return lines.slice(start, end).map((currLine, idx) => {
+            let num = String(start + idx + 1);
+
+            while (num.length < maxNumLength) {
+                num = ' ' + num;
+            }
+
+            return num + ' |' + currLine;
+        }).join('\n');
+    }
+
+    if (column > MAX_LINE_LENGTH) {
+        cutLeft = column - OFFSET_CORRECTION + 3;
+        column = OFFSET_CORRECTION - 2;
+    }
+
+    for (let i = startLine; i <= endLine; i++) {
+        if (i >= 0 && i < lines.length) {
+            let len = line[i].length;
+            lines[i] =
+                (cutLeft > 0 && len > cutLeft ? '\u2026' : '') +
+                lines[i].substr(cutLeft, MAX_LINE_LENGTH - 2) +
+                (len > cutLeft + MAX_LINE_LENGTH - 1 ? '\u2026' : '');
+        }
+    }
+
+    return [
+        processLines(startLine, line),
+        new Array(column + maxNumLength + 2).join('-') + '^',
+        processLines(line, endLine)
+    ].join('\n');
+}
+
+/* Error class for invalid css syntax */
+export class CssSyntaxError extends SyntaxError {
+    constructor(message, source, offset, line, column) {
+        super(message);
+        this.name = 'CssSyntaxError';
+        this.source = source;
+        this.offset = offset;
+        this.line = line;
+        this.column = column;
+    }
+
+    /* Getter for formatted parsing error */
+    getFormattedError() {
+        const sourcePart = getSourceFragment(this, 2);
+        return `Parse error: ${this.message}\n${sourcePart}`;
+    }
+}

--- a/lib/tokenizer-utils.es6
+++ b/lib/tokenizer-utils.es6
@@ -1,0 +1,59 @@
+/* eslint no-bitwise: 0 */
+
+/* Port of csstree utils */
+
+/* Check if value is a hex value */
+export function isHex(code) {
+    return code >= 48 && code <= 57 || // 0 .. 9
+           code >= 65 && code <= 70 || // A .. F
+           code >= 97 && code <= 102;  // a .. f
+}
+
+/* Compare two char values */
+export function cmpChar(testStr, offset, referenceCode) {
+    let code = testStr.charCodeAt(offset);
+
+    // code.toLowerCase()
+    if (code >= 65 && code <= 90) {
+        code |= 32;
+    }
+
+    return code === referenceCode;
+}
+
+/* Deeply compare two strings */
+export function cmpStr(testStr, start, end, referenceStr) {
+    if (end - start !== referenceStr.length) {
+        return false;
+    }
+
+    if (start < 0 || end > testStr.length) {
+        return false;
+    }
+
+    for (let i = start; i < end; i++) {
+        let testCode = testStr.charCodeAt(i);
+        const refCode = referenceStr.charCodeAt(i - start);
+
+        // testStr[i].toLowerCase()
+        if (testCode >= 65 && testCode <= 90) {
+            testCode |= 32;
+        }
+
+        if (testCode !== refCode) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/* Check if string ends with specific substring */
+export function endsWith(testStr, referenceStr) {
+    return cmpStr(
+        testStr,
+        testStr.length - referenceStr.length,
+        testStr.length,
+        referenceStr
+    );
+}


### PR DESCRIPTION
It is work in progress patch with attemp to merge `csstree` tokenizer in `postcss` .

**Description**:
 
Mostly because `csstree` tokenizer much more detailed and works with lower structures, most of "heavy lifting" done in parser part. 

Because of that, if we fully integrate `csstree` we need rewrite most of parser parts to support new tokens system that works with current "array-based" structure.

The point is to minimalise efforts for updating parser. We can use `csstree` scanner that will operate character structures and then plug it to updated `tokenizer` where it produces on each `readNextToken` call token compatible with current token structure and parser.

Obviously need feedback of @lahmatiy as I may miss something.

If this structure works fine for you @ai, I will continue work.  If not, I don't see reasons to integrate `csstree` tokenizer as it can be effortless to just upgrade current `tokenizer`.

**Roadmap**:
- [x] Port initial structures from `csstree`
- [x] Fix linting issues
- [ ] Integrate `csstree` output with current token types (in progress)
- [ ] Update parser for support streaming (in progress)
- [ ] Fix tests related to new architecture
- [ ] More?
