### PR TITLE
Remove unmaintained precss plugin from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 
 ### Better CSS Readability
 
-* [`precss`] contains plugins for Sass-like features, like variables, nesting,
-  and mixins.
 * [`postcss-sorting`] sorts the content of rules and at-rules.
 * [`postcss-utilities`] includes the most commonly used shortcuts and helpers.
 * [`short`] adds and extends numerous shorthand properties.
@@ -146,7 +144,6 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 [`stylelint`]:                  https://github.com/stylelint/stylelint
 [`stylefmt`]:                   https://github.com/morishitter/stylefmt
 [`cssnano`]:                    https://cssnano.co/
-[`precss`]:                     https://github.com/jonathantneal/precss
 [`doiuse`]:                     https://github.com/anandthakker/doiuse
 [`rtlcss`]:                     https://github.com/MohammadYounes/rtlcss
 [`short`]:                      https://github.com/jonathantneal/postcss-short
@@ -310,7 +307,6 @@ Then create `postcss.config.js`:
 ```js
 module.exports = {
   plugins: [
-    require('precss'),
     require('autoprefixer')
   ]
 }
@@ -330,7 +326,7 @@ gulp.task('css', () => {
 
   return gulp.src('src/**/*.css')
     .pipe( sourcemaps.init() )
-    .pipe( postcss([ require('precss'), require('autoprefixer') ]) )
+    .pipe( postcss([ require('autoprefixer') ]) )
     .pipe( sourcemaps.write('.') )
     .pipe( gulp.dest('build/') )
 })
@@ -410,11 +406,10 @@ For other environments, you can use the JS API:
 ```js
 const autoprefixer = require('autoprefixer')
 const postcss = require('postcss')
-const precss = require('precss')
 const fs = require('fs')
 
 fs.readFile('src/app.css', (err, css) => {
-  postcss([precss, autoprefixer])
+  postcss([autoprefixer])
     .process(css, { from: 'src/app.css', to: 'dest/app.css' })
     .then(result => {
       fs.writeFile('dest/app.css', result.css, () => true)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 
 ### Better CSS Readability
 
+* [`postcss-nested`] unwraps nested rules the way Sass does.
 * [`postcss-sorting`] sorts the content of rules and at-rules.
 * [`postcss-utilities`] includes the most commonly used shortcuts and helpers.
 * [`short`] adds and extends numerous shorthand properties.
@@ -144,6 +145,7 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 [`stylelint`]:                  https://github.com/stylelint/stylelint
 [`stylefmt`]:                   https://github.com/morishitter/stylefmt
 [`cssnano`]:                    https://cssnano.co/
+[`postcss-nested`]:             https://github.com/postcss/postcss-nested
 [`doiuse`]:                     https://github.com/anandthakker/doiuse
 [`rtlcss`]:                     https://github.com/MohammadYounes/rtlcss
 [`short`]:                      https://github.com/jonathantneal/postcss-short
@@ -240,8 +242,7 @@ Then create `postcss.config.js`:
 ```js
 module.exports = {
   plugins: [
-    require('autoprefixer'),
-    require('postcss-nested')
+    require('autoprefixer')
   ]
 }
 ```
@@ -258,8 +259,7 @@ in project’s root:
 ```js
 module.exports = {
   plugins: [
-    require('autoprefixer'),
-    require('postcss-nested')
+    require('autoprefixer')
   ]
 }
 ```
@@ -307,6 +307,7 @@ Then create `postcss.config.js`:
 ```js
 module.exports = {
   plugins: [
+    require('postcss-nested'),
     require('autoprefixer')
   ]
 }
@@ -406,10 +407,11 @@ For other environments, you can use the JS API:
 ```js
 const autoprefixer = require('autoprefixer')
 const postcss = require('postcss')
+const postcssNested = require('postcss-nested')
 const fs = require('fs')
 
 fs.readFile('src/app.css', (err, css) => {
-  postcss([autoprefixer])
+  postcss([postcssNested, autoprefixer])
     .process(css, { from: 'src/app.css', to: 'dest/app.css' })
     .then(result => {
       fs.writeFile('dest/app.css', result.css, () => true)

--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ Then create `postcss.config.js`:
 ```js
 module.exports = {
   plugins: [
-    require('autoprefixer')
+    require('autoprefixer'),
+    require('postcss-nested')
   ]
 }
 ```
@@ -259,7 +260,8 @@ in project’s root:
 ```js
 module.exports = {
   plugins: [
-    require('autoprefixer')
+    require('autoprefixer'),
+    require('postcss-nested')
   ]
 }
 ```
@@ -307,8 +309,8 @@ Then create `postcss.config.js`:
 ```js
 module.exports = {
   plugins: [
-    require('postcss-nested'),
-    require('autoprefixer')
+    require('autoprefixer'),
+    require('postcss-nested')
   ]
 }
 ```
@@ -327,7 +329,7 @@ gulp.task('css', () => {
 
   return gulp.src('src/**/*.css')
     .pipe( sourcemaps.init() )
-    .pipe( postcss([ require('autoprefixer') ]) )
+    .pipe( postcss([ require('autoprefixer'), require('postcss-nested') ]) )
     .pipe( sourcemaps.write('.') )
     .pipe( gulp.dest('build/') )
 })
@@ -411,7 +413,7 @@ const postcssNested = require('postcss-nested')
 const fs = require('fs')
 
 fs.readFile('src/app.css', (err, css) => {
-  postcss([postcssNested, autoprefixer])
+  postcss([autoprefixer, postcssNested])
     .process(css, { from: 'src/app.css', to: 'dest/app.css' })
     .then(result => {
       fs.writeFile('dest/app.css', result.css, () => true)


### PR DESCRIPTION
A fresh install of postcss and precss throws this error:

> Unknown error from PostCSS plugin. Your current PostCSS version is 8.3.6, but precss uses 7.0.36.

Precss seems to be no longer maintained, and I suggest removing it from the Readme. [Last commit](https://github.com/csstools/precss/commits/master) was 3 years ago.