### PR TITLE
Code style changes to Deno port

### DIFF
--- a/lib/previous-map.js
+++ b/lib/previous-map.js
@@ -2,7 +2,7 @@
 
 let { dirname, join } = require('path')
 let mozilla = require('source-map')
-let fs = require('fs')
+let { existsSync, readFileSync } = require('fs')
 
 function fromBase64 (str) {
   if (Buffer) {
@@ -86,9 +86,9 @@ class PreviousMap {
 
   loadFile (path) {
     this.root = dirname(path)
-    if (fs.existsSync && fs.existsSync(path)) {
+    if (existsSync(path)) {
       this.mapFile = path
-      return fs.readFileSync(path, 'utf-8').toString().trim()
+      return readFileSync(path, 'utf-8').toString().trim()
     }
   }
 

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -1,5 +1,3 @@
 'use strict'
 
-module.exports = {
-  isClean: Symbol('isClean')
-}
+module.exports.isClean = Symbol('isClean')

--- a/test/css-syntax-error.test.ts
+++ b/test/css-syntax-error.test.ts
@@ -2,7 +2,7 @@ import { red, bold, magenta, yellow, gray, cyan } from 'colorette'
 import { pathToFileURL } from 'url'
 import stripAnsi from 'strip-ansi'
 import Concat from 'concat-with-sourcemaps'
-import path from 'path'
+import { join, resolve as pathResolve } from 'path'
 
 import postcss, {
   ProcessOptions,
@@ -127,25 +127,25 @@ it('misses position without source', () => {
 
 it('uses source map', () => {
   function urlOf (file: string) {
-    return pathToFileURL(path.join(__dirname, file)).toString()
+    return pathToFileURL(join(__dirname, file)).toString()
   }
 
-  let concat = new Concat(true, path.join(__dirname, 'build', 'all.css'))
+  let concat = new Concat(true, join(__dirname, 'build', 'all.css'))
   concat.add(urlOf('a.css'), 'a { }\n')
   concat.add(urlOf('b.css'), '\nb {\n')
 
   let error = parseError(concat.content.toString(), {
-    from: path.join(__dirname, 'build', 'all.css'),
+    from: join(__dirname, 'build', 'all.css'),
     map: { prev: concat.sourceMap }
   })
 
-  expect(error.file).toEqual(path.join(__dirname, 'b.css'))
+  expect(error.file).toEqual(join(__dirname, 'b.css'))
   expect(error.line).toEqual(2)
   expect(error.source).not.toBeDefined()
 
   expect(error.input).toEqual({
-    url: urlOf(path.join('build', 'all.css')),
-    file: path.join(__dirname, 'build', 'all.css'),
+    url: urlOf(join('build', 'all.css')),
+    file: join(__dirname, 'build', 'all.css'),
     line: 3,
     column: 1,
     source: 'a { }\n\nb {\n'
@@ -154,25 +154,25 @@ it('uses source map', () => {
 
 it('works with path in sources', () => {
   function pathOf (file: string) {
-    return path.join(__dirname, file)
+    return join(__dirname, file)
   }
 
-  let concat = new Concat(true, path.join(__dirname, 'build', 'all.css'))
+  let concat = new Concat(true, join(__dirname, 'build', 'all.css'))
   concat.add(pathOf('a.css'), 'a { }\n')
   concat.add(pathOf('b.css'), '\nb {\n')
 
   let error = parseError(concat.content.toString(), {
-    from: path.join(__dirname, 'build', 'all.css'),
+    from: join(__dirname, 'build', 'all.css'),
     map: { prev: concat.sourceMap }
   })
 
-  expect(error.file).toEqual(path.join(__dirname, 'b.css'))
+  expect(error.file).toEqual(join(__dirname, 'b.css'))
   expect(error.line).toEqual(2)
   expect(error.source).not.toBeDefined()
 
   expect(error.input).toEqual({
-    url: pathToFileURL(pathOf(path.join('build', 'all.css'))).toString(),
-    file: path.join(__dirname, 'build', 'all.css'),
+    url: pathToFileURL(pathOf(join('build', 'all.css'))).toString(),
+    file: join(__dirname, 'build', 'all.css'),
     line: 3,
     column: 1,
     source: 'a { }\n\nb {\n'
@@ -204,7 +204,7 @@ it('does not uses wrong source map', () => {
       }
     }
   })
-  expect(error.file).toEqual(path.resolve('build/all.css'))
+  expect(error.file).toEqual(pathResolve('build/all.css'))
 })
 
 it('set source plugin', () => {

--- a/test/processor.test.ts
+++ b/test/processor.test.ts
@@ -1,4 +1,4 @@
-import path from 'path'
+import { resolve as pathResolve } from 'path'
 
 import postcss, { Plugin, Result, Node, Root, parse } from '../lib/postcss.js'
 import LazyResult from '../lib/lazy-result.js'
@@ -137,7 +137,7 @@ it('throws with file name', () => {
     }
   }
 
-  expect(error.file).toEqual(path.resolve('a.css'))
+  expect(error.file).toEqual(pathResolve('a.css'))
   expect(error.message).toMatch(/a.css:1:1: Unclosed block$/)
 })
 


### PR DESCRIPTION
Related with https://github.com/postcss/postcss/issues/1430#issuecomment-701043034

I've added some changes in the way that some modules are imported, to ease the automatic transformation to Deno that I'm doing here: https://github.com/oscarotero/postcss-deno
