### PR TITLE
docs: fix .plugin parameter reference

### DIFF
--- a/lib/postcss.es6
+++ b/lib/postcss.es6
@@ -89,7 +89,7 @@ function postcss(...plugins) {
  * ```js
  * postcss.plugin('postcss-caniuse-test', () => {
  *   return (root, result) => {
- *     css.walkDecls(decl => {
+ *     root.walkDecls(decl => {
  *       if ( !caniuse.support(decl.prop) ) {
  *         decl.warn(result, 'Some browsers do not support ' + decl.prop);
  *       }


### PR DESCRIPTION
`css` doesn't exist in this example, but `root` does.