### PR TITLE
postcss-nested-import

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -287,6 +287,7 @@ loosely resembles the original.
 * [`postcss-combine-duplicated-selectors`] automatically join identical css selectors.
 * [`postcss-filter-mq`] Filter all matching or non-matching media queries.
 * [`postcss-import`] inlines the stylesheets referred to by `@import` rules.
+* [`postcss-nested-import`] inlines stylesheets referred to by `@import` rules inside nested rule blocks.
 * [`postcss-partial-import`] inlines standard imports and Sass-like partials.
 * [`postcss-reference`] emulates Less’s [`@import (reference)`].
 * [`postcss-remove-root`] removes all instances of `:root` from a stylesheet.
@@ -661,6 +662,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-filter`]:                       https://github.com/alanev/postcss-filter
 [`postcss-hidden`]:                       https://github.com/lukelarsen/postcss-hidden
 [`postcss-import`]:                       https://github.com/postcss/postcss-import
+[`postcss-nested-import`]:                https://github.com/eriklharper/postcss-nested-import
 [`postcss-layout`]:                       https://github.com/arccoza/postcss-layout
 [`postcss-mixins`]:                       https://github.com/postcss/postcss-mixins
 [`postcss-nested`]:                       https://github.com/postcss/postcss-nested


### PR DESCRIPTION
Hello!  I [created a new postcss plugin that allows for `@import` statements to work within nested css statements](https://github.com/eriklharper/postcss-nested-import).  I'd like to get this reviewed by the PostCSS community and also would like your help in determining why my tests are failing, which I think is due to how postcss processes the results, and not from a bug in my plugin code.  I used the PostCSS plugin boilerplate, so you can clone my project, run `yarn` and then `jest` to see the result of the test which looks like this:

```
FAIL  ./index.test.js
  ● replaces @import with the contents of the file being imported inside a declaration block.

    expect(received).toEqual(expected)

    Expected value to equal:
      ".vendor { background: silver; } .vendor-font { font-size: 14px; }"
    Received:
      ".vendor {
        background: silver
    }
    .vendor-font {
        font-size: 14px
    }"
```

It appears that when postcss runs and outputs a result, it adds line breaks to the code and also removes the semicolons from the end of the statements for some reason.  Not sure why this is happening, but advisement would be much appreciated.

Thanks!
Erik Harper