### PR TITLE
Fix import url for Deno example

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ PostCSS also supports [Deno]:
 
 ```js
 import postcss from 'https://deno.land/x/postcss/mod.js'
-import autoprefixer from 'https://dev.jspm.io/autoprefixer'
+import autoprefixer from 'https://jspm.dev/autoprefixer'
 
 const result = await postcss([autoprefixer]).process(css)
 ```


### PR DESCRIPTION
The current Deno example did't work. I created [this issue](https://github.com/postcss/autoprefixer/issues/1402).

Here is an announcement about the url change: https://jspm.org/jspm-dev-release
