### PR TITLE
fix(types): make `Rule.selectors` non-optional

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -1178,7 +1178,7 @@ declare namespace postcss {
      * An array containing the rule's individual selectors.
      * Groups of selectors are split at commas.
      */
-    selectors?: string[];
+    selectors: string[];
     /**
      * @param overrides New properties to override in the clone.
      * @returns A clone of this node. The node and its (cloned) children will


### PR DESCRIPTION
`Rule.selectors` is guaranteed to be an array. The array itself _may_ be empty.

https://github.com/postcss/postcss/blob/d245ada946919df91009fd1745a7075bf5e84e43/lib/rule.es6#L22-L40

https://github.com/postcss/postcss/blob/d245ada946919df91009fd1745a7075bf5e84e43/lib/list.es6#L12-L53