### PR TITLE
Remove js-base64 from dependencies

### DIFF
--- a/lib/map-generator.es6
+++ b/lib/map-generator.es6
@@ -1,4 +1,3 @@
-import { Base64 } from 'js-base64';
 import   mozilla  from 'source-map';
 import   path     from 'path';
 
@@ -126,7 +125,7 @@ export default class MapGenerator {
 
         if ( this.isInline() ) {
             content = 'data:application/json;base64,' +
-                       Base64.encode( this.map.toString() );
+                       new Buffer( this.map.toString() ).toString('base64');
 
         } else if ( typeof this.mapOpts.annotation === 'string' ) {
             content = this.mapOpts.annotation;

--- a/lib/previous-map.es6
+++ b/lib/previous-map.es6
@@ -1,4 +1,3 @@
-import { Base64 } from 'js-base64';
 import   mozilla  from 'source-map';
 import   path     from 'path';
 import   fs       from 'fs';
@@ -69,22 +68,18 @@ class PreviousMap {
     }
 
     decodeInline(text) {
-        let utfd64 = 'data:application/json;charset=utf-8;base64,';
-        let utf64  = 'data:application/json;charset=utf8;base64,';
-        let b64    = 'data:application/json;base64,';
-        let uri    = 'data:application/json,';
+        // data:application/json;charset=utf-8;base64,
+        // data:application/json;charset=utf8;base64,
+        // data:application/json;base64,
+        let baseUri = /^data:application\/json;(?:charset=utf-?8;)?base64,/;
+        let uri     = 'data:application/json,';
 
         if ( this.startWith(text, uri) ) {
             return decodeURIComponent( text.substr(uri.length) );
 
-        } else if ( this.startWith(text, b64) ) {
-            return Base64.decode( text.substr(b64.length) );
-
-        } else if ( this.startWith(text, utf64) ) {
-            return Base64.decode( text.substr(utf64.length) );
-
-        } else if ( this.startWith(text, utfd64) ) {
-            return Base64.decode( text.substr(utfd64.length) );
+        } else if ( baseUri.test(text) ) {
+            return new Buffer(text.substr(RegExp.lastMatch.length), 'base64')
+                .toString();
 
         } else {
             let encoding = text.match(/data:application\/json;([^,]+),/)[1];

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "repository": "postcss/postcss",
   "dependencies": {
     "chalk": "^1.1.3",
-    "js-base64": "^2.1.9",
     "source-map": "^0.5.6",
     "supports-color": "^3.2.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,10 +2512,6 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-js-base64@^2.1.9:
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
-
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"


### PR DESCRIPTION
PostCSS is currently using `js-base64` for encode/decode base64 content of source maps. But there is a "standart" way in node.js world to do it using Buffer API.
Yep, Buffer doesn't supported by browsers. But it will be included if build by bundlers. I tested with browserify, everything ok. Moreover `js-base64` also uses Buffer when possible, so `buffer` module includes in bundle by browserify anyway.
I believe changes doesn't break much, but minus one redundant dependency.