### PR TITLE
Add support for Deno

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           ref: master
           path: postcss
-
+      
       - name: Convert the code
         run: |
           rm -rf deno
@@ -36,7 +36,11 @@ jobs:
           cp postcss/LICENSE deno/
 
           deno test --unstable --allow-read deno/test/*
-      
+
+      - name: Get the tag name
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
       - name: Commit the changes and create the tag
         run: |
           git config user.name deno-conversion
@@ -44,5 +48,5 @@ jobs:
           git add deno
           git commit -m "update code"
           git push
-          git tag deno/${{ github.event.release.tag_name }}
+          git tag deno/${{ steps.get_version.outputs.VERSION }}
           git push --tags

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -37,6 +37,7 @@ jobs:
           deno test --unstable --allow-read deno/test/*
       
       - name: Commit the changes
+        run: |
           git add deno
           git commit -m "update code"
           git push

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -19,13 +19,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: postcss/postcss-deno
-      
+          token: ${{ secrets.GitHub_PAT }}
+
       - name: Checkout postcss
         uses: actions/checkout@v2
         with:
           ref: master
           path: postcss
-      
+
       - name: Convert the code
         run: |
           rm -rf deno

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,37 @@
+name: Deno
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout postcss (deno)
+        uses: actions/checkout@v2
+        with:
+          ref: deno
+
+      - name: Setup Deno environment
+        uses: denolib/setup-deno@v2.2.0
+        with:
+          deno-version: v1.x
+      
+      - name: Checkout postcss (master)
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          path: postcss
+
+      - name: Convert the code
+        run: |
+          rm -rf deno
+          deno run --unstable --allow-write --allow-read to_deno.js
+          deno fmt deno
+          cp postcss/README.md deno/
+          cp postcss/CHANGELOG.md deno/
+          cp postcss/LICENSE deno/
+
+          deno test --unstable --allow-read deno/test/*

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -35,3 +35,9 @@ jobs:
           cp postcss/LICENSE deno/
 
           deno test --unstable --allow-read deno/test/*
+      
+      - name: Commit the changes
+          git add deno
+          git commit -m "update code"
+          git push
+

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: postcss/postcss-deno
-          token: ${{ secrets.GitHub_PAT }}
+          token: ${{ secrets.PAT }}
 
       - name: Checkout postcss
         uses: actions/checkout@v2

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,8 +1,9 @@
 name: Deno
 
 on:
-  create:
-    tags
+  push:
+    tags:
+      - "8.*"
 
 jobs:
   build:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,8 +1,8 @@
 name: Deno
 
 on:
-  push:
-    branches: [ master ]
+  create:
+    tags
 
 jobs:
   build:
@@ -36,10 +36,12 @@ jobs:
 
           deno test --unstable --allow-read deno/test/*
       
-      - name: Commit the changes
+      - name: Commit the changes and create the tag
         run: |
           git config user.name deno-conversion
           git config user.email github-actions@github.com
           git add deno
           git commit -m "update code"
           git push
+          git tag deno/${{ github.ref }}
+          git push --tags

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout postcss (deno)
-        uses: actions/checkout@v2
-        with:
-          ref: deno
-
       - name: Setup Deno environment
         uses: denolib/setup-deno@v2.2.0
         with:
           deno-version: v1.x
+
+      - name: Checkout postcss-deno
+        uses: actions/checkout@v2
+        with:
+          repository: postcss/postcss-deno
       
-      - name: Checkout postcss (master)
+      - name: Checkout postcss
         uses: actions/checkout@v2
         with:
           ref: master
@@ -48,5 +48,5 @@ jobs:
           git add deno
           git commit -m "update code"
           git push
-          git tag deno/${{ steps.get_version.outputs.VERSION }}
+          git tag ${{ steps.get_version.outputs.VERSION }}
           git push --tags

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -38,7 +38,8 @@ jobs:
       
       - name: Commit the changes
         run: |
+          git config user.name deno-conversion
+          git config user.email github-actions@github.com
           git add deno
           git commit -m "update code"
           git push
-

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -44,5 +44,5 @@ jobs:
           git add deno
           git commit -m "update code"
           git push
-          git tag deno/${{ github.ref }}
+          git tag deno/${{ github.event.release.tag_name }}
           git push --tags

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ prefixer({ display: 'flex' }) //=> { display: ['-webkit-box', '-webkit-flex', '-
 
 ### Deno
 
-PostCSS supports [Deno], the new JavaScript/TypeScript runtime.
+PostCSS also supports [Deno], the new JavaScript/TypeScript runtime.
 
 ```js
 import postcss from "https://deno.land/x/postcss/mod.js";

--- a/README.md
+++ b/README.md
@@ -369,6 +369,19 @@ prefixer({ display: 'flex' }) //=> { display: ['-webkit-box', '-webkit-flex', '-
 [webpack]:      https://webpack.github.io/
 
 
+### Deno
+
+PostCSS has support for [Deno], the new JavaScript/TypeScript runtime:
+
+```js
+import postcss from "https://deno.land/x/postcss/mod.js";
+import autoprefixer from "https://dev.jspm.io/autoprefixer";
+
+const result = await postcss([autoprefixer]).process(css);
+```
+
+[Deno]: https://deno.land/
+
 ### Runners
 
 * **Grunt**: [`@lodder/grunt-postcss`](https://github.com/C-Lodder/grunt-postcss)

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ prefixer({ display: 'flex' }) //=> { display: ['-webkit-box', '-webkit-flex', '-
 
 ### Deno
 
-PostCSS also supports [Deno], the new JavaScript/TypeScript runtime.
+PostCSS supports [Deno], the new JavaScript/TypeScript runtime.
 
 ```js
 import postcss from "https://deno.land/x/postcss/mod.js";

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ prefixer({ display: 'flex' }) //=> { display: ['-webkit-box', '-webkit-flex', '-
 
 ### Deno
 
-PostCSS has support for [Deno], the new JavaScript/TypeScript runtime:
+PostCSS has support for [Deno], the new JavaScript/TypeScript runtime.
 
 ```js
 import postcss from "https://deno.land/x/postcss/mod.js";

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ prefixer({ display: 'flex' }) //=> { display: ['-webkit-box', '-webkit-flex', '-
 
 ### Deno
 
-PostCSS has support for [Deno], the new JavaScript/TypeScript runtime.
+PostCSS supports [Deno], the new JavaScript/TypeScript runtime.
 
 ```js
 import postcss from "https://deno.land/x/postcss/mod.js";


### PR DESCRIPTION
Related #1430 

I've created the new repository [postcss-deno](https://github.com/postcss/postcss-deno) containing a script to get the postcss code and transform to javascript compatible with Deno.

This PR add a github action that is runned after creating new tags, so it will update automatically the code in the postcss-deno repository and create the same tag there.

The only requirement is a secret variable with a [PAT](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) that have writting access to postcss-deno repository in order to commit the changes and create the new tag. So, after merging this PR, you have to:

- Go to Settings > Secrets of this repository
- Click in "New Secret"
- The secret name is `PAT`, and the value the access token

That's all.