### PR TITLE
Remove unused code

### DIFF
--- a/lib/css-syntax-error.d.ts
+++ b/lib/css-syntax-error.d.ts
@@ -1,4 +1,4 @@
-import Input, { FilePosition } from './input.js'
+import { FilePosition } from './input.js'
 
 /**
  * The CSS parser throws this error for broken CSS.

--- a/lib/root.d.ts
+++ b/lib/root.d.ts
@@ -1,11 +1,6 @@
 import Container, { ContainerProps } from './container.js'
 import { ProcessOptions } from './postcss.js'
-import { ChildNode } from './node.js'
-import Declaration from './declaration.js'
-import Comment from './comment.js'
-import AtRule from './at-rule.js'
 import Result from './result.js'
-import Rule from './rule.js'
 
 interface RootRaws {
   /**

--- a/test/root.test.ts
+++ b/test/root.test.ts
@@ -1,9 +1,5 @@
 import { Result, parse } from '../lib/postcss.js'
 
-function privateMethods (obj: object): any {
-  return obj
-}
-
 it('prepend() fixes spaces on insert before first', () => {
   let css = parse('a {} b {}')
   css.prepend({ selector: 'em' })

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,4 +1,4 @@
-import postcss, { Result, PluginCreator, SourceMap } from '../lib/postcss.js'
+import postcss, { Result, PluginCreator } from '../lib/postcss.js'
 
 const plugin: PluginCreator<string> = prop => {
   return {


### PR DESCRIPTION
Spotted in VS Code that some code is not used. Then enabled [`@typescript-eslint/no-unused-vars`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md) to catch everything.