### PR TITLE
Add `dir-dependency` documentation

### DIFF
--- a/docs/guidelines/plugin.md
+++ b/docs/guidelines/plugin.md
@@ -217,7 +217,7 @@ a `dependency` message to the `result`:
 result.messages.push({
   type: 'dependency',
   plugin: 'postcss-import',
-  file: '/js/example.js',
+  file: '/imported/file.css',
   parent: result.opts.from
 })
 ```

--- a/docs/guidelines/plugin.md
+++ b/docs/guidelines/plugin.md
@@ -208,9 +208,9 @@ is described in [API docs].
 
 ## 3. Dependencies
 
-### 3.1. Use the `dependency` message type for file dependencies
+### 3.1. Use messages to specify dependencies
 
-If a plugin depends on another file, it should be declared by attaching
+If a plugin depends on another file, it should be specified by attaching
 a `dependency` message to the `result`:
 
 ```js
@@ -222,17 +222,13 @@ result.messages.push({
 })
 ```
 
-
-### 3.2. Use the `dir-dependency` message type for directory dependencies
-
-If a plugin depends on the contents of a directory it should be declared
-by attaching a `dir-dependency` message to the `result`:
+Specify recursive directory dependencies using the `dir-dependency` message type:
 
 ```js
 result.messages.push({
   type: 'dir-dependency',
   plugin: 'postcss-import',
-  dir: '/js',
+  dir: '/imported',
   parent: result.opts.from
 })
 ```

--- a/docs/guidelines/plugin.md
+++ b/docs/guidelines/plugin.md
@@ -238,19 +238,6 @@ result.messages.push({
 ```
 
 
-### 3.3. Detect available dependency types
-
-PostCSS runners may declare which message types they support using the
-`messageTypes` option. Plugins can use this to check that the types it
-requires are available:
-
-```js
-let supportsDirDependencies = result.opts.messageTypes.includes('dir-dependency')
-```
-
-Note that if a runner does not declare `messageTypes` then it is generally
-safe to assume that the runner only supports the `dependency` type.
-
 ## 4. Errors
 
 ### 4.1. Use `node.error` on CSS relevant errors

--- a/docs/guidelines/plugin.md
+++ b/docs/guidelines/plugin.md
@@ -206,9 +206,54 @@ is described in [API docs].
 [API docs]: https://postcss.org/api/
 
 
-## 3. Errors
+## 3. Dependencies
 
-### 3.1. Use `node.error` on CSS relevant errors
+### 3.1. Use the `dependency` message type for file dependencies
+
+If a plugin depends on another file, it should be declared by attaching
+a `dependency` message to the `result`:
+
+```js
+result.messages.push({
+  type: 'dependency',
+  plugin: 'postcss-import',
+  file: '/js/example.js',
+  parent: result.opts.from
+})
+```
+
+
+### 3.2. Use the `dir-dependency` message type for directory dependencies
+
+If a plugin depends on the contents of a directory it should be declared
+by attaching a `dir-dependency` message to the `result`:
+
+```js
+result.messages.push({
+  type: 'dir-dependency',
+  plugin: 'postcss-import',
+  dir: '/js',
+  parent: result.opts.from
+})
+```
+
+
+### 3.3. Detect available dependency types
+
+PostCSS runners may declare which message types they support using the
+`messageTypes` option. Plugins can use this to check that the types it
+requires are available:
+
+```js
+let supportsDirDependencies = result.opts.messageTypes.includes('dir-dependency')
+```
+
+Note that if a runner does not declare `messageTypes` then it is generally
+safe to assume that the runner only supports the `dependency` type.
+
+## 4. Errors
+
+### 4.1. Use `node.error` on CSS relevant errors
 
 If you have an error because of input CSS (like an unknown name
 in a mixin plugin) you should use `node.error` to create an error
