### PR TITLE
Update deprecated subpath pattern to "./*"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       "import": "./lib/postcss.mjs",
       "types": "./lib/postcss.d.ts"
     },
-    "./": "./"
+    "./*": "./*"
   },
   "main": "./lib/postcss.js",
   "types": "./lib/postcss.d.ts",


### PR DESCRIPTION
Fixes the following NPM error:

```
ERROR  (node:14100) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at 
... node_modules\postcss\package.json.
Update this package.json to use a subpath pattern like "./*".
```