### PR TITLE
Fixes TransformCallback type definition

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -33,7 +33,7 @@ declare namespace postcss {
     /**
      * @returns Asynchronous plugins should return a promise.
      */
-    (root: Root, result?: Result): void | Function | any;
+    (root: Root, result: Result): Promise<any> | any;
   }
   interface PluginInitializer<T> {
     (pluginOptions?: T): Transformer;


### PR DESCRIPTION
TransformCallback's result argument shouldn't be undefined. Also the return type could use some clarification.

fixes #1213