### PR TITLE
Fix circular dependencies

### DIFF
--- a/lib/at-rule.es6
+++ b/lib/at-rule.es6
@@ -1,4 +1,4 @@
-import Container from './container'
+import Container, { registerAtRule } from './container'
 
 /**
  * Represents an at-rule.
@@ -90,3 +90,5 @@ class AtRule extends Container {
 }
 
 export default AtRule
+
+registerAtRule(AtRule)

--- a/lib/container.es6
+++ b/lib/container.es6
@@ -2,6 +2,20 @@ import Declaration from './declaration'
 import Comment from './comment'
 import Node from './node'
 
+let parse, Rule, AtRule
+
+export function registerParse (dependant) {
+  parse = dependant
+}
+
+export function registerRule (dependant) {
+  Rule = dependant
+}
+
+export function registerAtRule (dependant) {
+  AtRule = dependant
+}
+
 function cleanSource (nodes) {
   return nodes.map(i => {
     if (i.nodes) i.nodes = cleanSource(i.nodes)
@@ -584,7 +598,6 @@ class Container extends Node {
 
   normalize (nodes, sample) {
     if (typeof nodes === 'string') {
-      let parse = require('./parse')
       nodes = cleanSource(parse(nodes).nodes)
     } else if (Array.isArray(nodes)) {
       nodes = nodes.slice(0)
@@ -606,10 +619,8 @@ class Container extends Node {
       }
       nodes = [new Declaration(nodes)]
     } else if (nodes.selector) {
-      let Rule = require('./rule')
       nodes = [new Rule(nodes)]
     } else if (nodes.name) {
-      let AtRule = require('./at-rule')
       nodes = [new AtRule(nodes)]
     } else if (nodes.text) {
       nodes = [new Comment(nodes)]

--- a/lib/input.es6
+++ b/lib/input.es6
@@ -2,6 +2,7 @@ import path from 'path'
 
 import CssSyntaxError from './css-syntax-error'
 import PreviousMap from './previous-map'
+import { registerInput } from './terminal-highlight'
 
 let sequence = 0
 
@@ -169,6 +170,8 @@ class Input {
 }
 
 export default Input
+
+registerInput(Input)
 
 /**
  * @typedef  {object} filePosition

--- a/lib/lazy-result.es6
+++ b/lib/lazy-result.es6
@@ -3,6 +3,7 @@ import stringify from './stringify'
 import warnOnce from './warn-once'
 import Result from './result'
 import parse from './parse'
+import { registerLazyResult } from './root'
 
 function isPromise (obj) {
   return typeof obj === 'object' && typeof obj.then === 'function'
@@ -378,6 +379,8 @@ class LazyResult {
 }
 
 export default LazyResult
+
+registerLazyResult(LazyResult)
 
 /**
  * @callback onFulfilled

--- a/lib/parse.es6
+++ b/lib/parse.es6
@@ -1,5 +1,6 @@
 import Parser from './parser'
 import Input from './input'
+import { registerParse } from './container'
 
 function parse (css, opts) {
   let input = new Input(css, opts)
@@ -31,3 +32,5 @@ function parse (css, opts) {
 }
 
 export default parse
+
+registerParse(parse)

--- a/lib/processor.es6
+++ b/lib/processor.es6
@@ -1,4 +1,5 @@
 import LazyResult from './lazy-result'
+import { registerProcessor } from './root'
 
 /**
  * Contains plugins to process CSS. Create one `Processor` instance,
@@ -135,6 +136,8 @@ class Processor {
 }
 
 export default Processor
+
+registerProcessor(Processor)
 
 /**
  * @callback builder

--- a/lib/root.es6
+++ b/lib/root.es6
@@ -1,5 +1,15 @@
 import Container from './container'
 
+let LazyResult, Processor
+
+export function registerLazyResult (dependant) {
+  LazyResult = dependant
+}
+
+export function registerProcessor (dependant) {
+  Processor = dependant
+}
+
 /**
  * Represents a CSS file and contains all its parsed nodes.
  *
@@ -61,9 +71,6 @@ class Root extends Container {
    * const result = root1.toResult({ to: 'all.css', map: true })
    */
   toResult (opts = { }) {
-    let LazyResult = require('./lazy-result')
-    let Processor = require('./processor')
-
     let lazy = new LazyResult(new Processor(), this, opts)
     return lazy.stringify()
   }

