### PR TITLE
Provide Tokenizer, Comment and Parser as named exports

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -1329,7 +1329,7 @@ declare namespace postcss {
      * Comments inside selectors, at-rule parameters, or declaration values will
      * be stored in the Node#raws properties.
      */
-    interface Comment extends NodeBase {
+    class Comment extends Node {
         type: 'comment';
         /**
          * Returns the comment's parent node.

--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -60,36 +60,46 @@ declare namespace postcss {
         endOfFile(): boolean;
     }
 
+    type TokenKind = "[" | "]" | "(" | ")" | "{" | "}" | ";" | ":" | "space" | "brackets" | "string" | "at-word" | "word" | "comment";
+    type StringToken = ["string", string, number, number, number, number];
+    type WordToken = ["word", string, number, number, number, number];
+    type SpaceToken = ["space", string];
+    type AtWordToken = ["at-word", string, number, number, number, number];
+    type CommentToken = ["comment", string, number, number, number, number];
+    type BracketsToken = ["brackets", string, number, number, number, number];
+    type SyntaxToken = [ "[" | "]" | "{" | "}" | ":" | ";" | "(" | ")", string, number, number];
+    export type Token = StringToken|WordToken|SpaceToken|BracketsToken|AtWordToken|CommentToken|SyntaxToken;
+
     export function tokenizer(input: Input, opts?: Partial<TokenizerOptions>): TokenizerResult;
 
     export class Parser {
         constructor(input: Input);
         createTokenizer(): void;
         parser(): void;
-        comment(token: string): void;
-        emptyRule(token: string): void;
-        other(start: string): void;
-        rule(tokens: string[]): void;
-        decl(tokens: string[]): void;
-        atrule(token: string): void;
-        end(token: string): void;
+        comment(token: CommentToken): void;
+        emptyRule(token: Token): void;
+        other(start: Token): void;
+        rule(tokens: Token[]): void;
+        decl(tokens: Token[]): void;
+        atrule(token: Token): void;
+        end(token: Token): void;
         endFile(): void;
-        freeSemicolon(token: string): void;
-        init(node: Node, line: string, column: string): void;
-        raw(node: Node, prop: string, tokens: string[]): void;
-        spacesAndCommentsFromEnd(tokens: string[]): string;
-        spacesAndCommentsFromStart(tokens: string[]): string;
-        spacesFromEnd(tokens: string[]): string;
-        stringFrom(tokens: string[], from: number): string;
-        colon(tokens: string[]): number|false;
-        unclosedBracket(bracket: string[]): void;
-        unknownWord(tokens: string[]): void;
-        unexpectedClose(token: string[]): void;
+        freeSemicolon(token: Token): void;
+        init(node: Node, line: number, column: number): void;
+        raw(node: Node, prop: string, tokens: Token[]): void;
+        spacesAndCommentsFromEnd(tokens: Token[]): string;
+        spacesAndCommentsFromStart(tokens: Token[]): string;
+        spacesFromEnd(tokens: Token[]): string;
+        stringFrom(tokens: Token[], from: number): string;
+        colon(tokens: Token[]): number|false;
+        unclosedBracket(bracket: Token): void;
+        unknownWord(tokens: Token): void;
+        unexpectedClose(token: Token): void;
         unclosedBlock(): void;
-        doubleColon(token: string[]): void;
-        unnamedAtrule(node: Node, token: string[]): void;
-        precheckMissedSemicolon(tokens: string[]): string[];
-        checkMissedSemicolon(tokens: string[]): void;
+        doubleColon(token: Token): void;
+        unnamedAtrule(node: Node, token: Token): void;
+        precheckMissedSemicolon(tokens: Token[]): string[];
+        checkMissedSemicolon(tokens: Token[]): void;
     }
 
     export class Stringifier {

--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -49,6 +49,49 @@ declare namespace postcss {
          */
         function unprefixed(prop: string): string;
     }
+
+    interface TokenizerOptions {
+        ignoreErrors: boolean;
+    }
+
+    interface TokenizerResult {
+        back (token: string): void;
+        nextToken(): string;
+        endOfFile(): boolean;
+    }
+
+    export function tokenizer(input: Input, opts?: Partial<TokenizerOptions>): TokenizerResult;
+
+    export class Parser {
+        constructor(input: Input);
+        createTokenizer(): void;
+        parser(): void;
+        comment(token: string): void;
+        emptyRule(token: string): void;
+        other(start: string): void;
+        rule(tokens: string[]): void;
+        decl(tokens: string[]): void;
+        atrule(token: string): void;
+        end(token: string): void;
+        endFile(): void;
+        freeSemicolon(token: string): void;
+        init(node: Node, line: string, column: string): void;
+        raw(node: Node, prop: string, tokens: string[]): void;
+        spacesAndCommentsFromEnd(tokens: string[]): string;
+        spacesAndCommentsFromStart(tokens: string[]): string;
+        spacesFromEnd(tokens: string[]): string;
+        stringFrom(tokens: string[], from: number): string;
+        colon(tokens: string[]): number|false;
+        unclosedBracket(bracket: string[]): void;
+        unknownWord(tokens: string[]): void;
+        unexpectedClose(token: string[]): void;
+        unclosedBlock(): void;
+        doubleColon(token: string[]): void;
+        unnamedAtrule(node: Node, token: string[]): void;
+        precheckMissedSemicolon(tokens: string[]): string[];
+        checkMissedSemicolon(tokens: string[]): void;
+    }
+
     export class Stringifier {
         builder: Stringifier.Builder;
         constructor(builder?: Stringifier.Builder);
@@ -667,22 +710,22 @@ declare namespace postcss {
         prev(): ChildNode | void;
 		/**
 		 * Insert new node before current node to current node’s parent.
-		 * 
+		 *
 		 * Just an alias for `node.parent.insertBefore(node, newNode)`.
-		 * 
+		 *
 		 * @returns this node for method chaining.
-		 * 
+		 *
 		 * @example
 		 * decl.before('content: ""');
 		 */
 		before(newNode: Node | object | string | Node[]): this;
 		/**
 		 * Insert new node after current node to current node’s parent.
-		 * 
+		 *
 		 * Just an alias for `node.parent.insertAfter(node, newNode)`.
-		 * 
+		 *
 		 * @returns this node for method chaining.
-		 * 
+		 *
 		 * @example
 		 * decl.after('color: black');
 		 */

--- a/lib/postcss.es6
+++ b/lib/postcss.es6
@@ -8,6 +8,8 @@ import parse       from './parse';
 import list        from './list';
 import Rule        from './rule';
 import Root        from './root';
+import tokenizer   from './tokenize';
+import Parser      from './parser';
 
 /**
  * Create a new {@link Processor} instance that will apply `plugins`
@@ -239,3 +241,4 @@ postcss.rule = defaults => new Rule(defaults);
 postcss.root = defaults => new Root(defaults);
 
 export default postcss;
+export { tokenizer, Comment, Parser };


### PR DESCRIPTION
This fixes #1094 

This PR provides `tokenizer`, `Parser` and `Comment` as named exports of PostCSS.
Additionally, it extends the Typescript type declarations with typings for all three types.