### PR TITLE
fix(input): undefined check in addition to the null check

### DIFF
--- a/lib/input.es6
+++ b/lib/input.es6
@@ -18,7 +18,7 @@ class Input {
    * @param {object} [opts] {@link Processor#process} options.
    */
   constructor (css, opts = { }) {
-    if (css === null || (typeof css === 'object' && !css.toString)) {
+    if (css === null || css === undefined || (typeof css === 'object' && !css.toString)) {
       throw new Error(`PostCSS received ${ css } instead of CSS string`)
     }
 


### PR DESCRIPTION
Was compiling through ng-packagr and got the following errors. Looks like `css` is undefined at the time this bit of code was reached and the `toString` existence check fails.

![image](https://user-images.githubusercontent.com/4655972/83440024-2f690600-a412-11ea-9956-fd08ae14cf99.png)

![image](https://user-images.githubusercontent.com/4655972/83440105-5cb5b400-a412-11ea-958d-36bf545e30cc.png)


Error after this PR:
![image](https://user-images.githubusercontent.com/4655972/83440316-b9b16a00-a412-11ea-8372-c2146bc0b255.png)
