### PR TITLE
Fix browser bundling with webpack 5

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -130,7 +130,9 @@ class Input {
 
     result.input = { line, column, source: this.css }
     if (this.file) {
-      result.input.url = pathToFileURL(this.file).toString()
+      if(pathToFileURL) {
+        result.input.url = pathToFileURL(this.file).toString()
+      }
       result.input.file = this.file
     }
 
@@ -162,7 +164,11 @@ class Input {
     }
 
     if (fromUrl.protocol === 'file:') {
-      result.file = fileURLToPath(fromUrl)
+      if(fileURLToPath){
+        result.file = fileURLToPath(fromUrl)
+      } else {
+        throw new Error(`file: protocol is not available in this postcss build`);
+      }
     }
 
     let source = consumer.sourceContentFor(from.source)

--- a/lib/input.js
+++ b/lib/input.js
@@ -130,7 +130,7 @@ class Input {
 
     result.input = { line, column, source: this.css }
     if (this.file) {
-      if(pathToFileURL) {
+      if (pathToFileURL) {
         result.input.url = pathToFileURL(this.file).toString()
       }
       result.input.file = this.file
@@ -164,10 +164,10 @@ class Input {
     }
 
     if (fromUrl.protocol === 'file:') {
-      if(fileURLToPath){
+      if (fileURLToPath) {
         result.file = fileURLToPath(fromUrl)
       } else {
-        throw new Error(`file: protocol is not available in this postcss build`);
+        throw new Error(`file: protocol is not available in this PostCSS build`);
       }
     }
 

--- a/lib/input.js
+++ b/lib/input.js
@@ -167,6 +167,7 @@ class Input {
       if (fileURLToPath) {
         result.file = fileURLToPath(fromUrl)
       } else {
+        // istanbul ignore next
         throw new Error(`file: protocol is not available in this PostCSS build`);
       }
     }

--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -4,7 +4,7 @@ let { dirname, resolve, relative, sep } = require('path')
 let { pathToFileURL } = require('url')
 let mozilla = require('source-map')
 
-let pathAvailable = Boolean(dirname, resolve, relative, sep)
+let pathAvailable = Boolean(dirname && resolve && relative && sep)
 
 class MapGenerator {
   constructor(stringify, root, opts) {

--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -202,10 +202,10 @@ class MapGenerator {
     if (this.mapOpts.from) {
       return this.toUrl(this.mapOpts.from)
     } else if (this.mapOpts.absolute) {
-      if(pathToFileURL) {
+      if (pathToFileURL) {
         return pathToFileURL(node.source.input.from).toString()
       } else {
-        throw new Error('map option "absolute" is not available in this postcss build')
+        throw new Error('`map.absolute` option is not available in this PostCSS build')
       }
     } else {
       return this.toUrl(this.path(node.source.input.from))

--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -202,7 +202,11 @@ class MapGenerator {
     if (this.mapOpts.from) {
       return this.toUrl(this.mapOpts.from)
     } else if (this.mapOpts.absolute) {
-      return pathToFileURL(node.source.input.from).toString()
+      if(pathToFileURL) {
+        return pathToFileURL(node.source.input.from).toString()
+      } else {
+        throw new Error('map option "absolute" is not available in this postcss build')
+      }
     } else {
       return this.toUrl(this.path(node.source.input.from))
     }

--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -205,6 +205,7 @@ class MapGenerator {
       if (pathToFileURL) {
         return pathToFileURL(node.source.input.from).toString()
       } else {
+        // istanbul ignore next
         throw new Error('`map.absolute` option is not available in this PostCSS build')
       }
     } else {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     "./lib/terminal-highlight": false,
     "colorette": false,
     "fs": false,
-    "path": false
+    "path": false,
+    "url": false
   },
   "size-limit": [
     {


### PR DESCRIPTION
I think that the browser field is missing `url: false`.
I'm not completely sure that this is the right fix and also the npm package `url` does not implement the APIs used by postcss. 

steps to reproduce

```
mkdir postcss-browser 
cd postcss-browser 
mkdir src
echo 'import "postcss";' > src/index.js
npm init -y
npm install webpack webpack-cli postcss
npx webpack
```
This will emit error: 
```
ERROR in ./node_modules/postcss/lib/input.js 3:39-53
Module not found: Error: Can't resolve 'url' in 'C:\projects\postcss-web-bundle\postcss-browser\node_modules\postcss\lib'
```