### PR TITLE
Remove source-map from browser build

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -2,6 +2,7 @@
 
 let { fileURLToPath, pathToFileURL } = require('url')
 let { resolve, isAbsolute } = require('path')
+let { SourceMapConsumer, SourceMapGenerator } = require('source-map')
 let { nanoid } = require('nanoid/non-secure')
 
 let terminalHighlight = require('./terminal-highlight')
@@ -10,6 +11,7 @@ let PreviousMap = require('./previous-map')
 
 let fromOffsetCache = Symbol('fromOffset cache')
 
+let sourceMapAvailable = Boolean(SourceMapConsumer && SourceMapGenerator)
 let pathAvailable = Boolean(resolve && isAbsolute)
 
 class Input {
@@ -43,7 +45,7 @@ class Input {
       }
     }
 
-    if (pathAvailable) {
+    if (pathAvailable && sourceMapAvailable) {
       let map = new PreviousMap(this.css, opts)
       if (map.text) {
         this.map = map
@@ -168,7 +170,7 @@ class Input {
         result.file = fileURLToPath(fromUrl)
       } else {
         // istanbul ignore next
-        throw new Error(`file: protocol is not available in this PostCSS build`);
+        throw new Error(`file: protocol is not available in this PostCSS build`)
       }
     }
 

--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -2,8 +2,9 @@
 
 let { dirname, resolve, relative, sep } = require('path')
 let { pathToFileURL } = require('url')
-let mozilla = require('source-map')
+let { SourceMapConsumer, SourceMapGenerator } = require('source-map')
 
+let sourceMapAvailable = Boolean(SourceMapConsumer && SourceMapGenerator)
 let pathAvailable = Boolean(dirname && resolve && relative && sep)
 
 class MapGenerator {
@@ -99,7 +100,7 @@ class MapGenerator {
       let map
 
       if (this.mapOpts.sourcesContent === false) {
-        map = new mozilla.SourceMapConsumer(prev.text)
+        map = new SourceMapConsumer(prev.text)
         if (map.sourcesContent) {
           map.sourcesContent = map.sourcesContent.map(() => null)
         }
@@ -206,7 +207,9 @@ class MapGenerator {
         return pathToFileURL(node.source.input.from).toString()
       } else {
         // istanbul ignore next
-        throw new Error('`map.absolute` option is not available in this PostCSS build')
+        throw new Error(
+          '`map.absolute` option is not available in this PostCSS build'
+        )
       }
     } else {
       return this.toUrl(this.path(node.source.input.from))
@@ -215,7 +218,7 @@ class MapGenerator {
 
   generateString() {
     this.css = ''
-    this.map = new mozilla.SourceMapGenerator({ file: this.outputFile() })
+    this.map = new SourceMapGenerator({ file: this.outputFile() })
 
     let line = 1
     let column = 1
@@ -282,7 +285,7 @@ class MapGenerator {
   generate() {
     this.clearAnnotation()
 
-    if (pathAvailable && this.isMap()) {
+    if (pathAvailable && sourceMapAvailable && this.isMap()) {
       return this.generateMap()
     }
 

--- a/lib/previous-map.js
+++ b/lib/previous-map.js
@@ -2,7 +2,7 @@
 
 let { existsSync, readFileSync } = require('fs')
 let { dirname, join } = require('path')
-let mozilla = require('source-map')
+let { SourceMapConsumer, SourceMapGenerator } = require('source-map')
 
 function fromBase64(str) {
   if (Buffer) {
@@ -30,7 +30,7 @@ class PreviousMap {
 
   consumer() {
     if (!this.consumerCache) {
-      this.consumerCache = new mozilla.SourceMapConsumer(this.text)
+      this.consumerCache = new SourceMapConsumer(this.text)
     }
     return this.consumerCache
   }
@@ -48,11 +48,15 @@ class PreviousMap {
   }
 
   getAnnotationURL(sourceMapString) {
-    return sourceMapString.match(/\/\*\s*# sourceMappingURL=((?:(?!sourceMappingURL=).)*)\*\//)[1].trim()
+    return sourceMapString
+      .match(/\/\*\s*# sourceMappingURL=((?:(?!sourceMappingURL=).)*)\*\//)[1]
+      .trim()
   }
 
   loadAnnotation(css) {
-    let annotations = css.match(/\/\*\s*# sourceMappingURL=(?:(?!sourceMappingURL=).)*\*\//gm)
+    let annotations = css.match(
+      /\/\*\s*# sourceMappingURL=(?:(?!sourceMappingURL=).)*\*\//gm
+    )
 
     if (annotations && annotations.length > 0) {
       // Locate the last sourceMappingURL to avoid picking up
@@ -107,9 +111,9 @@ class PreviousMap {
           }
           return map
         }
-      } else if (prev instanceof mozilla.SourceMapConsumer) {
-        return mozilla.SourceMapGenerator.fromSourceMap(prev).toString()
-      } else if (prev instanceof mozilla.SourceMapGenerator) {
+      } else if (prev instanceof SourceMapConsumer) {
+        return SourceMapGenerator.fromSourceMap(prev).toString()
+      } else if (prev instanceof SourceMapGenerator) {
         return prev.toString()
       } else if (this.isMap(prev)) {
         return JSON.stringify(prev)

--- a/package.json
+++ b/package.json
@@ -130,12 +130,13 @@
     "colorette": false,
     "fs": false,
     "path": false,
-    "url": false
+    "url": false,
+    "source-map": false
   },
   "size-limit": [
     {
       "path": "lib/postcss.js",
-      "limit": "30 KB"
+      "limit": "23 KB"
     }
   ],
   "jest": {


### PR DESCRIPTION
Since `path` is false in browsers build the `source-map` package is actually not in use*.  

This PR adds `"source-map": false` to the `package.json` also added explicit protection for the existence of the `source-map` API's.
Now if one will want to use postcss in browser and support source maps he will need to include `path` and `source-map` packages

This will decreased the bundle size of postcss by ~27% (from 29KB to 21KB)

(*) There is only one feature that I wasn't sure what to do with related to `fromJSON`. It is using the `PreviousMap` (no problem there) and `PreviousMap` uses the `source-map` package and I wasn't sure how to fallback. It might be a super edge case for browsers.