### PR TITLE
Add postcss-deep-scopable

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -334,6 +334,7 @@ loosely resembles the original.
 * [`postcss-uncss`] removes unused CSS from your stylesheets.
 * [`postcss-html-filter`] filters out CSS that does not apply to the HTML you provide.
 * [`postcss-no-important`] delete declarations !important.
+* [`postcss-deep-scopable`] unified deep scoped style postcss plugin for vue
 
 See also plugins in modular minifier [`cssnano`].
 
@@ -830,3 +831,4 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-viewport-height-correction`]:   https://github.com/Faisal-Manzer/postcss-viewport-height-correction
 [`postcss-clamp`]:                        https://github.com/polemius/postcss-clamp
 [`postcss-pseudo-is`]:                    https://github.com/IlyaUpyackovich/postcss-pseudo-is
+[`postcss-deep-scopable`]:                https://github.com/litt1e-p/postcss-deep-scopable


### PR DESCRIPTION
Thanks for your great postcss project and I wrote a unified deep scoped style postcss plugin for vue, which can be used to transfrom those deep selectors in less/scss/sass to unified selector of Vue. I wish it can do some help for Vue users. And this time I add some Input/output examples, Thanks.