### PR TITLE
Mark getters as readonly

### DIFF
--- a/lib/container.d.ts
+++ b/lib/container.d.ts
@@ -47,7 +47,7 @@ export default abstract class Container extends Node {
    * rule.first === rules.nodes[0]
    * ```
    */
-  get first (): ChildNode | undefined
+  readonly first: ChildNode | undefined
 
   /**
    * The container’s last child.
@@ -56,7 +56,7 @@ export default abstract class Container extends Node {
    * rule.last === rule.nodes[rule.nodes.length - 1]
    * ```
    */
-  get last (): ChildNode | undefined
+  readonly last: ChildNode | undefined
 
   /**
    * Iterates through the container’s immediate children,

--- a/lib/input.d.ts
+++ b/lib/input.d.ts
@@ -103,7 +103,7 @@ export default class Input {
    * root.source.input.from //=> "<input css 1>"
    * ```
    */
-  get from (): string
+  readonly from: string
 
   /**
    * Reads the input source map and returns a symbol position

--- a/lib/lazy-result.d.ts
+++ b/lib/lazy-result.d.ts
@@ -70,18 +70,18 @@ export default class LazyResult implements Promise<Result> {
    * Returns the default string description of an object.
    * Required to implement the Promise interface.
    */
-  get [Symbol.toStringTag] (): string
+  readonly [Symbol.toStringTag]: string
 
   /**
    * Returns a `Processor` instance, which will be used
    * for CSS transformations.
    */
-  get processor (): Processor
+  readonly processor: Processor
 
   /**
    * Options from the `Processor#process` call.
    */
-  get opts (): ResultOptions
+  readonly opts: ResultOptions
 
   /**
    * Processes input CSS through synchronous plugins, converts `Root`
@@ -92,7 +92,7 @@ export default class LazyResult implements Promise<Result> {
    * it will throw an error. This is why this method is only
    * for debug purpose, you should always use `LazyResult#then`.
    */
-  get css (): string
+  readonly css: string
 
   /**
    * An alias for the `css` property. Use it with syntaxes
@@ -103,7 +103,7 @@ export default class LazyResult implements Promise<Result> {
    * it will throw an error. This is why this method is only
    * for debug purpose, you should always use `LazyResult#then`.
    */
-  get content (): string
+  readonly content: string
 
   /**
    * Processes input CSS through synchronous plugins
@@ -114,7 +114,7 @@ export default class LazyResult implements Promise<Result> {
    * it will throw an error. This is why this method is only
    * for debug purpose, you should always use `LazyResult#then`.
    */
-  get map (): SourceMap
+  readonly map: SourceMap
 
   /**
    * Processes input CSS through synchronous plugins
@@ -126,7 +126,7 @@ export default class LazyResult implements Promise<Result> {
    * This is why this method is only for debug purpose,
    * you should always use `LazyResult#then`.
    */
-  get root (): Root
+  readonly root: Root
 
   /**
    * Processes input CSS through synchronous plugins
@@ -138,7 +138,7 @@ export default class LazyResult implements Promise<Result> {
    * This is why this method is only for debug purpose,
    * you should always use `LazyResult#then`.
    */
-  get messages (): Message[]
+  readonly messages: Message[]
 
   /**
    * Processes input CSS through synchronous plugins

--- a/lib/result.d.ts
+++ b/lib/result.d.ts
@@ -151,7 +151,7 @@ export default class Result {
    * result.css === result.content
    * ```
    */
-  get content (): string
+  readonly content: string
 
   /**
    * Returns for `Result#css` content.


### PR DESCRIPTION
As I understand, all these properties should be treated as `readonly`. This stricter modifier ensures proper typechecking.

Furthermore, this seems to be a required change to fix [my PR on @types/autoprefixer](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49166). See [this comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49166#issuecomment-718236687); those errors can be fixed by incorporating these changes in `postcss`.