@@ -221,7 +266,7 @@ if (typeof mixins[name] === 'undefined') {
 ```
 
 
-### 3.2. Use `result.warn` for warnings
+### 4.2. Use `result.warn` for warnings
 
 Do not print warnings with `console.log` or `console.warn`,
 because some PostCSS runner may not allow console output.
@@ -237,9 +282,9 @@ Declaration (decl, { result }) {
 If CSS input is a source of the warning, the plugin must set the `node` option.
 
 
-## 4. Documentation
+## 5. Documentation
 
-### 4.1. Document your plugin in English
+### 5.1. Document your plugin in English
 
 PostCSS plugins must have their `README.md` wrote in English. Do not be afraid
 of your English skills, as the open source community will fix your errors.
@@ -248,7 +293,7 @@ Of course, you are welcome to write documentation in other languages;
 just name them appropriately (e.g. `README.ja.md`).
 
 
-### 4.2. Include input and output examples
+### 5.2. Include input and output examples
 
 The plugin's `README.md` must contain example input and output CSS.
 A clear example is the best way to describe how your plugin works.
@@ -260,7 +305,7 @@ Of course, this guideline does not apply if your plugin does not
 transform the CSS.
 
 
-### 4.3. Maintain a changelog
+### 5.3. Maintain a changelog
 
 PostCSS plugins must describe the changes of all their releases
 in a separate file, such as `CHANGELOG.md`, `History.md`, or [GitHub Releases].
@@ -273,7 +318,7 @@ Of course, you should be using [SemVer].
 [SemVer]:           https://semver.org/
 
 
-### 4.4. Include `postcss-plugin` keyword in `package.json`
+### 5.4. Include `postcss-plugin` keyword in `package.json`
 
 PostCSS plugins written for npm must have the `postcss-plugin` keyword
 in their `package.json`. This special keyword will be useful for feedback about

--- a/docs/guidelines/runner.md
+++ b/docs/guidelines/runner.md
@@ -80,7 +80,7 @@ messages to the `result`. Runners should watch these and ensure that the
 CSS is rebuilt when they change.
 
 ```js
-for (let message in result.messages) {
+for (let message of result.messages) {
   if (message.type === 'dependency') {
     watcher.addFile(message.file)
   } else if (message.type === 'dir-dependency') {

--- a/docs/guidelines/runner.md
+++ b/docs/guidelines/runner.md
@@ -71,9 +71,42 @@ is described in [API docs].
 [API docs]: https://postcss.org/api/
 
 
-## 3. Output
+## 3. Dependencies
 
-### 3.1. Don’t show JS stack for `CssSyntaxError`
+### 3.1. Rebuild when dependencies change
+
+PostCSS plugins may declare file or directory dependencies by attaching
+messages to the `result`. Runners should watch these and ensure that the
+CSS is rebuilt when they change.
+
+```js
+for (let message in result.messages) {
+  if (message.type === 'dependency') {
+    watcher.addFile(message.file)
+  } else if (message.type === 'dir-dependency') {
+    watcher.addDir(message.dir)
+  }
+}
+```
+
+
+### 3.2. Declare support
+
+PostCSS runners must specify which message types they support using the
+`messageTypes` option, so that plugins know which types are available:
+
+```js
+processor.process({
+  from: file.path,
+  to: file.path,
+  messageTypes: ['dependency', 'dir-dependency']
+})
+```
+
+
+## 4. Output
+
+### 4.1. Don’t show JS stack for `CssSyntaxError`
 
 PostCSS runners must not show a stack trace for CSS syntax errors,
 as the runner can be used by developers who are not familiar with JavaScript.
@@ -90,7 +123,7 @@ processor.process(opts).catch(error => {
 ```
 
 
-### 3.2. Display `result.warnings()`
+### 4.2. Display `result.warnings()`
 
 PostCSS runners must output warnings from `result.warnings()`:
 
@@ -106,7 +139,7 @@ See also [postcss-log-warnings] and [postcss-messages] plugins.
 [postcss-messages]:     https://github.com/postcss/postcss-messages
 
 
-### 3.3. Allow the user to write source maps to different files
+### 4.3. Allow the user to write source maps to different files
 
 PostCSS by default will inline source maps in the generated file; however,
 PostCSS runners must provide an option to save the source map in a different
@@ -119,9 +152,9 @@ if (result.map) {
 ```
 
 
-## 4. Documentation
+## 5. Documentation
 
-### 4.1. Document your runner in English
+### 5.1. Document your runner in English
 
 PostCSS runners must have their `README.md` wrote in English. Do not be afraid
 of your English skills, as the open source community will fix your errors.
@@ -130,7 +163,7 @@ Of course, you are welcome to write documentation in other languages;
 just name them appropriately (e.g. `README.ja.md`).
 
 
-### 4.2. Maintain a changelog
+### 5.2. Maintain a changelog
 
 PostCSS runners must describe changes of all releases in a separate file,
 such as `ChangeLog.md`, `History.md`, or with [GitHub Releases].
@@ -143,7 +176,7 @@ Of course, you should use [SemVer].
 [SemVer]:           https://semver.org/
 
 
-### 4.3. `postcss-runner` keyword in `package.json`
+### 5.3. `postcss-runner` keyword in `package.json`
 
 PostCSS runners written for npm must have the `postcss-runner` keyword
 in their `package.json`. This special keyword will be useful for feedback about
@@ -153,7 +186,7 @@ For packages not published to npm, this is not mandatory, but recommended
 if the package format is allowed to contain keywords.
 
 
-### 4.4. Keep `postcss` to `peerDependencies`
+### 5.4. Keep `postcss` to `peerDependencies`
 
 AST can be broken because of different `postcss` version in different plugins.
 Different plugins could use a different node creators (like `postcss.decl()`).

--- a/docs/guidelines/runner.md
+++ b/docs/guidelines/runner.md
@@ -77,7 +77,7 @@ is described in [API docs].
 
 PostCSS plugins may declare file or directory dependencies by attaching
 messages to the `result`. Runners should watch these and ensure that the
-CSS is rebuilt when they change.
+CSS is rebuilt when they change. Directories should be watched recursively.
 
 ```js
 for (let message of result.messages) {

--- a/docs/guidelines/runner.md
+++ b/docs/guidelines/runner.md
@@ -90,20 +90,6 @@ for (let message in result.messages) {
 ```
 
 
-### 3.2. Declare support
-
-PostCSS runners must specify which message types they support using the
-`messageTypes` option, so that plugins know which types are available:
-
-```js
-processor.process({
-  from: file.path,
-  to: file.path,
-  messageTypes: ['dependency', 'dir-dependency']
-})
-```
-
-
 ## 4. Output
 
 ### 4.1. Don’t show JS stack for `CssSyntaxError`

--- a/docs/writing-a-plugin.md
+++ b/docs/writing-a-plugin.md
@@ -317,9 +317,9 @@ Second argument also have `result` object to add warnings:
     }
 ```
 
-If your plugin load another file, you can use `result` to add message, that
-webpack/Gulp should add this file to a watching list
-(and rebuild CSS on file changes):
+If your plugin depends on another file, you can attach a message to `result`
+to signify to runners (webpack, Gulp etc.) that they should rebuild the CSS
+when this file changes:
 
 ```js
     AtRule: {
@@ -333,6 +333,18 @@ webpack/Gulp should add this file to a watching list
         })
       }
     }
+```
+
+If the dependency is a directory you should use the `dir-dependency`
+message type instead:
+
+```js
+result.messages.push({
+  type: 'dir-dependency',
+  plugin: 'postcss-import',
+  dir: importedDir,
+  parent: result.opts.from
+})
 ```
 
 If you find an syntax error (for instance, undefined custom property),


### PR DESCRIPTION
As discussed in #1537 this pull request adds documentation for a new `dir-dependency` message type that can be used to signify that a plugin depends on the contents of a directory. This would be used in the same way as the `dependency` message but with a `dir` property instead of a `file` property:

```js
result.messages.push({
  type: 'dir-dependency',
  plugin: 'postcss-import',
  dir: '/js',
  parent: result.opts.from
})
```

Runners should watch this directory for changes and rebuild the CSS when something changes.

This PR also adds some documentation for the existing `dependency` message to the plugin and runner guides, and clarifies the usage of dependency messages in the "Writing a PostCSS Plugin" documentation.