### PR TITLE
Fixed selector parsing with comment inside

### DIFF
--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -369,19 +369,28 @@ export default class Parser {
         let length = tokens.length;
         let value  = '';
         let clean  = true;
+        let next, prev;
+        const pattern = /^(.|#)([\w-])+$/i;
+
         for ( let i = 0; i < length; i += 1 ) {
             token = tokens[i];
             type  = token[0];
 
             if ( type === 'comment' && node.type === 'rule' ) {
-                if ( !(
-                    tokens[i + 1][0] === 'space' ||
-                    tokens[i - 1][0] === 'space'
-                ) ) {
+                prev = tokens[i - 1];
+                next = tokens[i + 1];
+
+                if (
+                    prev[0] !== 'space' &&
+                    next[0] !== 'space' &&
+                    pattern.test(prev[1]) &&
+                    pattern.test(next[1])
+                ) {
                     value += token[1];
                 } else {
                     clean = false;
                 }
+
                 continue;
             }
 

--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -370,7 +370,7 @@ export default class Parser {
         let value  = '';
         let clean  = true;
         let next, prev;
-        const pattern = /^(.|#)([\w-])+$/i;
+        const pattern = /^([.|#])?([\w])+/i;
 
         for ( let i = 0; i < length; i += 1 ) {
             token = tokens[i];

--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -372,19 +372,20 @@ export default class Parser {
         for ( let i = 0; i < length; i += 1 ) {
             token = tokens[i];
             type  = token[0];
-            if ( type === 'comment' ) {
-                if (
-                    node.type === 'rule' &&
-                    !(
-                        tokens[i + 1][0] === 'space' ||
-                        tokens[i - 1][0]  === 'space'
-                    )
-                ) {
+
+            if ( type === 'comment' && node.type === 'rule' ) {
+                if ( !(
+                    tokens[i + 1][0] === 'space' ||
+                    tokens[i - 1][0] === 'space'
+                ) ) {
                     value += token[1];
                 } else {
                     clean = false;
                 }
-            } else if (type === 'space' && i === length - 1 ) {
+                continue;
+            }
+
+            if ( type === 'comment' || type === 'space' && i === length - 1 ) {
                 clean = false;
             } else {
                 value += token[1];

--- a/lib/parser.es6
+++ b/lib/parser.es6
@@ -372,7 +372,19 @@ export default class Parser {
         for ( let i = 0; i < length; i += 1 ) {
             token = tokens[i];
             type  = token[0];
-            if ( type === 'comment' || type === 'space' && i === length - 1 ) {
+            if ( type === 'comment' ) {
+                if (
+                    node.type === 'rule' &&
+                    !(
+                        tokens[i + 1][0] === 'space' ||
+                        tokens[i - 1][0]  === 'space'
+                    )
+                ) {
+                    value += token[1];
+                } else {
+                    clean = false;
+                }
+            } else if (type === 'space' && i === length - 1 ) {
                 clean = false;
             } else {
                 value += token[1];


### PR DESCRIPTION
Fixes https://github.com/postcss/postcss/issues/1066 . 

As was discussed, if comment does not have at least space from one of side interp it as a part of word.

> Note,  some of `postcss-parser-tests` should be updated as them match old parsing rules.