### PR TITLE
Add config for Webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,14 +181,7 @@ Use [`postcss-loader`] in `webpack.config.js`:
 Use this if you are bundling your CSS into your JS (the default Webpack behaviour)
 
 ```js
-const path = require('path');
-
 module.exports = {
-    entry: './app/index',
-    output: {
-        filename: 'bundle.js',
-        path: path.resolve(__dirname, 'dist')
-    },
     module: {
         loaders: [
             {
@@ -218,17 +211,11 @@ module.exports = {
 }
 ```
 
-Use this with if you are extracting your CSS from your Webpack bundle
+Use this with if you are extracting your CSS from your Webpack bundle using the [extract-text-webpack-plugin](https://github.com/webpack-contrib/extract-text-webpack-plugin).
 ```js
-const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
-    entry: './app/index',
-    output: {
-        filename: 'bundle.js',
-        path: path.resolve(__dirname, 'dist')
-    },
     module: {
         loaders: [
             test: /\.css$/,

--- a/README.md
+++ b/README.md
@@ -178,20 +178,83 @@ You can start using PostCSS in just two steps:
 
 Use [`postcss-loader`] in `webpack.config.js`:
 
+Use this if you are bundling your CSS into your JS (the default Webpack behaviour)
+
 ```js
+const path = require('path');
+
 module.exports = {
+    entry: './app/index',
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist')
+    },
     module: {
         loaders: [
             {
                 test: /\.css$/,
-                loaders: [
-                    'style-loader',
-                    'css-loader?importLoaders=1',
-                    'postcss-loader'
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'style-loader',
+                    },
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            sourceMap: true,
+                            importLoaders: 1,
+                        }
+                    },
+                    {
+                        loader: 'postcss-loader',
+                        options: {
+                            sourceMap: 'inline',
+                        }
+                    }
                 ]
             }
         ]
     }
+}
+```
+
+Use this with if you are extracting your CSS from your Webpack bundle
+```js
+const path = require('path');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+module.exports = {
+    entry: './app/index',
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist')
+    },
+    module: {
+        loaders: [
+            test: /\.css$/,
+            loader: ExtractTextPlugin.extract({
+                fallback: 'style-loader',
+                loader: [
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            sourceMap: true,
+                            importLoaders: 1,
+                        }
+                    },
+                    {
+                        loader: 'postcss-loader',
+                        options: {
+                            sourceMap: 'inline',
+                        }
+                    },
+                ]
+            })
+        ]
+    },
+    plugins: [
+        new ExtractTextPlugin('bundle.css'),
+    ],
 }
 ```
 


### PR DESCRIPTION
This PR is intended to fix the hacks in #970. I have included multiple ways to compile PostCSS with Webpack: inline (default webpack behaviour) or separate CSS (using the extract-text-plugin).