### PR TITLE
Return correct column on `missed semicolon`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -552,7 +552,13 @@ class Parser {
         if (founded === 2) break
       }
     }
-    throw this.input.error('Missed semicolon', token[2])
+    // If the token is a word, e.g. `!important`, `red` or any other valid property's value.
+    // Then we need to return the colon after that word token. [3] is the "end" colon of that word.
+    // And because we need it after that one we do +1 to get the next one.
+    throw this.input.error(
+      'Missed semicolon',
+      token[0] === 'word' ? token[3] + 1 : token[2]
+    )
   }
 }
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -203,3 +203,23 @@ it('suggests postcss-less for Less sources', () => {
     parse('.@{my-selector} { }', { from: 'app.less' })
   }).toThrow(/postcss-less/)
 })
+
+it('should give the correct column of missed semicolon with !important', () => {
+  let error
+  try {
+    parse('a { \n    color: red !important\n    background-color: black;\n}')
+  } catch (e) {
+    error = e
+  }
+  expect(error.message).toMatch(/2:26: Missed semicolon/)
+})
+
+it('should give the correct column of missed semicolon without !important', () => {
+  let error
+  try {
+    parse('a { \n    color: red\n    background-color: black;\n}')
+  } catch (e) {
+    error = e
+  }
+  expect(error.message).toMatch(/2:15: Missed semicolon/)
+})


### PR DESCRIPTION
I've added some test-cases to ensure it works.
Also added a comment about `why` we it need to get token[3]+1

And ultimately it resolves https://github.com/postcss/postcss/issues/1617

Regards,
Gusted