### PR TITLE
fix(typescript): ensure LazyResult complies with Promise interface.

### DIFF
--- a/lib/lazy-result.d.ts
+++ b/lib/lazy-result.d.ts
@@ -13,7 +13,7 @@ import Root from './root.js'
  * const lazy = postcss([autoprefixer]).process(css)
  * ```
  */
-export default class LazyResult {
+export default class LazyResult implements Promise<Result> {
   /**
    * Processes input CSS through synchronous and asynchronous plugins
    * and calls `onFulfilled` with a Result instance. If a plugin throws
@@ -65,6 +65,12 @@ export default class LazyResult {
    * @param opts      Options from the `Processor#process` or `Root#toResult`.
    */
   constructor (processor: Processor, css: string, opts: ResultOptions)
+
+  /**
+   * Returns the default string description of an object.
+   * Required to implement the Promise interface.
+   */
+  get [Symbol.toStringTag] (): string
 
   /**
    * Returns a `Processor` instance, which will be used

--- a/lib/lazy-result.js
+++ b/lib/lazy-result.js
@@ -114,6 +114,10 @@ class LazyResult {
     })
   }
 
+  get [Symbol.toStringTag] () {
+    return 'LazyResult'
+  }
+
   get processor () {
     return this.result.processor
   }

--- a/test/lazy-result.test.ts
+++ b/test/lazy-result.test.ts
@@ -57,3 +57,8 @@ it('executes on finally callback', () => {
     .finally(mockCallback)
     .then(() => expect(mockCallback).toHaveBeenCalledTimes(1))
 })
+
+it('prints its object type', () => {
+  let result = new LazyResult(processor, 'a {}', {})
+  expect(Object.prototype.toString.call(result)).toEqual('[object LazyResult]')
+})

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,4 +1,4 @@
-import { PluginCreator } from '../lib/postcss.js'
+import postcss, { Result, PluginCreator, SourceMap } from '../lib/postcss.js'
 
 const plugin: PluginCreator<string> = prop => {
   return {
@@ -13,5 +13,20 @@ const plugin: PluginCreator<string> = prop => {
 }
 
 plugin.postcss = true
+
+interface StyleCompileResults {
+  code: string
+  map: SourceMap | undefined
+}
+
+const processResult: Promise<Result> | Result = postcss([
+  plugin
+]).process('h1{color: black;}', { from: undefined })
+const processed:
+  | StyleCompileResults
+  | Promise<StyleCompileResults> = processResult.then(result => ({
+  code: result.css,
+  map: result.map
+}))
 
 export default plugin


### PR DESCRIPTION
Hi, following our Gitter chat yesterday, I've learnt `LazyResult` was meant to implement the `Promise` contract.  This pull request adds the [[Symbol.toStringTag] property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) to `LazyResult` which Typescript requires to type something as a `Promise`. 

* Explicitly implement Promise<Result> in the type declaration
* Add mising [Symbol.toStringTag] property
* Add some type tests to ensure we can type `postcss(plugins).process` results