### PR TITLE
Refactoring. Delete unnecessary else with return

### DIFF
--- a/lib/container.es6
+++ b/lib/container.es6
@@ -167,13 +167,12 @@ class Container extends Node {
           return callback(child, i)
         }
       })
-    } else {
-      return this.walk((child, i) => {
-        if (child.type === 'decl' && child.prop === prop) {
-          return callback(child, i)
-        }
-      })
     }
+    return this.walk((child, i) => {
+      if (child.type === 'decl' && child.prop === prop) {
+        return callback(child, i)
+      }
+    })
   }
 
   /**
@@ -214,13 +213,12 @@ class Container extends Node {
           return callback(child, i)
         }
       })
-    } else {
-      return this.walk((child, i) => {
-        if (child.type === 'rule' && child.selector === selector) {
-          return callback(child, i)
-        }
-      })
     }
+    return this.walk((child, i) => {
+      if (child.type === 'rule' && child.selector === selector) {
+        return callback(child, i)
+      }
+    })
   }
 
   /**
@@ -267,13 +265,12 @@ class Container extends Node {
           return callback(child, i)
         }
       })
-    } else {
-      return this.walk((child, i) => {
-        if (child.type === 'atrule' && child.name === name) {
-          return callback(child, i)
-        }
-      })
     }
+    return this.walk((child, i) => {
+      if (child.type === 'atrule' && child.name === name) {
+        return callback(child, i)
+      }
+    })
   }
 
   /**
@@ -552,9 +549,8 @@ class Container extends Node {
   index (child) {
     if (typeof child === 'number') {
       return child
-    } else {
-      return this.nodes.indexOf(child)
     }
+    return this.nodes.indexOf(child)
   }
 
   /**


### PR DESCRIPTION
We can delete last `else` because this no necessary.

For example, if we have code like this:

```javascript
if (typeof child === 'number') {
  return child
} else {
  return this.nodes.indexOf(child)
}
```

And variable `child` has type `number` then the function always return `child` and never goes on the lines after if-statment. So we can delete `else`-branch:

```javascript
if (typeof child === 'number') {
  return child
}
return this.nodes.indexOf(child)
``` 

I think this part of code more readable then first one.