### PR TITLE
Fixup JSON AST conversion

### DIFF
--- a/lib/fromJSON.js
+++ b/lib/fromJSON.js
@@ -9,23 +9,30 @@ let Root = require('./root')
 let Rule = require('./rule')
 
 function fromJSON (json, inputs) {
-  let { _inputs, ...defaults } = json
-  inputs = _inputs || inputs
+  let { inputs: ownInputs, ...defaults } = json
+  if (ownInputs) {
+    inputs = []
+    for (let input of ownInputs) {
+      let inputHydrated = { ...input }
+      if (inputHydrated.map) {
+        inputHydrated.map = {
+          ...inputHydrated.map,
+          __proto__: PreviousMap.prototype
+        }
+      }
+      inputs.push(inputHydrated)
+    }
+  }
   if (defaults.nodes) {
     defaults.nodes = json.nodes.map(n => fromJSON(n, inputs))
   }
   if (defaults.source) {
-    defaults.source = { ...defaults.source }
-    if (defaults.source.input != null) {
+    let { inputId, ...source } = defaults.source
+    defaults.source = source
+    if (inputId != null) {
       defaults.source.input = {
-        ...inputs[defaults.source.input],
+        ...inputs[inputId],
         __proto__: Input.prototype
-      }
-      if (defaults.source.input.map) {
-        defaults.source.input.map = {
-          ...defaults.source.input.map,
-          __proto__: PreviousMap.prototype
-        }
       }
     }
   }

--- a/lib/fromJSON.js
+++ b/lib/fromJSON.js
@@ -13,7 +13,7 @@ function fromJSON (json, inputs) {
   if (ownInputs) {
     inputs = []
     for (let input of ownInputs) {
-      let inputHydrated = { ...input }
+      let inputHydrated = { ...input, __proto__: Input.prototype }
       if (inputHydrated.map) {
         inputHydrated.map = {
           ...inputHydrated.map,
@@ -30,10 +30,7 @@ function fromJSON (json, inputs) {
     let { inputId, ...source } = defaults.source
     defaults.source = source
     if (inputId != null) {
-      defaults.source.input = {
-        ...inputs[inputId],
-        __proto__: Input.prototype
-      }
+      defaults.source.input = inputs[inputId]
     }
   }
   if (defaults.type === 'root') {

--- a/lib/fromJSON.js
+++ b/lib/fromJSON.js
@@ -8,16 +8,17 @@ let Input = require('./input')
 let Root = require('./root')
 let Rule = require('./rule')
 
-function fromJSON (json) {
-  let defaults = { ...json }
-  if (json.nodes) {
-    defaults.nodes = json.nodes.map(i => fromJSON(i))
+function fromJSON (json, inputs) {
+  let { _inputs, ...defaults } = json
+  inputs = _inputs || inputs
+  if (defaults.nodes) {
+    defaults.nodes = json.nodes.map(n => fromJSON(n, inputs))
   }
   if (defaults.source) {
     defaults.source = { ...defaults.source }
-    if (defaults.source.input) {
+    if (defaults.source.input != null) {
       defaults.source.input = {
-        ...defaults.source.input,
+        ...inputs[defaults.source.input],
         __proto__: Input.prototype
       }
       if (defaults.source.input.map) {
@@ -28,15 +29,15 @@ function fromJSON (json) {
       }
     }
   }
-  if (json.type === 'root') {
+  if (defaults.type === 'root') {
     return new Root(defaults)
-  } else if (json.type === 'decl') {
+  } else if (defaults.type === 'decl') {
     return new Declaration(defaults)
-  } else if (json.type === 'rule') {
+  } else if (defaults.type === 'rule') {
     return new Rule(defaults)
-  } else if (json.type === 'comment') {
+  } else if (defaults.type === 'comment') {
     return new Comment(defaults)
-  } else if (json.type === 'atrule') {
+  } else if (defaults.type === 'atrule') {
     return new AtRule(defaults)
   } else {
     throw new Error('Unknown node type: ' + json.type)

--- a/lib/fromJSON.js
+++ b/lib/fromJSON.js
@@ -13,22 +13,22 @@ function fromJSON (json) {
   if (json.nodes) {
     defaults.nodes = json.nodes.map(i => fromJSON(i))
   }
-  if (json.type === 'root') {
-    if (defaults.source) {
-      defaults.source = { ...defaults.source }
-      if (defaults.source.input) {
-        defaults.source.input = {
-          ...defaults.source.input,
-          __proto__: Input.prototype
-        }
-        if (defaults.source.input.map) {
-          defaults.source.input.map = {
-            ...defaults.source.input.map,
-            __proto__: PreviousMap.prototype
-          }
+  if (defaults.source) {
+    defaults.source = { ...defaults.source }
+    if (defaults.source.input) {
+      defaults.source.input = {
+        ...defaults.source.input,
+        __proto__: Input.prototype
+      }
+      if (defaults.source.input.map) {
+        defaults.source.input.map = {
+          ...defaults.source.input.map,
+          __proto__: PreviousMap.prototype
         }
       }
     }
+  }
+  if (json.type === 'root') {
     return new Root(defaults)
   } else if (json.type === 'decl') {
     return new Declaration(defaults)

--- a/lib/node.js
+++ b/lib/node.js
@@ -199,7 +199,8 @@ class Node {
         }
         fixed[name] = {
           inputId,
-          start: value.start
+          start: value.start,
+          end: value.end
         }
       } else {
         fixed[name] = value

--- a/lib/node.js
+++ b/lib/node.js
@@ -187,7 +187,7 @@ class Node {
         })
       } else if (typeof value === 'object' && value.toJSON) {
         fixed[name] = value.toJSON()
-      } else if (this.type === 'root' && name === 'source') {
+      } else if (name === 'source') {
         fixed[name] = {
           input: value.input.toJSON(),
           start: value.start

--- a/lib/node.js
+++ b/lib/node.js
@@ -191,14 +191,14 @@ class Node {
       } else if (typeof value === 'object' && value.toJSON) {
         fixed[name] = value.toJSON(inputs)
       } else if (name === 'source') {
-        let input = inputs.get(value.input)
-        if (input == null) {
-          input = inputsNextIndex
+        let inputId = inputs.get(value.input)
+        if (inputId == null) {
+          inputId = inputsNextIndex
           inputs.set(value.input, inputsNextIndex)
           inputsNextIndex++
         }
         fixed[name] = {
-          input,
+          inputId,
           start: value.start
         }
       } else {
@@ -207,7 +207,7 @@ class Node {
     }
 
     if (emitInputs) {
-      fixed._inputs = [...inputs.keys()].map(input => input.toJSON())
+      fixed.inputs = [...inputs.keys()].map(input => input.toJSON())
     }
 
     return fixed

--- a/lib/node.js
+++ b/lib/node.js
@@ -166,8 +166,11 @@ class Node {
     if (!keepBetween) delete this.raws.between
   }
 
-  toJSON () {
+  toJSON (inputs) {
     let fixed = {}
+    let emitInputs = inputs == null
+    inputs = inputs || new Map()
+    let inputsNextIndex = 0
 
     for (let name in this) {
       if (!Object.prototype.hasOwnProperty.call(this, name)) {
@@ -180,21 +183,31 @@ class Node {
       if (Array.isArray(value)) {
         fixed[name] = value.map(i => {
           if (typeof i === 'object' && i.toJSON) {
-            return i.toJSON()
+            return i.toJSON(inputs)
           } else {
             return i
           }
         })
       } else if (typeof value === 'object' && value.toJSON) {
-        fixed[name] = value.toJSON()
+        fixed[name] = value.toJSON(inputs)
       } else if (name === 'source') {
+        let input = inputs.get(value.input)
+        if (input == null) {
+          input = inputsNextIndex
+          inputs.set(value.input, inputsNextIndex)
+          inputsNextIndex++
+        }
         fixed[name] = {
-          input: value.input.toJSON(),
+          input,
           start: value.start
         }
       } else {
         fixed[name] = value
       }
+    }
+
+    if (emitInputs) {
+      fixed._inputs = [...inputs.keys()].map(input => input.toJSON())
     }
 
     return fixed

--- a/test/fromJSON.test.ts
+++ b/test/fromJSON.test.ts
@@ -6,7 +6,7 @@ it('rehydrates a JSON AST', () => {
   let cssWithMap = postcss().process(
     '.foo { color: red; font-size: 12pt; } /* abc */ @media (width: 60em) { }',
     {
-      from: undefined,
+      from: 'x.css',
       map: {
         inline: true
       },
@@ -24,6 +24,17 @@ it('rehydrates a JSON AST', () => {
   rehydrated.nodes[0].remove()
 
   expect(rehydrated.nodes).toHaveLength(3)
+
+  expect(
+    postcss().process(rehydrated, {
+      from: undefined,
+      map: {
+        inline: true
+      },
+      stringifier: postcss.stringify
+    }).css
+  ).toBe(`/* abc */ @media (width: 60em) { }
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInguY3NzIiwiPG5vIHNvdXJjZT4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQXNDLFNDQXRDLENEQWdELHdCQ0FoRCIsImZpbGUiOiJ0by5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyIuZm9vIHsgY29sb3I6IHJlZDsgZm9udC1zaXplOiAxMnB0OyB9IC8qIGFiYyAqLyBAbWVkaWEgKHdpZHRoOiA2MGVtKSB7IH0iLG51bGxdfQ== */`)
 })
 
 it('throws when rehydrating an invalid JSON AST', () => {

--- a/test/fromJSON.test.ts
+++ b/test/fromJSON.test.ts
@@ -34,7 +34,7 @@ it('rehydrates a JSON AST', () => {
       stringifier: postcss.stringify
     }).css
   ).toBe(`/* abc */ @media (width: 60em) { }
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInguY3NzIiwiPG5vIHNvdXJjZT4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQXNDLFNDQXRDLENEQWdELHdCQ0FoRCIsImZpbGUiOiJ0by5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyIuZm9vIHsgY29sb3I6IHJlZDsgZm9udC1zaXplOiAxMnB0OyB9IC8qIGFiYyAqLyBAbWVkaWEgKHdpZHRoOiA2MGVtKSB7IH0iLG51bGxdfQ== */`)
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInguY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFzQyxRQUFRLEVBQUUsdUJBQXVCIiwiZmlsZSI6InRvLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIi5mb28geyBjb2xvcjogcmVkOyBmb250LXNpemU6IDEycHQ7IH0gLyogYWJjICovIEBtZWRpYSAod2lkdGg6IDYwZW0pIHsgfSJdfQ== */`)
 })
 
 it('throws when rehydrating an invalid JSON AST', () => {

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -292,6 +292,7 @@ it('toJSON() converts custom properties', () => {
     nodes: [],
     raws: {},
     _hack: 'hack',
+    inputs: [],
     _cache: [1]
   })
 })


### PR DESCRIPTION
I've found two problems related to `Input`:

1std and 2nd commit: I missed that all nodes have a `source` property, not just the root (this caused stringification to fail)

3rd commit: More of an optimization: because of 1), the source contents & map would be stored once for every node (!). This has something like a quadratic memory usage because larger CSS files have more files, so with 10x more rules, the CSS source is about 10x larger and is stored 10x times.
I've instead deduplicated these inputs objects by replacing `node.source.input` with a number in the `toJSON` output and including a `_inputs` array which maps number to input object (because most of these are `===`-equal). This is then reversed in fromJSON. This breaks a buch of `postcss-parser-tests` tests at the moment though. What do you think of this approach? (Before I try to adjust the parser test runner to accept this version...)