### PR TITLE
Updated walk() to print out more information on exception

### DIFF
--- a/lib/container.es6
+++ b/lib/container.es6
@@ -106,11 +106,24 @@ class Container extends Node {
      */
     walk(callback) {
         return this.each( (child, i) => {
-            let result = callback(child, i);
-            if ( result !== false && child.walk ) {
-                result = child.walk(callback);
+            try {
+                let result = callback(child, i);
+                if ( result !== false && child.walk ) {
+                    result = child.walk(callback);
+                }
+                return result;
+            } catch (exception) {
+                // If an error occurs, attempt to print
+                // out information that will narrow down
+                // where the problem can be found.
+                throw new Error(
+                    `${exception.message}
+                    File: ${child.source.input.file}
+                    CSS Rule: ${child.selector} (lines: 
+                        ${child.source.start.line}
+                        -${child.source.end.line})`
+                );
             }
-            return result;
         });
     }
 


### PR DESCRIPTION
This is a modification to the walk() method found for the Container object. The difference from the original is that it now attempts to print out more information to help a developer locate where the problem occurred.