### PR TITLE
Add missing "comment" export in types + reorder

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -409,8 +409,10 @@ export interface Postcss {
 }
 
 export const stringify: Stringifier
-export const atRule: Postcss['atRule']
 export const parse: Parser
+
+export const comment: Postcss['comment']
+export const atRule: Postcss['atRule']
 export const decl: Postcss['decl']
 export const rule: Postcss['rule']
 export const root: Postcss['root']


### PR DESCRIPTION
Hello, I noticed "comment" was missing from the types when trying to `import { comment } from "postcss";`.
This PR adds the missing type and reorders the types to match the javascript file.