### PR TITLE
Added Section "Treat Warnings as Errors" to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,26 @@ Common options:
 [Midas]:              https://github.com/ben-eb/midas
 [SCSS]:               https://github.com/postcss/postcss-scss
 
+### Treat Warnings as Errors
+
+In some situations it might be helpful to fail the build on any warning from PostCSS or one of its plugins. This guarantees that no warnings go unnoticed, and helps to avoid bugs. While there is no option to enable treating warnings as errors, it can easily be done by appending a custom plugin to `postcss.config.js`:
+
+```js
+module.exports = {
+  plugins: [
+    require('autoprefixer'),
+    require('postcss').plugin("postcss-fail-on-warn", () => {
+      return (root, result) => {
+        if (result.warnings().length > 0) {
+          throw new Error(result.warnings()[0])
+        }
+      }
+    })
+  ]
+}
+```
+
+
 ## Editors & IDE Integration
 
 ### Atom


### PR DESCRIPTION
As discussed in https://github.com/postcss/autoprefixer/issues/1165#issuecomment-445377691

Improvement suggestions welcome.