### PR TITLE
Update package.json to fix deprecation of "./"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       "import": "./lib/postcss.mjs",
       "types": "./lib/postcss.d.ts"
     },
-    "./": "./"
+    "./*": "./*"
   },
   "main": "./lib/postcss.js",
   "types": "./lib/postcss.d.ts",


### PR DESCRIPTION
When executing 'ng build --prod' on Angular: 
Generating browser application bundles (phase: building)...(node:1188) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at {{PROYECT_PATH}}\node_modules\css-loader\node_modules\postcss\package.json.
Update this package.json to use a subpath pattern like "./*".
(Use `node --trace-deprecation ...` to show where the warning was created)