### PR TITLE
remove root assignment in stringifier

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -38,7 +38,6 @@ class Stringifier {
   }
 
   root (node) {
-    this.root = node
     this.body(node)
     if (node.raws.after) this.builder(node.raws.after)
   }

--- a/test/stringifier.test.js
+++ b/test/stringifier.test.js
@@ -163,3 +163,12 @@ it('uses optional raws.indent', () => {
   rule.append({ prop: 'color', value: 'black' })
   expect(rule.toString()).toEqual('a {\n color: black\n}')
 })
+
+it('handles nested roots', () => {
+  let root = new Root()
+  let subRoot = new Root()
+  subRoot.append(new AtRule({ name: 'foo' }))
+  root.append(subRoot)
+
+  expect(root.toString()).toEqual('@foo')
+})


### PR DESCRIPTION
Fixes #1494 

I had a search around your codebase and it doesn't look like anything used `Stringifier#root` as a property. so i just removed the line. if you'd rather have it renamed, let me know

it was overwriting the `root(node)` method previously, which was clearly wrong and caused issues with nested roots.

cc @ai 