### PR TITLE
Add postcss-hash plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -379,6 +379,7 @@ See also plugins in modular minifier [`cssnano`].
 * [`postcss-flexboxfixer`] unprefixes `-webkit-` only flexbox in legacy CSS.
 * [`postcss-flexbugs-fixes`] fixes some of known [flexbox bugs].
 * [`postcss-gradientfixer`] unprefixes `-webkit-` only gradients in legacy CSS.
+* [`postcss-hash`] replaces output file names with any supporeted HASH algorithms for cache busting.
 * [`postcss-ie8`] strips out unsupported properties and media queries for IE8.
 * [`postcss-increase-specificity`] increases the specificity of your selectors.
 * [`postcss-inline-rtl`] converts your CSS to right-to-left,
@@ -744,3 +745,4 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-autocorrect`]:                  https://github.com/DimitrisNL/postcss-autocorrect
 [`postcss-state-selector`]:               https://github.com/binjospookie/postcss-state-selector
 [`postcss-html-filter`]:                  https://github.com/mapbox/postcss-html-filter
+[`postcss-hash`]:                         https://github.com/dacodekid/postcss-hash


### PR DESCRIPTION
PostCSS plugin to replace output file names with HASH algorithms (md5, sha256, sha512, etc) and string length of your choice - for cache busting.