### PR TITLE
feat: add ignoreUnclosed option to nextToken method

### DIFF
--- a/lib/tokenize.es6
+++ b/lib/tokenize.es6
@@ -45,9 +45,12 @@ export default function tokenizer (input, options = {}) {
     return returned.length === 0 && pos >= length
   }
 
-  function nextToken () {
+  function nextToken (opts = {}) {
     if (returned.length) return returned.pop()
     if (pos >= length) return
+
+    let defaults = { ignoreUnclosed: false }
+    opts = Object.assign({}, defaults, opts)
 
     code = css.charCodeAt(pos)
     if (
@@ -109,7 +112,7 @@ export default function tokenizer (input, options = {}) {
             escaped = false
             next = css.indexOf(')', next + 1)
             if (next === -1) {
-              if (ignore) {
+              if (ignore || opts.ignoreUnclosed) {
                 next = pos
                 break
               } else {
@@ -154,7 +157,7 @@ export default function tokenizer (input, options = {}) {
           escaped = false
           next = css.indexOf(quote, next + 1)
           if (next === -1) {
-            if (ignore) {
+            if (ignore || opts.ignoreUnclosed) {
               next = pos + 1
               break
             } else {
@@ -247,7 +250,7 @@ export default function tokenizer (input, options = {}) {
         if (code === SLASH && css.charCodeAt(pos + 1) === ASTERISK) {
           next = css.indexOf('*/', pos + 2) + 1
           if (next === 0) {
-            if (ignore) {
+            if (ignore || opts.ignoreUnclosed) {
               next = css.length
             } else {
               unclosed('comment')

--- a/test/tokenize.test.js
+++ b/test/tokenize.test.js
@@ -269,3 +269,27 @@ it('tokenizes hexadecimal escape', () => {
     ['space', ' ']
   ])
 })
+
+it('ignore unclosed per token request', () => {
+  function tokn (css, opts) {
+    let processor = tokenizer(new Input(css), opts)
+    let tokens = []
+    while (!processor.endOfFile()) {
+      tokens.push(processor.nextToken({ ignoreUnclosed: true }))
+    }
+    return tokens
+  }
+
+  let css = `How's it going (`
+  let tokens = tokn(css, {})
+  let expected = [['word', 'How', 1, 1, 1, 3],
+    ['string', "'s", 1, 4, 1, 5],
+    ['space', ' '],
+    ['word', 'it', 1, 7, 1, 8],
+    ['space', ' '],
+    ['word', 'going', 1, 10, 1, 14],
+    ['space', ' '],
+    ['(', '(', 1, 16]]
+
+  expect(tokens).toEqual(expected)
+})


### PR DESCRIPTION
This PR stems from [an issue in postcss-less](https://github.com/shellscape/postcss-less/issues/117) and a [short discussion on twitter](https://twitter.com/sitnikcode/status/1044319395760263168) with @ai.

### Use Case

PostCSS v7 has a wonderful parser class structure that enabled syntaxes to be created by inheriting from the base `Parser` class and selectively overriding methods to handle syntax nuances - all _without having to reimplement a parser or tokenizer._ That's a **massive** advantage to developers. However, there are some strict rules hardcoded into the tokenizer. Because the tokenizer is optimized for performance, it cannot be made a class to be inherited from. A mechanism is then needed to work around/with the hardcoded tokenizer rules.

In some situations it would be preferable to fetch the next token from a tokenizer while ignoring any `unclosed` errors for only the next token request. This is different than instantiating the tokenizer with the `ignoreErrors` options, as it only ignores `unclosed` for a single `tokenizer.nextToken()` request. 

This PR implements an `ignoreUnclosed` option. The naming of that option was chosen because that option is _only_ used on lines where the `else` cases result in the `unclosed(...)` method being called, and an "Unclosed X" error is thrown. Hence the naming is more specific, but should aid in usability and providing a distinction between the top-level tokenizer option `ignoreErrors` and this new `nextToken` method option.

Example Usage:

```js
// default value for `nextToken` opts is `{}`
// default value for ignoreUnclosed is `false`
this.tokenizer.nextToken({ ignoreUnclosed: true });
```
