### PR TITLE
Proposal: change plugin creator type to allow returning a processor.

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -170,7 +170,7 @@ export interface Plugin extends Processors {
 }
 
 export interface PluginCreator<PluginOptions> {
-  (opts?: PluginOptions): Plugin
+  (opts?: PluginOptions): Plugin | Processor
   postcss: true
 }
 

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -1,4 +1,4 @@
-import postcss, { Root } from '../lib/postcss.js'
+import postcss, { Root, PluginCreator } from '../lib/postcss.js'
 import Processor from '../lib/processor.js'
 
 afterEach(() => {
@@ -28,6 +28,16 @@ it('takes plugin from other processor', () => {
   let b = () => {}
   let c = () => {}
   let other = postcss([a, b])
+  expect(postcss([other, c]).plugins).toEqual([a, b, c])
+})
+
+it('takes plugins from a a plugin returning a processor', () => {
+  let a = () => {}
+  let b = () => {}
+  let c = () => {}
+  let other = postcss([a, b])
+  let meta = (() => other) as PluginCreator<void>
+  meta.postcss = true
   expect(postcss([other, c]).plugins).toEqual([a, b, c])
 })
 

--- a/test/processor.test.ts
+++ b/test/processor.test.ts
@@ -1,6 +1,13 @@
 import { resolve as pathResolve } from 'path'
 
-import postcss, { Plugin, Result, Node, Root, parse } from '../lib/postcss.js'
+import postcss, {
+  Plugin,
+  Result,
+  Node,
+  Root,
+  parse,
+  PluginCreator
+} from '../lib/postcss.js'
 import LazyResult from '../lib/lazy-result.js'
 import Processor from '../lib/processor.js'
 
@@ -525,6 +532,17 @@ it('supports plugins returning processors', () => {
   let other: any = (postcss as any).plugin('test', () => {
     return new Processor([a])
   })
+  processor.use(other)
+  expect(processor.plugins).toEqual([a])
+})
+
+it('supports plugin creators returning processors', () => {
+  let a = () => {}
+  let processor = new Processor()
+  let other = (() => {
+    return new Processor([a])
+  }) as PluginCreator<void>
+  other.postcss = true
   processor.use(other)
   expect(processor.plugins).toEqual([a])
 })


### PR DESCRIPTION
Returning a a `Processor` instance from a plugin creator (function with `postcss = true`) already works in practice, and was supported with PostCSS 7 plugins, but TypeScript types do not allow it. This updates the types and adds a test. 

### Use case
Support 'plugins of plugins' like cssnano (https://github.com/cssnano/cssnano/pull/961) or postcss-modules. These 'meta-plugins' take some options, build a list of plugins, create a `Processor` and run `process()` over the AST. The issue is that in PostCSS 8, this does not notify visitor plugins, forcing these 'meta-plugins' to run as `OnceExit`. This pull request would allow to return a `Processor` instance instead of calling `process()` inside the 'meta-plugin'.

### Alternatives
1. Keep using `OnceExit()` with a separate `process()`. This means 'meta-plugins' and all plugins inside of them could never share the same tree as other plugins.
2. Instead of returning a `Processor`, allow returning any object with a `plugins` field. This would require to recursively call `normalize()` on the plugins arrays in the `Processor` constructor to initialize the plugins. I think it's better to let the meta-plugins take care of all initialization of their own plugins.
2. Do not expose meta-plugins as postcss plugins at all. Instead, force users to call a function that returns a plugin array or a Processor. In a sense I feel it would be better as it would remove a layer of abstaction, but on the other hand it makes configuring the PostCSS instance more complicated, and introduces a breaking change.