### PR TITLE
Add missing Transformer type to processor.d.ts

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -94,7 +94,7 @@ export interface PluginCreator<PluginOptions> {
   postcss: true
 }
 
-interface Transformer extends TransformCallback {
+export interface Transformer extends TransformCallback {
   postcssPlugin: string
   postcssVersion: string
 }

--- a/lib/processor.d.ts
+++ b/lib/processor.d.ts
@@ -2,6 +2,7 @@ import {
   AcceptedPlugin,
   Plugin,
   ProcessOptions,
+  Transformer,
   TransformCallback
 } from './postcss.js'
 import LazyResult from './lazy-result.js'


### PR DESCRIPTION
This PR adds the missing `Transformer` import to the `processor.d.ts`. The `processor.d.ts` references the `Transformer` interface for the [`plugins`](https://github.com/postcss/postcss/blob/bdd34bda76baa651550fedb7c07c054abb8256bb/lib/processor.d.ts#L41) field. However, this interface is never imported.

Couple of interesting things about this change:
- VSCode doesn't automatically surfaces this missing `Transformer` type and instead resolves it `Transformer` type exposed by [`lib.dom.d.ts`](https://github.com/microsoft/TypeScript/blob/a960463cf3ae379b670e0e3154445d9392c9b667/lib/lib.dom.d.ts#L1814). Adding `lib: []` to the `tsconfig.json` does make VSCode error out on the missing type.
- I don't understand why `check-dts` has not picked this up. 