### PR TITLE
Fix relative source map path on Windows

### DIFF
--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -189,7 +189,7 @@ class MapGenerator {
   }
 
   toUnixPath (path) {
-	return path.replace(/\\/g, '/')
+    return path.replace(/\\/g, '/')
   }
 
   toUrl (path) {

--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -153,10 +153,10 @@ class MapGenerator {
 
   outputFile () {
     if (this.opts.to) {
-      return this.toUrl(this.path(this.opts.to))
+      return this.toUnixPath(this.path(this.opts.to))
     }
     if (this.opts.from) {
-      return this.toUrl(this.path(this.opts.from))
+      return this.toUnixPath(this.path(this.opts.from))
     }
     return 'to.css'
   }
@@ -188,10 +188,14 @@ class MapGenerator {
     return file
   }
 
+  toUnixPath (path) {
+	return path.replace(/\\/g, '/')
+  }
+
   toUrl (path) {
     if (sep === '\\') {
       // istanbul ignore next
-      path = path.replace(/\\/g, '/')
+      path = this.toUnixPath(path)
     }
     return encodeURI(path).replace(/[#?]/g, encodeURIComponent)
   }

--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -153,10 +153,10 @@ class MapGenerator {
 
   outputFile () {
     if (this.opts.to) {
-      return this.path(this.opts.to)
+      return this.toUrl(this.path(this.opts.to))
     }
     if (this.opts.from) {
-      return this.path(this.opts.from)
+      return this.toUrl(this.path(this.opts.from))
     }
     return 'to.css'
   }


### PR DESCRIPTION
When working with a relative sourcemap path on windows, e.g:

```
..\\file.css
```

PostCSS pases this on to the `source-map` package, which returns

```
..\\\\file.css
```

This fix ensures the relative path gets converted for windows.