### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 7.0 “President Amy”
 * Remove Node.js 9 and Node.js 4 support.
-* Remove IE and “dead” browsers from Babel.
+* Remove IE and “dead” browsers support for client-side Babel transpiling.
 * Add CSS position on error happened inside `walk()` (by Nikhil Gaba).
 * Add `LazyResult#finally` (by Igor Kamyshev).
 * Add warning on calling PostCSS without plugins and syntax options.


### PR DESCRIPTION
small rephrase to make sure its clear the ie/dead browser removal only applies to the client-side postcss babel step, not postcss "in general" (as per https://github.com/postcss/postcss/issues/1178#issuecomment-417553553)