--- a/lib/rule.es6
+++ b/lib/rule.es6
@@ -1,4 +1,4 @@
-import Container from './container'
+import Container, { registerRule } from './container'
 import list from './list'
 
 /**
@@ -87,3 +87,5 @@ class Rule extends Container {
 }
 
 export default Rule
+
+registerRule(Rule)

--- a/lib/terminal-highlight.es6
+++ b/lib/terminal-highlight.es6
@@ -1,7 +1,12 @@
 import chalk from 'chalk'
 
 import tokenizer from './tokenize'
-import Input from './input'
+
+let Input
+
+export function registerInput (dependant) {
+  Input = dependant
+}
 
 const HIGHLIGHT_THEME = {
   'brackets': chalk.cyan,

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -1,7 +1,7 @@
 let Declaration = require('../lib/declaration')
 let parse = require('../lib/parse')
 let Rule = require('../lib/rule')
-let Root = require('../lib/root')
+let { default: Root } = require('../lib/root')
 
 let example = 'a { a: 1; b: 2 }' +
                 '/* a */' +

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -5,7 +5,7 @@ let Declaration = require('../lib/declaration')
 let postcss = require('../lib/postcss')
 let AtRule = require('../lib/at-rule')
 let parse = require('../lib/parse')
-let Root = require('../lib/root')
+let { default: Root } = require('../lib/root')
 let Rule = require('../lib/rule')
 
 function stringify (node, builder) {

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -3,7 +3,8 @@ let path = require('path')
 let fs = require('fs')
 
 let parse = require('../lib/parse')
-let Root = require('../lib/root')
+let { default: Root } = require('../lib/root')
+require('../lib/processor')
 
 it('works with file reads', () => {
   let stream = fs.readFileSync(cases.path('atrule-empty.css'))

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -5,7 +5,7 @@ let Processor = require('../lib/processor')
 let postcss = require('../lib/postcss')
 let Result = require('../lib/result')
 let parse = require('../lib/parse')
-let Root = require('../lib/root')
+let { default: Root } = require('../lib/root')
 
 function prs () {
   return new Root({ raws: { after: 'ok' } })

--- a/test/root.test.js
+++ b/test/root.test.js
@@ -1,6 +1,10 @@
 let Result = require('../lib/result')
 let parse = require('../lib/parse')
 
+require('../lib/rule')
+require('../lib/at-rule')
+require('../lib/processor')
+
 it('prepend() fixes spaces on insert before first', () => {
   let css = parse('a {} b {}')
   css.prepend({ selector: 'em' })

--- a/test/stringifier.test.js
+++ b/test/stringifier.test.js
@@ -3,7 +3,7 @@ let Declaration = require('../lib/declaration')
 let AtRule = require('../lib/at-rule')
 let parse = require('../lib/parse')
 let Node = require('../lib/node')
-let Root = require('../lib/root')
+let { default: Root } = require('../lib/root')
 let Rule = require('../lib/rule')
 
 let str

--- a/test/tokenize.test.js
+++ b/test/tokenize.test.js
@@ -1,5 +1,6 @@
 let tokenizer = require('../lib/tokenize')
 let Input = require('../lib/input')
+require('../lib/rule')
 
 function tokenize (css, opts) {
   let processor = tokenizer(new Input(css), opts)


### PR DESCRIPTION
While building a recent project with Rollup, we ran in to [issues with circular dependencies](https://github.com/rollup/plugins/issues/164) in PostCSS. This PR solves circular dependencies across 3 files, and adds consistency to how files are included.

#### A sampling of current circular dependencies
```
./container.js -> ./rule.js -> ./container.js
./container.js -> ./parse.js -> ./parser.js -> ./rule.js -> ./container.js
./css-syntax-error.js -> terminal-highlight.js -> input.js -> css-syntax-error.js
./parse.js -> parser.js -> at-rule.js -> container.js -> parse.js
...
```

#### `container.es6`

In `container.es6` there are 3 late-style `require` in the `normalize` function. This PR removes the `require` completely and replaces it with a register dependency pattern.

#### `root.es6`

In `root.es6` there are 2 late-style `require` in the `toResult` function. This PR removes the `require` completely and replaces it with a register dependency pattern.

#### `terminal-highlight.es6`

`terminal-highlight.es6` does not use `require` to include `input.es6` in the terminalHighlight function. None the less, in a different environment, this would cause the same error. This PR replaces the import statement with a register dependency pattern.

#### Improvement

- All code is included with `import` or by registering a dependency
- 5 `require` statements removed
- No public API is changed
- PostCSS can be bundled with Rollup or other bundlers
