### PR TITLE
Running postcss in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
   },
   "pre-commit": [
     "lint-staged"
-  ]
+  ],
+  "browser": {
+    "fs": false
+  }
 }


### PR DESCRIPTION
To run postcss in the browser, the module _fs_ is required. With this addition we can tell webpack to ignore the _fs_ module.

This has been an issue before #830

https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module