### PR TITLE
Support Class Plugins

### DIFF
--- a/lib/lazy-result.js
+++ b/lib/lazy-result.js
@@ -109,15 +109,7 @@ class LazyResult {
     this.result = new Result(processor, root, opts)
     this.helpers = { ...postcss, result: this.result, postcss }
     this.plugins = this.processor.plugins.map(plugin => {
-      if (
-        typeof plugin === 'function' &&
-        plugin.prototype &&
-        plugin.prototype.constructor === plugin &&
-        plugin.postcss === true
-      ) {
-        // eslint-disable-next-line new-cap
-        return new plugin(this.result)
-      } else if (typeof plugin === 'object' && plugin.prepare) {
+      if (typeof plugin === 'object' && plugin.prepare) {
         return { ...plugin, ...plugin.prepare(this.result) }
       } else {
         return plugin

--- a/lib/lazy-result.js
+++ b/lib/lazy-result.js
@@ -109,7 +109,15 @@ class LazyResult {
     this.result = new Result(processor, root, opts)
     this.helpers = { ...postcss, result: this.result, postcss }
     this.plugins = this.processor.plugins.map(plugin => {
-      if (typeof plugin === 'object' && plugin.prepare) {
+      if (
+        typeof plugin === 'function' &&
+        plugin.prototype &&
+        plugin.prototype.constructor === plugin &&
+        plugin.postcss === true
+      ) {
+        // eslint-disable-next-line new-cap
+        return new plugin(this.result)
+      } else if (typeof plugin === 'object' && plugin.prepare) {
         return { ...plugin, ...plugin.prepare(this.result) }
       } else {
         return plugin

--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -93,8 +93,8 @@ export interface PluginClass extends Processors {
   postcssPlugin: string
 }
 
-export interface PluginConstructor {
-  new (opts: any): PluginClass
+export interface PluginConstructor<PluginOptions = any> {
+  new (opts: PluginOptions): PluginClass
   prototype: PluginClass
   postcss: boolean
 }

--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -89,6 +89,16 @@ export interface Plugin extends Processors {
   prepare?: (result: Result) => Processors
 }
 
+export interface PluginClass extends Processors {
+  postcssPlugin: string
+}
+
+export interface PluginConstructor {
+  new (opts: any): PluginClass
+  prototype: PluginClass
+  postcss: boolean
+}
+
 export interface PluginCreator<PluginOptions> {
   (opts?: PluginOptions): Plugin
   postcss: true
@@ -110,6 +120,7 @@ export interface OldPlugin<T> extends Transformer {
 
 export type AcceptedPlugin =
   | Plugin
+  | PluginConstructor
   | PluginCreator<any>
   | OldPlugin<any>
   | TransformCallback

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -36,8 +36,8 @@ class Processor {
   normalize (plugins) {
     let normalized = []
     for (let i of plugins) {
-      if (i.postcss === true) {
-        i = i()
+      if (typeof i === 'function' && i.postcss === true) {
+        if (!i.prototype || i.prototype.constructor !== i) i = i()
       } else if (i.postcss) {
         i = i.postcss
       }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -37,7 +37,9 @@ class Processor {
     let normalized = []
     for (let i of plugins) {
       if (typeof i === 'function' && i.postcss === true) {
-        if (!i.prototype || i.prototype.constructor !== i) i = i()
+        // eslint-disable-next-line new-cap
+        if (i.prototype && i.prototype.constructor === i) i = new i()
+        else i = i()
       } else if (i.postcss) {
         i = i.postcss
       }

--- a/test/visitor.test.ts
+++ b/test/visitor.test.ts
@@ -266,6 +266,35 @@ it('wraps node to proxies', () => {
   expect(props).toEqual(['color'])
 })
 
+it('supports a class plugin', async () => {
+  let didRunConstructor = false
+  let { css } = await postcss([
+    class MyPlugin {
+      constructor () {
+        didRunConstructor = true
+      }
+
+      get postcssPlugin () {
+        return 'do-nothing'
+      }
+
+      Declaration (decl: Declaration) {
+        if (decl.prop === 'color') {
+          decl.value = 'green'
+        }
+      }
+
+      static get postcss () {
+        return true
+      }
+    }
+  ]).process('.a{ color: red; } ' + '.b{ will-change: transform; }', {
+    from: 'a.css'
+  })
+  expect(didRunConstructor).toEqual(true)
+  expect(css).toEqual('.a{ color: green; } ' + '.b{ will-change: transform; }')
+})
+
 const cssThree = '.a{ color: red; } .b{ will-change: transform; }'
 
 const expectedThree =


### PR DESCRIPTION
**WIP**: This is just an idea. I’m unable to see it through right now.

Supporting class functions would allow PostCSS plugins to more easily setup and share data.

Currently, users need to create one or two functions to setup data. New authors will need to familiarize themselves with these patterns specific to PostCSS:

```js
module.exports = opts => ({
  postcssPlugin: "PLUGIN NAME",
  prepare(result) {
    const variables = {}
    return {
      Declaration(node) {
        if (node.variable) variables[node.prop] = node.value
      },
      RootExit() {
        console.log(variables)
      },
    }
  },
})
```

Using classes, the pattern will be more familiar to JavaScripts authors.

```js
module.exports = class PostCSSPlugin {
  constructor(opts, result) {
    this.variables = {}
  }
  get postcssPlugin() {
    return 'PLUGIN NAME'
  }
  Declaration(node) {
    if (node.variable) this.variables[node.prop] = node.value
  }
  RootExit() {
    console.log(this.variables)
  }
}
```

Furthermore, a class pattern would allow plugins to _extend_ one another. For instance, someone could create a plugin that extends visitors to selectors or values.

This PR prevents class functions from throwing an error, and supports them as a kind of visitor, only where the `constructor()` takes the place of an object `prepare()`.

Currently, using a class function throws an unexpected error to do with `i = i()`. This PR happens to resolve that, but it could also be resolved separately.