### PR TITLE
Improve `Input` interface type definition

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -571,7 +571,11 @@ declare namespace postcss {
      * Represents the input source map passed from a compilation step before
      * PostCSS (e.g., from the Sass compiler).
      */
-    map: PreviousMap;
+    map?: PreviousMap;
+    /**
+     * Input CSS source.
+     */
+    css: string;
     /**
      * The flag to indicate whether or not the source code has Unicode BOM.
      */


### PR DESCRIPTION
I found some improvements in the current `Input` interface type definition.

- The `map` property should be optional.
  https://github.com/postcss/postcss/blob/abfaa7122a0f480bc5be0905df3c24a6a51a82d9/lib/input.es6#L96

- A `css` property is missing.
  https://github.com/postcss/postcss/blob/abfaa7122a0f480bc5be0905df3c24a6a51a82d9/lib/input.es6#L38