### PR TITLE
add postcss setup instructions for webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,39 @@ module.exports = {
 }
 ```
 
+### Webpack 2
+
+Use [`postcss-loader`] in `webpack.config.js` and add post-css into webpack's `LoaderOptionsPlugin`, like so:
+
+```js
+module.exports = {
+    module: {
+        rules: [
+            {
+                test: /\.css$/,
+                use: [
+                    'style-loader',
+                    'css-loader?importLoaders=1',
+                    'postcss-loader'
+                ],
+            },
+        ],
+    },
+    plugins: [
+        new webpack.LoaderOptionsPlugin({
+            options: {
+                postcss: [
+                    require('postcss-import'),
+                    require('postcss-mixins'),
+                    require('postcss-nested'),
+                    require('postcss-cssnext'),
+                ],
+            },
+        }),
+    ],
+}
+```
+
 [`postcss-loader`]: https://github.com/postcss/postcss-loader
 
 ### Gulp


### PR DESCRIPTION
I was able to get post-css working with Webpack 2 using this simple configuration (however, wasn't able to get post-css and webpack 2 working with the original instructions for webpack). 
Please feel free to confirm. Thanks! 