### PR TITLE
Add Plugin postcss-start-to-end

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -94,6 +94,7 @@ Or enable plugins directly in CSS using [`postcss-use`]:
 * [`postcss-selector-not`] transforms CSS4 `:not()` to CSS3 `:not()`.
 * [`postcss-selector-matches`] transforms CSS4 `:matches()`
   to more compatible CSS.
+* [`postcss-start-to-end`] lets you control your layout (ltr or rtl) through logical rather than direction / physical rules.
 * [`mq4-hover-shim`] supports the `@media (hover)` feature.
 
 See also [`cssnext`] plugins pack to add future CSS syntax by one line of code.
@@ -730,3 +731,4 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-parent-selector`]:              https://github.com/domwashburn/postcss-parent-selector
 [`postcss-font-family-system-ui`]:        https://github.com/JLHwung/postcss-font-family-system-ui
 [`postcss-percentage`]:                   https://github.com/creeperyang/postcss-percentage
+[`postcss-start-to-end`]:                 https://github.com/sandrina-p/postcss-start-to-end


### PR DESCRIPTION
This is my first _from scratch_ plugin that I built today all day long!

> [PostCSS](https://github.com/postcss/postcss) plugin that let you control your layout (`ltr` or `rtl`) through logical rather than direction / physical rules.

- [Postcss-plugin-boilerplated](https://github.com/postcss/postcss-plugin-boilerplate) was used
- [Postcss-plugin-guidelines](https://github.com/postcss/postcss/blob/master/docs/guidelines/plugin.md) were followed
- Yarn was used as dependency manager
- Travis is being used as CI service
- The plugin itself has 100% coverage with Jest.
- It is published on [npm](https://www.npmjs.com/package/postcss-start-to-end)
- I'm trying to add [Coveralls](https://coveralls.io/github/sandrina-p/postcss-start-to-end) as coverage reporter, but I'am having troubles.

Thank you, I learned a lot today! 🎉  🤓 

Note: Within the plugin there is a bonus script, _convert_, that is not tested at all, but it will be soon! I first need to learn more about NodeJS. 
