### PR TITLE
Fix typo in generated() deprecation message

### DIFF
--- a/lib/css-syntax-error.es6
+++ b/lib/css-syntax-error.es6
@@ -218,7 +218,7 @@ class CssSyntaxError {
     }
 
     get generated() {
-        warnOnce('CssSyntaxError#generated is depreacted. Use input instead.');
+        warnOnce('CssSyntaxError#generated is deprecated. Use input instead.');
         return this.input;
     }
 


### PR DESCRIPTION
In the deprecation message associated with the `generated()` function, the word deprecation was spelled `depreacted`. This is incredibly minor, but it's something I've run into a fair amount of times recently when searching for `react` inside my library's bundle.