### PR TITLE
Fix #1419

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -43,7 +43,7 @@ function rebuild (node, parent) {
       fix.nodes = node.nodes.map(j => rebuild(j, fix))
     } else if (i === 'parent' && parent) {
       fix.parent = parent
-    } else if (Object.prototype.hasOwnProperty.call(i)) {
+    } else if (Object.prototype.hasOwnProperty.call(node, i)) {
       fix[i] = node[i]
     }
   }


### PR DESCRIPTION
This conditional was always returning false because it wasn't passed the necessary `this` context, so nodes were being rebuilt with tons of important properties missing.