### PR TITLE
correct type for `annotation`

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -157,7 +157,7 @@ declare namespace postcss {
      *
      * If you have set inline: true, annotation cannot be disabled.
      */
-    annotation?: string | false;
+    annotation?: string | boolean;
     /**
      * Override "from" in map's sources.
      */


### PR DESCRIPTION
Setting `annotation: true` has a different behaviour to omitting the `annotation` key, but this is not allowable by the type system. 

This PR fixes this, so that `annotation: true` is an allowed option.