### PR TITLE
Allow replaceWith to be called with input that includes itself.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -250,10 +250,10 @@ class Node {
         if (node === this) {
           foundSelf = true;
         } else if (foundSelf) {
-          this.parent.insertAfter(bookmark, node);
+          this.parent.insertAfter(bookmark, node)
           bookmark = node;
         } else {
-          this.parent.insertBefore(bookmark, node);
+          this.parent.insertBefore(bookmark, node)
         }
       }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -244,14 +244,14 @@ class Node {
    */
   replaceWith (...nodes) {
     if (this.parent) {
-      let bookmark = this;
-      let foundSelf = false;
+      let bookmark = this
+      let foundSelf = false
       for (let node of nodes) {
         if (node === this) {
-          foundSelf = true;
+          foundSelf = true
         } else if (foundSelf) {
           this.parent.insertAfter(bookmark, node)
-          bookmark = node;
+          bookmark = node
         } else {
           this.parent.insertBefore(bookmark, node)
         }

--- a/lib/node.js
+++ b/lib/node.js
@@ -244,11 +244,22 @@ class Node {
    */
   replaceWith (...nodes) {
     if (this.parent) {
+      let bookmark = this;
+      let foundSelf = false;
       for (let node of nodes) {
-        this.parent.insertBefore(this, node)
+        if (node === this) {
+          foundSelf = true;
+        } else if (foundSelf) {
+          this.parent.insertAfter(bookmark, node);
+          bookmark = node;
+        } else {
+          this.parent.insertBefore(bookmark, node);
+        }
       }
 
-      this.remove()
+      if (!foundSelf) {
+        this.remove()
+      }
     }
 
     return this

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -127,6 +127,16 @@ it('replaceWith() replaces node', () => {
   expect(css.toString()).toEqual('a{fix:fixed;two:2}')
 })
 
+it('replaceWith() can include itself', () => {
+  let css = parse('a{one:1;two:2}')
+  let one = css.first.first
+  let beforeDecl = { prop: 'fix1', value: 'fixedOne' }
+  let afterDecl = { prop: 'fix2', value: 'fixedTwo' }
+  one.replaceWith(beforeDecl, one, afterDecl)
+
+  expect(css.toString()).toEqual('a{fix1:fixedOne;one:1;fix2:fixedTwo;two:2}')
+})
+
 it('toString() accepts custom stringifier', () => {
   expect(new Rule({ selector: 'a' }).toString(stringify)).toEqual('a')
 })


### PR DESCRIPTION
Consider an AST where a node `root` has child nodes `[a, b, c]` and there are other nodes `d` and `e`. `a.replaceWith(a, d, e)` now results in `root` having the children `[a, d, e, b, c]`.