### PR TITLE
parse: avoid re-resolution of "already absolute" file paths

### DIFF
--- a/lib/input.es6
+++ b/lib/input.es6
@@ -41,7 +41,7 @@ class Input {
     }
 
     if (opts.from) {
-      if (/^\w+:\/\//.test(opts.from)) {
+      if (/^\w+:\/\//.test(opts.from) || path.isAbsolute(opts.from)) {
         /**
          * The absolute path to the CSS source file defined
          * with the `from` option.
@@ -54,7 +54,7 @@ class Input {
          */
         this.file = opts.from
       } else {
-        this.file = path.isAbsolute(opts.from) ? opts.from : path.resolve(opts.from)
+        this.file = path.resolve(opts.from)
       }
     }
 

--- a/lib/input.es6
+++ b/lib/input.es6
@@ -54,9 +54,7 @@ class Input {
          */
         this.file = opts.from
       } else {
-        this.file = path.isAbsolute(opts.from) 
-          ? opts.from
-          : path.resolve(opts.from)
+        this.file = path.isAbsolute(opts.from) ? opts.from : path.resolve(opts.from)
       }
     }
 

--- a/lib/input.es6
+++ b/lib/input.es6
@@ -54,7 +54,9 @@ class Input {
          */
         this.file = opts.from
       } else {
-        this.file = path.resolve(opts.from)
+        this.file = path.isAbsolute(opts.from) 
+          ? opts.from
+          : path.resolve(opts.from)
       }
     }
 


### PR DESCRIPTION
On windows, when calling `postcss.parse` providing it with a posix-style absolute file path (e.g. running against an in-memory fs) leads to the `from` field being resolved to a windows-style path.

For example, the file from path `/a/b/c` gets resolved to `C:\\a\\b\\c`, which doesn't exist in my case.