### PR TITLE
Fix end tokens having wrong sourcemap entry

### DIFF
--- a/lib/map-generator.es6
+++ b/lib/map-generator.es6
@@ -231,10 +231,10 @@ class MapGenerator {
         if (node.source && node.source.end) {
           this.map.addMapping({
             source: this.sourcePath(node),
-            generated: { line, column: column - 1 },
+            generated: { line, column: column - 2 },
             original: {
               line: node.source.end.line,
-              column: node.source.end.column
+              column: node.source.end.column - 1
             }
           })
         } else {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -23,6 +23,6 @@ it('generates source map without fs', () => {
   expect(postcss([() => true]).process('a{}', { from: 'a.css', map: true }).css)
     .toEqual('a{}\n/*# sourceMappingURL=data:application/json;base64,' +
              'eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImEuY3NzIl0sIm5hbWVzIjpbXSw' +
-             'ibWFwcGluZ3MiOiJBQUFBLEdBQUciLCJmaWxlIjoiYS5jc3MiLCJzb3VyY2' +
+             'ibWFwcGluZ3MiOiJBQUFBLEVBQUUiLCJmaWxlIjoiYS5jc3MiLCJzb3VyY2' +
              'VzQ29udGVudCI6WyJhe30iXX0= */')
 })

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -66,6 +66,12 @@ it('generate right source map', () => {
     column: 0,
     name: null
   })
+  expect(map.originalPositionFor({ line: 1, column: 2 })).toEqual({
+    source: 'a.css',
+    line: 1,
+    column: 0,
+    name: null
+  })
   expect(map.originalPositionFor({ line: 2, column: 2 })).toEqual({
     source: 'a.css',
     line: 2,
@@ -75,6 +81,18 @@ it('generate right source map', () => {
   expect(map.originalPositionFor({ line: 3, column: 2 })).toEqual({
     source: 'a.css',
     line: 2,
+    column: 2,
+    name: null
+  })
+  expect(map.originalPositionFor({ line: 3, column: 14 })).toEqual({
+    source: 'a.css',
+    line: 2,
+    column: 14,
+    name: null
+  })
+  expect(map.originalPositionFor({ line: 4, column: 2 })).toEqual({
+    source: 'a.css',
+    line: 3,
     column: 2,
     name: null
   })


### PR DESCRIPTION
There was a bug where end node parts (not sure how they're actually called) like ";" or "}" had off-by-one-errors (explanation in separate comments)


[Before](http://sokra.github.io/source-map-visualization/#base64,CmJvZHkgewoJYmFja2dyb3VuZC1jb2xvcjogcmVkOwp9Cgo=,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNyYy9zdHlsZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IjtBQUNBO0NBQ0Msc0JBQXNCO0NBQ3RCIiwiZmlsZSI6Im91dC5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyJcbmJvZHkge1xuXHRiYWNrZ3JvdW5kLWNvbG9yOiByZWQ7XG59XG5cbiJdfQ==,CmJvZHkgewoJYmFja2dyb3VuZC1jb2xvcjogcmVkOwp9Cgo=)
[After](http://sokra.github.io/source-map-visualization/#base64,CmJvZHkgewoJYmFja2dyb3VuZC1jb2xvcjogcmVkOwp9Cgo=,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNyYy9zdHlsZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IjtBQUNBO0NBQ0MscUJBQXFCO0FBQ3RCIiwiZmlsZSI6Im91dC5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyJcbmJvZHkge1xuXHRiYWNrZ3JvdW5kLWNvbG9yOiByZWQ7XG59XG5cbiJdfQ==,CmJvZHkgewoJYmFja2dyb3VuZC1jb2xvcjogcmVkOwp9Cgo=)

Fixes #1222