### PR TITLE
updates ResultMessage interface with an index signature

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -440,9 +440,8 @@ declare namespace postcss {
   }
   interface ResultMessage {
     type: string;
-    text?: string;
-    plugin?: string;
-    browsers?: string[];
+    plugin: string;
+    [others: string]: any;
   }
   /**
    * Represents a plugin warning. It can be created using Result#warn().


### PR DESCRIPTION
By including an index signature, the `ResultMessage` interface becomes more extensible. Plugins are allowed to push messages that have properties besides the few that are already defined.

In fact, the only ones that are now specified explicitly are those that are required. This includes `plugin`, which previously was not marked required. However, the [API documentation guides users](http://api.postcss.org/Result.html#messages) to always specify both `type` and `plugin`.

cc @jedmao 

---

Before this change, the following code would produce an error:

```typescript
// Object literal may only specify known properties, and 'file' does not exist in type 'ResultMessage'.
result.messages.push({
  type: 'dependency',
  plugin: 'postcss-foo',
  file: '/some/path/to/dependent.css',
  parent: '/some/path/to/source.css'
});
```

AFAIK this is the shape of a message that is meant to be handled by file watchers, so this is a real use case.