### PR TITLE
Update README.md claim of "perfect" Parcel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ module.exports = {
 
 Parcel will even automatically install these plugins for you.
 
-> Please be aware of [the several issues in Version 1](https://github.com/parcel-bundler/parcel/labels/CSS%20Preprocessing). [Version 2](https://github.com/parcel-bundler/parcel/projects/5) may resolved the issues via [issue #2157](https://github.com/parcel-bundler/parcel/issues/2157).
+> Please, be aware of [the several issues in Version 1](https://github.com/parcel-bundler/parcel/labels/CSS%20Preprocessing). Notice, [Version 2](https://github.com/parcel-bundler/parcel/projects/5) may resolve the issues via [issue #2157](https://github.com/parcel-bundler/parcel/issues/2157).
 
 [Parcel]: https://parceljs.org
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ module.exports = {
 
 ### Parcel
 
-[Parcel] has perfect built-in PostCSS support. It already uses Autoprefixer
+[Parcel] has ~~perfect~~ built-in PostCSS support. It already uses Autoprefixer
 and cssnano. If you want to change plugins, create `postcss.config.js`
 in project’s root:
 
@@ -239,6 +239,8 @@ module.exports = {
 ```
 
 Parcel will even automatically install these plugins for you.
+
+> Please be aware of [the several issues in Version 1](https://github.com/parcel-bundler/parcel/labels/CSS%20Preprocessing). [Version 2](https://github.com/parcel-bundler/parcel/projects/5) may resolved the issues via [issue #2157](https://github.com/parcel-bundler/parcel/issues/2157).
 
 [Parcel]: https://parceljs.org
 


### PR DESCRIPTION
Update `README.md` to not tout Parcel's implementation as "perfect". There are [the several issues in Version 1](https://github.com/parcel-bundler/parcel/labels/CSS%20Preprocessing). And [Version 2](https://github.com/parcel-bundler/parcel/projects/5) is not out yet to possibly fix the issues via [issue #2157](parcel-bundler/parcel#2157).

I am amenable to any alteration of this edit. Perhaps, the change should be _only_ to remove the word "perfect". But, Parcel's implementation has been flawed for a long time.

_I provide the extra information, in hopes of saving someone else from believing Parcel will manage PostCSS for them. Three times over this and the past years, I have crawled out of the maze of Parcel & PostCSS rabbit holes to decide that it is _still_ better for a project to process with PostCSS directly, independently of Parcel._