### PR TITLE
Add postcss-class-name-shortener to docs/plugins.md

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -318,6 +318,7 @@ loosely resembles the original.
 * [`postcss-uncss`] removes unused CSS from your stylesheets.
 * [`postcss-html-filter`] filters out CSS that does not apply to the HTML you provide.
 * [`postcss-no-important`] delete declarations !important.
+* [`postcss-class-name-shortener`] shortens CSS class names to optimize website performance.
 
 See also plugins in modular minifier [`cssnano`].
 
@@ -786,3 +787,4 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-join-transitions`]:             https://github.com/JGJP/postcss-join-transitions
 [`postcss-font-display`]:                 https://github.com/dkrnl/postcss-font-display
 [`postcss-glitch`]:                       https://github.com/crftd/postcss-glitch
+[`postcss-class-name-shortener`]:         https://github.com/mbrandau/postcss-class-name-shortener

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -300,6 +300,7 @@ loosely resembles the original.
 
 * [`postcss-calc`] reduces `calc()` to values
   (when expressions involve the same units).
+* [`postcss-class-name-shortener`] shortens CSS class names to optimize website performance.
 * [`postcss-combine-duplicated-selectors`] automatically join identical css selectors.
 * [`postcss-filter-mq`] Filter all matching or non-matching media queries.
 * [`postcss-import`] inlines the stylesheets referred to by `@import` rules.
@@ -318,7 +319,6 @@ loosely resembles the original.
 * [`postcss-uncss`] removes unused CSS from your stylesheets.
 * [`postcss-html-filter`] filters out CSS that does not apply to the HTML you provide.
 * [`postcss-no-important`] delete declarations !important.
-* [`postcss-class-name-shortener`] shortens CSS class names to optimize website performance.
 
 See also plugins in modular minifier [`cssnano`].
 


### PR DESCRIPTION
PostCSS plugin that shortens CSS class names to optimize website performance.

https://github.com/mbrandau/postcss-class-name-shortener
https://www.npmjs.com/package/postcss-class-name-shortener