### PR TITLE
add .toString() on writeFile for JS API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ fs.readFile('src/app.css', (err, css) => {
     .then(result => {
       fs.writeFile('dest/app.css', result.css, () => true)
       if ( result.map ) {
-        fs.writeFile('dest/app.css.map', result.map, () => true)
+        fs.writeFile('dest/app.css.map', result.map.toString(), () => true)
       }
     })
 })


### PR DESCRIPTION
Potentially related to #1457 and #1370

This stemmed from me using the JS API in a script and getting the following error output:

```
node:internal/process/promises:227
          triggerUncaughtException(err, true /* fromPromise */);
          ^

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of SourceMapGenerator
    at Object.writeFile (node:fs:1482:5)
    at /Users/.../build-css.js:46:12
    at processTicksAndRejections (node:internal/process/task_queues:93:5) {
  code: 'ERR_INVALID_ARG_TYPE'
}

```