### PR TITLE
Ignore path module for browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
   "browser": {
     "./lib/terminal-highlight": false,
     "colorette": false,
-    "fs": false
+    "fs": false,
+    "path": false
   },
   "size-limit": [
     {


### PR DESCRIPTION
Compiling `postcss` in webpack 5 will cause an error due to the removal of automatic node built-in polyfills. 

This change tells webpack to ignore the `path` module when compiling, the same treatment `fs` already receives. I have successfully run `postcss` in webpack 5 with this change. 

This issue was raised in #1509
Resolves #1509

Example error:
```
ERROR in ./node_modules/postcss/lib/previous-map.js 4:24-39
Module not found: Error: Can't resolve 'path' in '/Users/person/some-project/node_modules/postcss/lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.
```