### PR TITLE
Expose Tokenizer `position` function

### DIFF
--- a/lib/tokenize.es6
+++ b/lib/tokenize.es6
@@ -37,6 +37,10 @@ export default function tokenizer (input, options = {}) {
   let buffer = []
   let returned = []
 
+  function position () {
+    return pos
+  }
+
   function unclosed (what) {
     throw input.error('Unclosed ' + what, line, pos - offset)
   }
@@ -309,6 +313,7 @@ export default function tokenizer (input, options = {}) {
   return {
     back,
     nextToken,
-    endOfFile
+    endOfFile,
+    position
   }
 }

--- a/test/tokenize.test.js
+++ b/test/tokenize.test.js
@@ -293,3 +293,17 @@ it('ignore unclosed per token request', () => {
 
   expect(tokens).toEqual(expected)
 })
+
+it('provides correct position', () => {
+  let css = `Three tokens`
+  let processor = tokenizer(new Input(css))
+  expect(processor.position()).toEqual(0)
+  processor.nextToken()
+  expect(processor.position()).toEqual(5)
+  processor.nextToken()
+  expect(processor.position()).toEqual(6)
+  processor.nextToken()
+  expect(processor.position()).toEqual(12)
+  processor.nextToken()
+  expect(processor.position()).toEqual(12)
+})


### PR DESCRIPTION
Exposes a `position` function returned from the tokenizer upon creation. This allows one to get the character the tokenizer is currently at.

Closes #1236