### PR TITLE
Handle empty path object in browser builds

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -10,6 +10,8 @@ let PreviousMap = require('./previous-map')
 
 let fromOffsetCache = Symbol('fromOffset cache')
 
+let pathAvailable = Boolean(resolve && isAbsolute);
+
 class Input {
   constructor (css, opts = {}) {
     if (
@@ -30,18 +32,20 @@ class Input {
     }
 
     if (opts.from) {
-      if (/^\w+:\/\//.test(opts.from) || isAbsolute(opts.from)) {
+      if (!pathAvailable || /^\w+:\/\//.test(opts.from) || isAbsolute(opts.from)) {
         this.file = opts.from
       } else {
         this.file = resolve(opts.from)
       }
     }
-
-    let map = new PreviousMap(this.css, opts)
-    if (map.text) {
-      this.map = map
-      let file = map.consumer().file
-      if (!this.file && file) this.file = this.mapResolve(file)
+    
+    if (pathAvailable) {
+      let map = new PreviousMap(this.css, opts)
+      if (map.text) {
+        this.map = map
+        let file = map.consumer().file
+        if (!this.file && file) this.file = this.mapResolve(file)
+      }
     }
 
     if (!this.file) {

--- a/lib/input.js
+++ b/lib/input.js
@@ -10,7 +10,7 @@ let PreviousMap = require('./previous-map')
 
 let fromOffsetCache = Symbol('fromOffset cache')
 
-let pathAvailable = Boolean(resolve && isAbsolute);
+let pathAvailable = Boolean(resolve && isAbsolute)
 
 class Input {
   constructor (css, opts = {}) {
@@ -32,13 +32,17 @@ class Input {
     }
 
     if (opts.from) {
-      if (!pathAvailable || /^\w+:\/\//.test(opts.from) || isAbsolute(opts.from)) {
+      if (
+        !pathAvailable ||
+        /^\w+:\/\//.test(opts.from) ||
+        isAbsolute(opts.from)
+      ) {
         this.file = opts.from
       } else {
         this.file = resolve(opts.from)
       }
     }
-    
+
     if (pathAvailable) {
       let map = new PreviousMap(this.css, opts)
       if (map.text) {

--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -4,6 +4,8 @@ let { dirname, resolve, relative, sep } = require('path')
 let { pathToFileURL } = require('url')
 let mozilla = require('source-map')
 
+let pathAvailable = Boolean(dirname, resolve, relative, sep);
+
 class MapGenerator {
   constructor (stringify, root, opts) {
     this.stringify = stringify
@@ -275,7 +277,7 @@ class MapGenerator {
   generate () {
     this.clearAnnotation()
 
-    if (this.isMap()) {
+    if (pathAvailable && this.isMap()) {
       return this.generateMap()
     }
 

--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -4,7 +4,7 @@ let { dirname, resolve, relative, sep } = require('path')
 let { pathToFileURL } = require('url')
 let mozilla = require('source-map')
 
-let pathAvailable = Boolean(dirname, resolve, relative, sep);
+let pathAvailable = Boolean(dirname, resolve, relative, sep)
 
 class MapGenerator {
   constructor (stringify, root, opts) {

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,17 +1,18 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 import { options, bold, red, gray, yellow } from 'colorette'
 
 beforeEach(() => {
-  jest.resetModules();
+  jest.resetModules()
   jest.doMock('fs', () => ({}))
   jest.doMock('colorette', () => ({ options, bold, red, gray, yellow }))
-});
+})
 
 afterEach(() => {
   options.enabled = true
 })
 
 it('shows code with colors (default)', () => {
-  let postcss = require('../lib/postcss.js');
+  let postcss = require('../lib/postcss.js')
 
   let error
   try {
@@ -35,7 +36,7 @@ it('shows code with colors (default)', () => {
 })
 
 it('shows code without colors (default)', () => {
-  let postcss = require('../lib/postcss.js');
+  let postcss = require('../lib/postcss.js')
 
   let error
   options.enabled = false
@@ -53,7 +54,7 @@ it('shows code without colors (default)', () => {
 })
 
 it('shows code without colors (setting)', () => {
-  let postcss = require('../lib/postcss.js');
+  let postcss = require('../lib/postcss.js')
 
   let error
   try {
@@ -69,7 +70,7 @@ it('shows code without colors (setting)', () => {
 })
 
 it('generates source map without fs', () => {
-  let postcss = require('../lib/postcss.js');
+  let postcss = require('../lib/postcss.js')
 
   expect(
     postcss([() => {}]).process('a{}', { from: 'a.css', map: true }).css
@@ -82,8 +83,8 @@ it('generates source map without fs', () => {
 })
 
 it(`doesn't throw error without path`, () => {
-  jest.doMock('path', () => ({}));
-  let postcss = require('../lib/postcss.js');
+  jest.doMock('path', () => ({}))
+  let postcss = require('../lib/postcss.js')
 
   expect(
     postcss([() => {}]).process('a{}', { from: 'a.css', map: true }).css

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,15 +1,18 @@
 import { options, bold, red, gray, yellow } from 'colorette'
 
-import postcss from '../lib/postcss.js'
-
-jest.doMock('fs', () => ({}))
-jest.doMock('colorette', () => ({ options, bold, red, gray, yellow }))
+beforeEach(() => {
+  jest.resetModules();
+  jest.doMock('fs', () => ({}))
+  jest.doMock('colorette', () => ({ options, bold, red, gray, yellow }))
+});
 
 afterEach(() => {
   options.enabled = true
 })
 
 it('shows code with colors (default)', () => {
+  let postcss = require('../lib/postcss.js');
+
   let error
   try {
     postcss.parse('a{')
@@ -32,6 +35,8 @@ it('shows code with colors (default)', () => {
 })
 
 it('shows code without colors (default)', () => {
+  let postcss = require('../lib/postcss.js');
+
   let error
   options.enabled = false
 
@@ -48,6 +53,8 @@ it('shows code without colors (default)', () => {
 })
 
 it('shows code without colors (setting)', () => {
+  let postcss = require('../lib/postcss.js');
+
   let error
   try {
     postcss.parse('a{')
@@ -62,6 +69,8 @@ it('shows code without colors (setting)', () => {
 })
 
 it('generates source map without fs', () => {
+  let postcss = require('../lib/postcss.js');
+
   expect(
     postcss([() => {}]).process('a{}', { from: 'a.css', map: true }).css
   ).toEqual(
@@ -70,4 +79,13 @@ it('generates source map without fs', () => {
       'ibWFwcGluZ3MiOiJBQUFBLEVBQUUiLCJmaWxlIjoiYS5jc3MiLCJzb3VyY2' +
       'VzQ29udGVudCI6WyJhe30iXX0= */'
   )
+})
+
+it(`doesn't throw error without path`, () => {
+  jest.doMock('path', () => ({}));
+  let postcss = require('../lib/postcss.js');
+
+  expect(
+    postcss([() => {}]).process('a{}', { from: 'a.css', map: true }).css
+  ).toEqual('a{}')
 })


### PR DESCRIPTION
I've also fixed the browser tests as they were not mocking correctly. Calling `doMock` after importing `postcss` had no effect as the module had already been processed before the mock takes effect. 