### PR TITLE
Don't split on escaped characters in list.split()

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -11,12 +11,12 @@ let list = {
     let escape = false
 
     for (let letter of string) {
-      if (quote) {
-        if (escape) {
-          escape = false
-        } else if (letter === '\\') {
-          escape = true
-        } else if (letter === quote) {
+      if (escape) {
+        escape = false
+      } else if (letter === '\\') {
+        escape = true
+      } else if (quote) {
+        if (letter === quote) {
           quote = false
         }
       } else if (letter === '"' || letter === "'") {

--- a/test/list.test.ts
+++ b/test/list.test.ts
@@ -16,6 +16,10 @@ it('space() checks functions', () => {
   expect(list.space('f( )) a( () )')).toEqual(['f( ))', 'a( () )'])
 })
 
+it('space() doesn\'t split on escaped spaces', () => {
+  expect(list.space('a\\ b')).toEqual(['a\\ b'])
+})
+
 it('space() works from variable', () => {
   let space = list.space
   expect(space('a b')).toEqual(['a', 'b'])
@@ -35,6 +39,10 @@ it('comma() checks quotes', () => {
 
 it('comma() checks functions', () => {
   expect(list.comma('f(,)), a(,(),)')).toEqual(['f(,))', 'a(,(),)'])
+})
+
+it('comma() doesn\'t split on escaped commas', () => {
+  expect(list.comma('a\\, b')).toEqual(['a\\, b'])
 })
 
 it('comma() works from variable', () => {


### PR DESCRIPTION
I ran into this in practice when cssnano converted a quoted attribute
selector (which contained a comma) to use backslash escapes instead.