### PR TITLE
Fix usage of default exports with TypeScript

### DIFF
--- a/lib/at-rule.js
+++ b/lib/at-rule.js
@@ -20,5 +20,6 @@ class AtRule extends Container {
 }
 
 module.exports = AtRule
+AtRule.default = AtRule
 
 Container.registerAtRule(AtRule)

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -10,3 +10,4 @@ class Comment extends Node {
 }
 
 module.exports = Comment
+Comment.default = Comment

--- a/lib/container.js
+++ b/lib/container.js
@@ -426,3 +426,4 @@ Container.registerAtRule = dependant => {
 }
 
 module.exports = Container
+Container.default = Container

--- a/lib/css-syntax-error.js
+++ b/lib/css-syntax-error.js
@@ -89,3 +89,4 @@ class CssSyntaxError extends Error {
 }
 
 module.exports = CssSyntaxError
+CssSyntaxError.default = CssSyntaxError

--- a/lib/declaration.js
+++ b/lib/declaration.js
@@ -21,3 +21,4 @@ class Declaration extends Node {
 }
 
 module.exports = Declaration
+Declaration.default = Declaration

--- a/lib/input.js
+++ b/lib/input.js
@@ -139,6 +139,7 @@ class Input {
 }
 
 module.exports = Input
+Input.default = Input
 
 if (terminalHighlight && terminalHighlight.registerInput) {
   terminalHighlight.registerInput(Input)

--- a/lib/lazy-result.js
+++ b/lib/lazy-result.js
@@ -475,5 +475,6 @@ LazyResult.registerPostcss = dependant => {
 }
 
 module.exports = LazyResult
+LazyResult.default = LazyResult
 
 Root.registerLazyResult(LazyResult)

--- a/lib/list.js
+++ b/lib/list.js
@@ -53,3 +53,4 @@ let list = {
 }
 
 module.exports = list
+list.default = list

--- a/lib/node.js
+++ b/lib/node.js
@@ -288,3 +288,4 @@ class Node {
 }
 
 module.exports = Node
+Node.default = Node

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -37,5 +37,6 @@ function parse (css, opts) {
 }
 
 module.exports = parse
+parse.default = parse
 
 Container.registerParse(parse)

--- a/lib/postcss.js
+++ b/lib/postcss.js
@@ -85,3 +85,4 @@ postcss.Node = Node
 LazyResult.registerPostcss(postcss)
 
 module.exports = postcss
+postcss.default = postcss

--- a/lib/previous-map.js
+++ b/lib/previous-map.js
@@ -140,3 +140,4 @@ class PreviousMap {
 }
 
 module.exports = PreviousMap
+PreviousMap.default = PreviousMap

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -65,5 +65,6 @@ class Processor {
 }
 
 module.exports = Processor
+Processor.default = Processor
 
 Root.registerProcessor(Processor)

--- a/lib/result.js
+++ b/lib/result.js
@@ -39,3 +39,4 @@ class Result {
 }
 
 module.exports = Result
+Result.default = Result

--- a/lib/root.js
+++ b/lib/root.js
@@ -56,3 +56,4 @@ Root.registerProcessor = dependant => {
 }
 
 module.exports = Root
+Root.default = Root

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -22,5 +22,6 @@ class Rule extends Container {
 }
 
 module.exports = Rule
+Rule.default = Rule
 
 Container.registerRule(Rule)

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -2,7 +2,10 @@
 
 let Stringifier = require('./stringifier')
 
-module.exports = function stringify (node, builder) {
+function stringify (node, builder) {
   let str = new Stringifier(builder)
   str.stringify(node)
 }
+
+module.exports = stringify
+stringify.default = stringify

--- a/lib/warning.js
+++ b/lib/warning.js
@@ -32,3 +32,4 @@ class Warning {
 }
 
 module.exports = Warning
+Warning.default = Warning

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "allowJs": true,
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "esModuleInterop": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "allowJs": true,
     "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true
+    "noEmit": true
   }
 }


### PR DESCRIPTION
This is done by assigning the property `default` for all properties that are exported using `export default` according to their type definitions.

Closes #1424