### PR TITLE
Fix deprecated folder mapping "./" in the "exports" field module reso…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       "import": "./lib/postcss.mjs",
       "types": "./lib/postcss.d.ts"
     },
-    "./": "./"
+    "./*": "./*"
   },
   "main": "./lib/postcss.js",
   "types": "./lib/postcss.d.ts",


### PR DESCRIPTION
…lution

NodeJS v15.1.0

(node:19936) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at D:\0\node_modules\postcss\package.json.
Update this package.json to use a subpath pattern like "./*".
(Use `node --trace-deprecation ...` to show where the warning was created)

Closes #1455 