### PR TITLE
Use @babel/plugin-proposal-export-default-from

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
+    "@babel/plugin-proposal-export-default-from": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
     "@logux/eslint-config": "^28.1.0",
     "babel-eslint": "^10.0.1",
-    "babel-plugin-add-module-exports": "^1.0.0",
     "concat-with-sourcemaps": "^1.1.0",
     "del": "^4.1.0",
     "docdash": "^1.1.0",
@@ -109,7 +109,7 @@
       ]
     ],
     "plugins": [
-      "add-module-exports"
+      "@babel/proposal-export-default-from"
     ]
   },
   "size-limit": [


### PR DESCRIPTION
Babel 7 has official @babel/plugin-proposal-export-default-from to replace third party add-module-exports plugin