### PR TITLE
Updates type definitions for ProcessOptions

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -244,7 +244,7 @@ declare namespace postcss {
     /**
      * Source map options
      */
-    map?: SourceMapOptions;
+    map?: SourceMapOptions | true;
   }
   interface Syntax {
     /**

--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -181,13 +181,11 @@ declare namespace postcss {
      *
      * If you have set inline: true, annotation cannot be disabled.
      */
-    annotation?: boolean | string;
+    annotation?: string | false;
     /**
-     * If true, PostCSS will try to correct any syntax errors that it finds in the CSS.
-     * This is useful for legacy code filled with hacks. Another use-case is interactive
-     * tools with live input — for example, the Autoprefixer demo.
+     * Override "from" in map's sources.
      */
-    safe?: boolean;
+    from?: string;
   }
   /**
    * A Processor instance contains plugins to process CSS. Create one
@@ -220,47 +218,52 @@ declare namespace postcss {
      */
     version: string;
   }
-  interface ProcessOptions extends Syntax {
+  interface ProcessOptions {
     /**
-     * The path of the CSS source file. You should always set from, because it is
+     * The path of the CSS source file. You should always set "from", because it is
      * used in source map generation and syntax error messages.
      */
     from?: string;
     /**
-     * The path where you'll put the output CSS file. You should always set it
+     * The path where you'll put the output CSS file. You should always set "to"
      * to generate correct source maps.
      */
     to?: string;
-    syntax?: Syntax;
-    /**
-     * Enable Safe Mode, in which PostCSS will try to fix CSS syntax errors.
-     */
-    safe?: boolean;
-    map?: postcss.SourceMapOptions;
     /**
      * Function to generate AST by string.
      */
-    parser?: Parse | Syntax;
+    parser?: Parser;
     /**
      * Class to generate string by AST.
      */
-    stringifier?: Stringify | Syntax;
+    stringifier?: Stringifier;
+    /**
+     * Object with parse and stringify.
+     */
+    syntax?: Syntax;
+    /**
+     * Source map options
+     */
+    map?: SourceMapOptions;
   }
   interface Syntax {
     /**
      * Function to generate AST by string.
      */
-    parse?: Parse;
+    parse?: Parser;
     /**
      * Class to generate string by AST.
      */
-    stringify?: Stringify;
+    stringify?: Stringifier;
   }
-  interface Parse {
-    (css?: string, opts?: postcss.SourceMapOptions): Root;
+  interface Parser {
+    (css: string, opts?: Pick<ProcessOptions, 'map' |'from'>): Root;
   }
-  interface Stringify {
-    (node?: postcss.Node, builder?: any): postcss.Result | void;
+  interface Stringifier {
+    (node: Node, builder: Builder): void;
+  }
+  interface Builder {
+    (part: string, node?: Node, type?: 'start' | 'end'): void;
   }
   /**
    * A promise proxy for the result of PostCSS transformations.


### PR DESCRIPTION
It seems that quite a few of the type definitions related to `ProcessOptions` were not in sync with the latest source. This change should bring it back up to date.

Notably:
*  `ProcessOptions` no longer extends `Syntax`. This used to be a way of saying the object had both `parse` and `stringify` options, but that wasn't true. The object does have `parser` and `stringifier` options.
*  The `safe` option was removed. It's not referenced in the [documentation](http://api.postcss.org/global.html#processOptions).
*  `Parse` and `Stringify` are renamed to `Parser` and `Stringifier`. This is consistent with the documentation, and reflects the fact that these are functions (verbs instead of nouns).
*  `Parser` options has `from` and `map` properties, instead of taking `SourceMapOptions` (which is the type for the `map` option). Fun use of the `Pick<T,K>` helper!
*  Fixes the argument optionality of `Parser` and `Stringifier`. Adds `Builder` to specify the argument that use to be an `any`.
*  General clean up of comments and types.