### PR TITLE
Export types for NodeErrorOptions

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -4,6 +4,7 @@ import Node, {
   Position,
   Source,
   ChildNode,
+  NodeErrorOptions,
   NodeProps,
   ChildProps,
   AnyNode
@@ -30,6 +31,7 @@ export {
   ChildNode,
   AnyNode,
   Message,
+  NodeErrorOptions,
   NodeProps,
   DeclarationProps,
   ContainerProps,


### PR DESCRIPTION
This will simplify the types import for `postcss-values-parser`: https://github.com/shellscape/postcss-values-parser/pull/132