### PR TITLE
[Proposal] Add `supportedDependencyTypes` documentation

### DIFF
--- a/docs/guidelines/plugin.md
+++ b/docs/guidelines/plugin.md
@@ -233,6 +233,24 @@ result.messages.push({
 })
 ```
 
+### 3.2. Detect available dependency types
+
+PostCSS runners may specify which dependency types they support using the
+`supportedDependencyTypes` option. This is an array of supported types.
+Plugins can use this to check that the required types are available:
+
+```js
+if (result.opts.supportedDependencyTypes.includes('dir-dependency')) {
+  // register directory dependency
+} else {
+  throw Error('Runner does not support the required dependency types.')
+}
+```
+
+Note that if a runner does not specify `supportedDependencyTypes` then
+it is generally safe to assume that the runner only supports the
+`dependency` type.
+
 
 ## 4. Errors
 

--- a/docs/guidelines/runner.md
+++ b/docs/guidelines/runner.md
@@ -89,6 +89,19 @@ for (let message of result.messages) {
 }
 ```
 
+### 3.2. Specify supported dependency types
+
+PostCSS runners must specify which dependency types they support using the
+`supportedDependencyTypes` option, so that plugins know which types are available:
+
+```js
+processor.process({
+  from: file.path,
+  to: file.path,
+  supportedDependencyTypes: ['dependency', 'dir-dependency']
+})
+```
+
 
 ## 4. Output
 


### PR DESCRIPTION
This pull request adds documentation for a way that PostCSS runners can specify which dependency types they support. Now that we have more than one dependency type, I think it is important that plugins are aware of which dependency types are available to them, and which aren't.

My proposal is for runners to define a `supportedDependencyTypes` option when running PostCSS:

```js
processor.process({
  from: file.path,
  to: file.path,
  supportedDependencyTypes: ['dependency', 'dir-dependency']
})
```

Then, plugins can read this from `result.opts`:

```js
if (result.opts.supportedDependencyTypes.includes('dir-dependency')) {
  // register directory dependency
} else {
  throw Error('Runner does not support the required dependency types.')
}
```

This provides a better experience for PostCSS users, because plugins can present clear errors when required dependency types are not available. It also allows plugins to register dependencies with confidence, knowing that they will be handled by the runner. Currently there is no way to know that a `dir-dependency` message has been handled. This can lead to plugins silently not working correctly and frustrated users.

Here's another concrete example: if we added a new `glob-dependency` type ([as discussed over on the Parcel repo](https://github.com/parcel-bundler/parcel/pull/6299#issuecomment-842670147)) plugins could make a decision about which dependencies to register, based on which types the runner supports:

```js
let pattern = '/src/**/*.html'
let supportsGlobDependencies = result.opts.supportedDependencyTypes?.includes('glob-dependency')
let supportsDirectoryDependencies = result.opts.supportedDependencyTypes?.includes('dir-dependency')

if (supportsGlobDependencies) {
  messages.push({ type: 'glob-dependency', glob: pattern })
} else if (supportsDirectoryDependencies) {
  messages.push({ type: 'dir-dependency', dir: getBase(pattern) })
} else {
  throw Error('Runner does not support the required dependency types.')
}
```

Some runners may not be able to support glob dependencies at all, and this would allow plugins to maximise compatibility.

This is just one idea and I am curious to hear what you think of it. Feedback and suggestions welcome, thanks!