### PR TITLE
Fix ReDoS in previous-map

### DIFF
--- a/lib/previous-map.js
+++ b/lib/previous-map.js
@@ -48,11 +48,11 @@ class PreviousMap {
   }
 
   getAnnotationURL(sourceMapString) {
-    return sourceMapString.match(/\/\*\s*# sourceMappingURL=(.*)\*\//)[1].trim()
+    return sourceMapString.match(/\/\*\s*# sourceMappingURL=((?:(?!sourceMappingURL=).)*)\*\//)[1].trim()
   }
 
   loadAnnotation(css) {
-    let annotations = css.match(/\/\*\s*# sourceMappingURL=.*\*\//gm)
+    let annotations = css.match(/\/\*\s*# sourceMappingURL=(?:(?!sourceMappingURL=).)*\*\//gm)
 
     if (annotations && annotations.length > 0) {
       // Locate the last sourceMappingURL to avoid picking up


### PR DESCRIPTION
Fix Strategy: Replace `(.*)` with `(?:(?!sourceMappingURL=).)*`