### PR TITLE
Update plugins.md， add plugin postcss-auto-rem

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -471,6 +471,8 @@ See also plugins in modular minifier [`cssnano`].
 * [`postcss-px-to-viewport`] generates viewport units (`vw`, `vh`, `vmin`, `vmax`) from `px` units.
 * [`postcss-viewport-height-correction`] solves the popular problem when `100vh`
   doesn’t fit the mobile browser screen.
+* [`postcss-auto-rem`] compiles pixel units to `rem` without configuration that combined with smart-rem will be a perfect rem solution.
+
 
 [flexbox bugs]: https://github.com/philipwalton/flexbugs
 


### PR DESCRIPTION
postcss-auto-rem will compile px to rem.
smart-rem will set the value of the HTML root element property fontsize automatically.