### PR TITLE
Fix TypeError: Cannot set property 'parent' of undefined on removeChild

### DIFF
--- a/lib/container.es6
+++ b/lib/container.es6
@@ -437,7 +437,7 @@ class Container extends Node {
    */
   removeChild (child) {
     child = this.index(child)
-    this.nodes[child].parent = undefined
+    (this.nodes[child] || {}).parent = undefined
     this.nodes.splice(child, 1)
 
     let index


### PR DESCRIPTION
I don't know how or why does it happen, but this error has been reported in vkalinichev/postcss-rtl#57 and this fix generates the same CSS files while preventing this error using said plugin.

I didn't have enough time to thoroughly debug either postcss or postcss-rtl for this.