### PR TITLE
Improve LazyResult type

### DIFF
--- a/lib/lazy-result.d.ts
+++ b/lib/lazy-result.d.ts
@@ -13,7 +13,7 @@ import Root from './root.js'
  * const lazy = postcss([autoprefixer]).process(css)
  * ```
  */
-export default class LazyResult implements Promise<Result> {
+export default class LazyResult implements PromiseLike<Result> {
   /**
    * Processes input CSS through synchronous and asynchronous plugins
    * and calls `onFulfilled` with a Result instance. If a plugin throws


### PR DESCRIPTION
This change is motivated by the ability to patch `Promise` prototype globally in both code and types. This change helps to avoid such behavior.

Though I think monkey patching prototypes is a terrible practice one cannot alway control the code of all their dependencies or the platform that is being developed on top of. Hopefully this change can help to ease the pain of working with such things.