### PR TITLE
Fix CommentRaws interface right type

### DIFF
--- a/lib/comment.d.ts
+++ b/lib/comment.d.ts
@@ -14,7 +14,7 @@ interface CommentRaws {
   /**
    * The space symbols between the comment’s text.
    */
-  right?: boolean
+  right?: string
 }
 
 export interface CommentProps extends NodeProps {


### PR DESCRIPTION
I believe `right` of the CommentRaws interface should be of type `string` instead of `boolean` 