### PR TITLE
Fix TypeScript module export

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -1303,5 +1303,5 @@ declare module "postcss" {
         interface JsonComment extends JsonNode {
         }
     }
-    export = postcss;
+    export default postcss;
 }


### PR DESCRIPTION
Sorry, @ai. I must not have copied over this one line properly, so I'm getting an error that postcss is not a function. Sorry about that.