### PR TITLE
fix: add `Document` to result sets and default parser type

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -222,7 +222,7 @@ export type AcceptedPlugin =
     }
   | Processor
 
-export interface Parser<RootNode = Root> {
+export interface Parser<RootNode = Root | Document> {
   (
     css: string | { toString(): string },
     opts?: Pick<ProcessOptions, 'map' | 'from'>
@@ -246,7 +246,7 @@ export interface Syntax {
   /**
    * Function to generate AST by string.
    */
-  parse?: Parser<Root | Document>
+  parse?: Parser
 
   /**
    * Class to generate string by AST.
@@ -379,7 +379,7 @@ export interface Postcss {
    * root1.append(root2).toResult().css
    * ```
    */
-  parse: Parser
+  parse: Parser<Root>
 
   /**
    * Rehydrate a JSON AST (from `Node#toJSON`) back into the AST classes.
@@ -459,7 +459,7 @@ export interface Postcss {
 }
 
 export const stringify: Stringifier
-export const parse: Parser
+export const parse: Parser<Root>
 export const fromJSON: JSONHydrator
 
 export const comment: Postcss['comment']

--- a/lib/result.d.ts
+++ b/lib/result.d.ts
@@ -4,6 +4,7 @@ import {
   SourceMap,
   TransformCallback,
   Root,
+  Document,
   Node,
   Warning,
   WarningOptions
@@ -94,7 +95,7 @@ export default class Result {
    * root.toResult().root === root
    * ```
    */
-  root: Root
+  root: Root | Document
 
   /**
    * Options from the `Processor#process` or `Root#toResult` call
@@ -141,7 +142,7 @@ export default class Result {
    * @param root      Root node after all transformations.
    * @param opts      Options from the `Processor#process` or `Root#toResult`.
    */
-  constructor(processor: Processor, root: Root, opts: ResultOptions)
+  constructor(processor: Processor, root: Root | Document, opts: ResultOptions)
 
   /**
    * An alias for the `Result#css` property.


### PR DESCRIPTION
Fixes #1667

A `Result` can now contain a root which is ` Document`. For example, a
custom syntax may produce a `Document` containing several nested `Root`
stylesheets.

Similarly, the default type parameter of `Parser` has been updated to
include `Document` since custom syntaxes must account for this anyway.

FYI the casts in the tests shouldn't reduce our test accuracy, since if the type was anything which doesn't cross over with `Root`, typescript would complain.