### PR TITLE
stop adding newline before sourceMappingURL

### DIFF
--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -145,10 +145,7 @@ class MapGenerator {
       content = this.outputFile() + '.map'
     }
 
-    let eol = '\n'
-    if (this.css.includes('\r\n')) eol = '\r\n'
-
-    this.css += eol + '/*# sourceMappingURL=' + content + ' */'
+    this.css += '/*# sourceMappingURL=' + content + ' */'
   }
 
   outputFile () {


### PR DESCRIPTION
solve issue https://github.com/sveltejs/svelte-preprocess/issues/286

adding the newline breaks line numers, when the style is injected into a html document

since its only eye-candy, with zero function, i simply removed it
