### PR TITLE
fix: add plugin name to deprecation message

### DIFF
--- a/lib/postcss.js
+++ b/lib/postcss.js
@@ -28,13 +28,17 @@ function postcss (...plugins) {
 postcss.plugin = function plugin (name, initializer) {
   if (console && console.warn) {
     console.warn(
-      'postcss.plugin was deprecated. Migration guide:\n' +
+      'in ' +
+        name +
+        ': postcss.plugin was deprecated. Migration guide:\n' +
         'https://evilmartians.com/chronicles/postcss-8-plugin-migration'
     )
     if (process.env.LANG && process.env.LANG.startsWith('cn')) {
       // istanbul ignore next
       console.warn(
-        'postcss.plugin 被弃用. 迁移指南:\n' +
+        '在 ' +
+          name +
+          ' 里面 postcss.plugin 被弃用. 迁移指南:\n' +
           'https://www.w3ctech.com/topic/2226'
       )
     }

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -51,6 +51,7 @@ it('creates plugin', () => {
     }
   })
   expect(console.warn).toHaveBeenCalledTimes(1)
+  expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/test/))
 
   let func1: any = postcss(plugin).plugins[0]
   expect(func1.postcssPlugin).toEqual('test')


### PR DESCRIPTION
Adding the plugin name to the deprecation message to help people debug which plugin needs to be upgraded.  
Translated string is from my friend who can read/write Chinese but only conversation, doesn't use it on a technical basis, so a proofread would be appreciated.