### PR TITLE
Update clone and cleanRaws docs

### DIFF
--- a/lib/node.es6
+++ b/lib/node.es6
@@ -161,17 +161,17 @@ class Node {
   }
 
   /**
-   * Returns a clone of the node.
+   * Returns an exact clone of the node.
    *
-   * The resulting cloned node and its (cloned) children will have
-   * a clean parent and code style properties.
+   * The resulting cloned node and its (cloned) children will retain
+   * code style properties.
    *
    * @param {object} [overrides] New properties to override in the clone.
    *
    * @example
+   * decl.raws.before    //=> "\n  "
    * const cloned = decl.clone({ prop: '-moz-' + decl.prop })
-   * cloned.raws.before  //=> undefined
-   * cloned.parent       //=> undefined
+   * cloned.raws.before  //=> "\n  "
    * cloned.toString()   //=> -moz-transform: scale(0)
    *
    * @return {Node} Clone of the node.
@@ -374,10 +374,23 @@ class Node {
     return result
   }
 
+  /**
+   * Clear the code style properties for the node and its children.
+   *
+   * @param {boolean} [keepBetween] Keep the raws.between symbols.
+   *
+   * @return {Node} This node for methods chain.
+   *
+   * @example
+   * node.raws.before  //=> ' '
+   * node.cleanRaws()
+   * node.raws.before  //=> undefined
+   */
   cleanRaws (keepBetween) {
     delete this.raws.before
     delete this.raws.after
     if (!keepBetween) delete this.raws.between
+    return this
   }
 
   positionInside (index) {

--- a/lib/node.es6
+++ b/lib/node.es6
@@ -379,7 +379,7 @@ class Node {
    *
    * @param {boolean} [keepBetween] Keep the raws.between symbols.
    *
-   * @return {Node} This node for methods chain.
+   * @returns {void}
    *
    * @example
    * node.raws.before  //=> ' '
@@ -390,7 +390,6 @@ class Node {
     delete this.raws.before
     delete this.raws.after
     if (!keepBetween) delete this.raws.between
-    return this
   }
 
   positionInside (index) {

--- a/package.json
+++ b/package.json
@@ -360,7 +360,9 @@
       "Cavit",
       "Nikhil",
       "Gaba",
-      "Kamyshev"
+      "Kamyshev",
+      "cleanRaws",
+      "keepBetween"
     ]
   }
 }


### PR DESCRIPTION
ESlint required an `@return` for JSDoc comments, so I had `cleanRaws` return itself like some other functions for chaining.