### PR TITLE
Improve postcss.d.ts so that type guards work

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -612,7 +612,8 @@ declare module "postcss" {
              */
             origin(line: number, column: number): InputOrigin;
         }
-        type Node = Container | Declaration | Comment;
+        type ChildNode = AtRule | Rule | Declaration | Comment;
+        type Node = Root | ChildNode;
         interface NodeBase {
             /**
              * Returns the input source of the node. The property is used in source
@@ -659,12 +660,12 @@ declare module "postcss" {
              * @returns The next child of the node's parent; or, returns undefined if
              * the current node is the last child.
              */
-            next(): Node;
+            next(): ChildNode | void;
             /**
              * @returns The previous child of the node's parent; or, returns undefined
              * if the current node is the first child.
              */
-            prev(): Node;
+            prev(): ChildNode | void;
             /**
              * @returns The Root instance of the node's tree.
              */
@@ -819,15 +820,15 @@ declare module "postcss" {
             /**
              * Contains the container's children.
              */
-            nodes?: Node[];
+            nodes?: ChildNode[];
             /**
              * @returns The container's first child.
              */
-            first?: Node;
+            first?: ChildNode;
             /**
              * @returns The container's last child.
              */
-            last?: Node;
+            last?: ChildNode;
             /**
              * @param overrides New properties to override in the clone.
              * @returns A clone of this node. The node and its (cloned) children will
@@ -838,7 +839,7 @@ declare module "postcss" {
              * @param child Child of the current container.
              * @returns The child's index within the container's "nodes" array.
              */
-            index(child: Node | number): number;
+            index(child: ChildNode | number): number;
             /**
              * Determines whether all child nodes satisfy the specified test.
              * @param callback A function that accepts up to three arguments. The
@@ -847,7 +848,7 @@ declare module "postcss" {
              * @returns True if the callback returns true for all of the container's
              * children.
              */
-            every(callback: (node: Node, index: number, nodes: Node[]) => any, thisArg?: any): boolean;
+            every(callback: (node: ChildNode, index: number, nodes: ChildNode[]) => any, thisArg?: any): boolean;
             /**
              * Determines whether the specified callback returns true for any child node.
              * @param callback A function that accepts up to three arguments. The some
@@ -859,7 +860,7 @@ declare module "postcss" {
              * @returns True if callback returns true for (at least) one of the
              * container's children.
              */
-            some(callback: (node: Node, index: number, nodes: Node[]) => boolean, thisArg?: any): boolean;
+            some(callback: (node: ChildNode, index: number, nodes: ChildNode[]) => boolean, thisArg?: any): boolean;
             /**
              * Iterates through the container's immediate children, calling the
              * callback function for each child. If you need to recursively iterate
@@ -871,7 +872,7 @@ declare module "postcss" {
              * will adjust the current index to match the mutations.
              * @returns False if the callback returns false during iteration.
              */
-            each(callback: (node: Node, index: number) => any): boolean | void;
+            each(callback: (node: ChildNode, index: number) => any): boolean | void;
             /**
              * Traverses the container's descendant nodes, calling `callback` for each
              * node. Like container.each(), this method is safe to use if you are
@@ -879,7 +880,7 @@ declare module "postcss" {
              * the container's immediate children, use container.each().
              * @param callback Iterator.
              */
-            walk(callback: (node: Node, index: number) => any): boolean | void;
+            walk(callback: (node: ChildNode, index: number) => any): boolean | void;
             /**
              * Traverses the container's descendant nodes, calling `callback` for each
              * declaration. Like container.each(), this method is safe to use if you
@@ -990,13 +991,13 @@ declare module "postcss" {
              * @param oldNode Child or child's index.
              * @returns This container for chaining.
              */
-            insertBefore(oldNode: Node | number, newNode: Node | Object | string): this;
+            insertBefore(oldNode: ChildNode | number, newNode: ChildNode | Object | string): this;
             /**
              * Insert newNode after oldNode within the container.
              * @param oldNode Child or child's index.
              * @returns This container for chaining.
              */
-            insertAfter(oldNode: Node | number, newNode: Node | Object | string): this;
+            insertAfter(oldNode: ChildNode | number, newNode: ChildNode | Object | string): this;
             /**
              * Removes the container from its parent and cleans the parent property in the
              * container and its children.
@@ -1009,7 +1010,7 @@ declare module "postcss" {
              * @param child Child or child's index.
              * @returns This container for chaining.
              */
-            removeChild(child: Node | number): this;
+            removeChild(child: ChildNode | number): this;
             /**
              * Removes all children from the container and cleans their parent
              * properties.
@@ -1021,7 +1022,7 @@ declare module "postcss" {
             /**
              * Contains the container's children.
              */
-            nodes?: Node[];
+            nodes?: ChildNode[];
             raws?: ContainerRaws;
         }
         interface ContainerRaws extends NodeRaws {
@@ -1031,15 +1032,15 @@ declare module "postcss" {
             /**
              * Contains the container's children.
              */
-            nodes?: Node[];
+            nodes?: ChildNode[];
             /**
              * @returns The container's first child.
              */
-            first?: Node;
+            first?: ChildNode;
             /**
              * @returns The container's last child.
              */
-            last?: Node;
+            last?: ChildNode;
         }
         /**
          * Represents a CSS file and contains all its parsed nodes.
@@ -1073,7 +1074,7 @@ declare module "postcss" {
              * @param child Child or child's index.
              * @returns This root node for chaining.
              */
-            removeChild(child: Node | number): this;
+            removeChild(child: ChildNode | number): this;
         }
         interface RootNewProps extends ContainerNewProps {
         }

--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -612,16 +612,8 @@ declare module "postcss" {
              */
             origin(line: number, column: number): InputOrigin;
         }
-        interface Node {
-            /**
-             * Returns a string representing the node's type. Possible values are
-             * root, atrule, rule, decl or comment.
-             */
-            type: string;
-            /**
-             * Returns the node's parent node.
-             */
-            parent: Container;
+        type Node = Container | Declaration | Comment;
+        interface NodeBase {
             /**
              * Returns the input source of the node. The property is used in source
              * map generation. If you create a node manually
@@ -818,15 +810,12 @@ declare module "postcss" {
              */
             raws?: NodeRaws;
         }
+        type Container = Root | AtRule | Rule;
         /**
          * Containers can store any content. If you write a rule inside a rule,
          * PostCSS will parse it.
          */
-        interface Container extends Node {
-            /**
-             * Returns the container's parent node.
-             */
-            parent: Container;
+        interface ContainerBase extends NodeBase {
             /**
              * Contains the container's children.
              */
@@ -1055,11 +1044,12 @@ declare module "postcss" {
         /**
          * Represents a CSS file and contains all its parsed nodes.
          */
-        interface Root extends Container {
+        interface Root extends ContainerBase {
+            type: 'root';
             /**
              * Inherited from Container. Should always be undefined for a Root node.
              */
-            parent: Container;
+            parent: void;
             /**
              * @param overrides New properties to override in the clone.
              * @returns A clone of this node. The node and its (cloned) children will
@@ -1093,7 +1083,12 @@ declare module "postcss" {
          * Represents an at-rule. If it's followed in the CSS by a {} block, this
          * node will have a nodes property representing its children.
          */
-        interface AtRule extends Container {
+        interface AtRule extends ContainerBase {
+            type: 'atrule';
+            /**
+             * Returns the atrule's parent node.
+             */
+            parent: Container;
             /**
              * The identifier that immediately follows the @.
              */
@@ -1139,7 +1134,8 @@ declare module "postcss" {
         /**
          * Represents a CSS rule: a selector followed by a declaration block.
          */
-        interface Rule extends Container {
+        interface Rule extends ContainerBase {
+            type: 'rule';
             /**
              * Returns the rule's parent node.
              */
@@ -1196,7 +1192,12 @@ declare module "postcss" {
         /**
          * Represents a CSS declaration.
          */
-        interface Declaration extends Node {
+        interface Declaration extends NodeBase {
+            type: 'decl';
+            /**
+             * Returns the declaration's parent node.
+             */
+            parent: Container;
             /**
              * The declaration's property name.
              */
@@ -1253,7 +1254,12 @@ declare module "postcss" {
          * Comments inside selectors, at-rule parameters, or declaration values will
          * be stored in the Node#raws properties.
          */
-        interface Comment extends Node {
+        interface Comment extends NodeBase {
+            type: 'comment';
+            /**
+             * Returns the comment's parent node.
+             */
+            parent: Container;
             /**
              * The comment's text.
              */


### PR DESCRIPTION
This PR enables type guards on the `type` property of `Node`.

```ts
function doSomethingWithNode(node: postcss.Node): string {
  switch (node.type) {
    case 'root':
      // node is inferred as Root here
      node.toResult();
      return 'root';
    case 'atrule':
      // node is inferred as AtRule here
      node.params = '';
      return 'atrule';
    case 'rule':
      // node is inferred as Rule here
      node.selector = '';
      return 'rule';
    case 'decl':
      // node is inferred as Declaration here
      node.important = false;
      return 'decl';
    case 'comment':
      // node is inferred as Comment here
      node.text = '';
      return 'comment';
    // default is not necessary as TypeScript knows the above cases are collectively exhaustive
  }
}
```

Additionally, the `parent` property of `Root` is altered from `Container` to `void`, as it "Should always be undefined for a Root node" according to its comment.