### PR TITLE
Add bugs field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
   "license": "MIT",
   "homepage": "https://postcss.org/",
   "repository": "postcss/postcss",
+  "bugs": {
+    "url": "https://github.com/postcss/postcss/issues"
+  },
   "dependencies": {
     "colorette": "^1.2.2",
     "nanoid": "^3.1.23",


### PR DESCRIPTION
It's useful for contributors who've cloned the repo to type `npm bugs` to launch GitHub Issues for this project. :-)

REF: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#bugs