### PR TITLE
Remove remaining references to unmaintained precss

### DIFF
--- a/docs/README-cn.md
+++ b/docs/README-cn.md
@@ -57,7 +57,6 @@ PostCSS 插件），请联系 [Evil Martians](https://evilmartians.com/?utm_sou
 
 ### 更佳的 CSS 可读性
 
-* [`precss`] 囊括了许多插件来支持类似 Sass 的特性，比如 CSS 变量，套嵌，mixins 等。
 * [`postcss-sorting`] 给规则的内容以及@规则排序。
 * [`postcss-utilities`] 囊括了最常用的简写方式和书写帮助。
 * [`short`] 添加并拓展了大量的缩写属性。

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -40,7 +40,6 @@ Or enable plugins directly in CSS using [`postcss-use`]:
 * [`cssnano`] contains plugins that optimize CSS size for use in production.
 * [`oldie`] contains plugins that transform your CSS
   for older Internet Explorer compatibility.
-* [`precss`] contains plugins that allow you to use Sass-like CSS.
 * [`rucksack`] contains plugins to speed up CSS development
   with new features and shortcuts.
 * [`level4`] contains only plugins that let you write CSS4 without

--- a/lib/processor.d.ts
+++ b/lib/processor.d.ts
@@ -14,7 +14,7 @@ import Root from './root.js'
  * initialize its plugins, and then use that instance on numerous CSS files.
  *
  * ```js
- * const processor = postcss([autoprefixer, precss])
+ * const processor = postcss([autoprefixer, postcss-nested])
  * processor.process(css1).then(result => console.log(result.css))
  * processor.process(css2).then(result => console.log(result.css))
  * ```
@@ -35,7 +35,7 @@ export default class Processor {
    * Plugins added to this processor.
    *
    * ```js
-   * const processor = postcss([autoprefixer, precss])
+   * const processor = postcss([autoprefixer, postcss-nested])
    * processor.plugins.length //=> 2
    * ```
    */
@@ -67,7 +67,7 @@ export default class Processor {
    * ```js
    * const processor = postcss()
    *   .use(autoprefixer)
-   *   .use(precss)
+   *   .use(postcss-nested)
    * ```
    *
    * @param plugin PostCSS plugin or `Processor` with plugins.


### PR DESCRIPTION
The precss plugin appears to be unmaintained, and does not support newer versions of PostCSS.

[References to precss were removed from the Readme back in August.](https://github.com/postcss/postcss/commit/e924aa05004ca1de91ddf06963734fadf4cc3c5f) But I forgot to search the repo for any other references, so this PR finishes removing/replacing other references to that plugin.

`docs/plugins.md` already has `postcss-nested` listed.

I did not add `postcss-nested` as a replacement in `docs/README-cn.md` as I don't know the language.