### PR TITLE
Sourcemaps fix for optional semicolon

### DIFF
--- a/lib/map-generator.es6
+++ b/lib/map-generator.es6
@@ -227,7 +227,8 @@ class MapGenerator {
         column += str.length
       }
 
-      if (node && type !== 'start') {
+      if (node && type !== 'start' &&
+           (node === node.parent.last ? node.parent.raws.semi : true)) {
         if (node.source && node.source.end) {
           this.map.addMapping({
             source: this.sourcePath(node),


### PR DESCRIPTION
Fixup for #1223:

> But I discovered an issue: the last semicolon might be missing, then [this](http://sokra.github.io/source-map-visualization/#base64,Cgpib2R5IHsKCWNvbG9yOiByZWQ7CgliYWNrZ3JvdW5kLWNvbG9yOiByZWQKfQoK,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNyYy9zdHlsZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7QUFFQTtDQUNDLFVBQVU7Q0FDVixvQkFBb0I7QUFDckIiLCJmaWxlIjoib3V0LmNzcyIsInNvdXJjZXNDb250ZW50IjpbIlxuXG5ib2R5IHtcblx0Y29sb3I6IHJlZDtcblx0YmFja2dyb3VuZC1jb2xvcjogcmVkXG59XG5cbiJdfQ==,Cgpib2R5IHsKCWNvbG9yOiByZWQ7CgliYWNrZ3JvdW5kLWNvbG9yOiByZWQKfQoK) happens (the last `d` of `red` is separate).
> Area there other cases where something similar might happen?
