### PR TITLE
Use source-map-js (source-map's fork) 

### DIFF
--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -2,7 +2,7 @@
 
 let { dirname, resolve, relative, sep } = require('path')
 let { pathToFileURL } = require('url')
-let mozilla = require('source-map')
+let mozilla = require('source-map-js')
 
 class MapGenerator {
   constructor (stringify, root, opts) {

--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -1,4 +1,4 @@
-import { SourceMapGenerator, RawSourceMap } from 'source-map'
+import { SourceMapGenerator, RawSourceMap } from 'source-map-js'
 
 import Node, {
   Position,

--- a/lib/previous-map.d.ts
+++ b/lib/previous-map.d.ts
@@ -1,4 +1,4 @@
-import { SourceMapConsumer } from 'source-map'
+import { SourceMapConsumer } from 'source-map-js'
 
 import { ProcessOptions } from './postcss.js'
 

--- a/lib/previous-map.js
+++ b/lib/previous-map.js
@@ -2,7 +2,7 @@
 
 let { existsSync, readFileSync } = require('fs')
 let { dirname, join } = require('path')
-let mozilla = require('source-map')
+let mozilla = require('source-map-js')
 
 function fromBase64 (str) {
   if (Buffer) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "colorette": "^1.2.1",
     "nanoid": "^3.1.20",
-    "source-map": "^0.6.1"
+    "source-map": "7rulnik/source-map#03378502bc3d8c8a71ada20ef199b2f469fae514"
   },
   "devDependencies": {
     "@logux/eslint-config": "^44.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "colorette": "^1.2.1",
     "nanoid": "^3.1.20",
-    "source-map": "7rulnik/source-map#03378502bc3d8c8a71ada20ef199b2f469fae514"
+    "source-map-js": "^0.6.2"
   },
   "devDependencies": {
     "@logux/eslint-config": "^44.0.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   "size-limit": [
     {
       "path": "lib/postcss.js",
-      "limit": "33 KB"
+      "limit": "34 KB"
     }
   ],
   "jest": {

--- a/test/lazy-result.test.ts
+++ b/test/lazy-result.test.ts
@@ -1,4 +1,4 @@
-import mozilla from 'source-map'
+import mozilla from 'source-map-js'
 
 import LazyResult from '../lib/lazy-result.js'
 import Processor from '../lib/processor.js'

--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -1,4 +1,4 @@
-import { SourceMapConsumer, SourceMapGenerator } from 'source-map'
+import { SourceMapConsumer, SourceMapGenerator } from 'source-map-js'
 import { removeSync, outputFileSync } from 'fs-extra'
 import { join, resolve, parse } from 'path'
 import { existsSync } from 'fs'

--- a/test/previous-map.test.ts
+++ b/test/previous-map.test.ts
@@ -1,5 +1,5 @@
 import { removeSync, outputFileSync } from 'fs-extra'
-import { SourceMapConsumer } from 'source-map'
+import { SourceMapConsumer } from 'source-map-js'
 import { pathToFileURL } from 'url'
 import { existsSync } from 'fs'
 import { join } from 'path'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9821,6 +9821,11 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -9844,10 +9849,6 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
-
-source-map@7rulnik/source-map#03378502bc3d8c8a71ada20ef199b2f469fae514:
-  version "0.6.3"
-  resolved "https://codeload.github.com/7rulnik/source-map/tar.gz/03378502bc3d8c8a71ada20ef199b2f469fae514"
 
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9845,6 +9845,10 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@7rulnik/source-map#03378502bc3d8c8a71ada20ef199b2f469fae514:
+  version "0.6.3"
+  resolved "https://codeload.github.com/7rulnik/source-map/tar.gz/03378502bc3d8c8a71ada20ef199b2f469fae514"
+
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"


### PR DESCRIPTION
I made the fork from source-map and named it [source-map-js](https://www.npmjs.com/package/source-map-js). It contains several performance optimizations. Now source-map consumer should be 4x faster.

PR with optimizations: https://github.com/7rulnik/source-map/pull/2
Reasons and difference of fork: https://github.com/7rulnik/source-map#difference-between-original-source-map 