### PR TITLE
feat: Support ranges for errors and warnings

### DIFF
--- a/lib/css-syntax-error.d.ts
+++ b/lib/css-syntax-error.d.ts
@@ -1,6 +1,21 @@
 import { FilePosition } from './input.js'
 
 /**
+ * A position that is part of a range.
+ */
+export interface RangePosition {
+  /**
+   * The line number in the input.
+   */
+  line: number
+
+  /**
+   * The column number in the input.
+   */
+  column: number
+}
+
+/**
  * The CSS parser throws this error for broken CSS.
  *
  * Custom parsers can throw this error for broken custom syntax using
@@ -31,17 +46,21 @@ import { FilePosition } from './input.js'
  */
 export default class CssSyntaxError {
   /**
-   * @param message Error message.
-   * @param line    Source line of the error.
-   * @param column  Source column of the error.
-   * @param source  Source code of the broken file.
-   * @param file    Absolute path to the broken file.
-   * @param plugin  PostCSS plugin name, if error came from plugin.
+   * Instantiates a CSS syntax error. Can be instantiated for a single position
+   * or for a range.
+   * @param message        Error message.
+   * @param lineOrStartPos If for a single position, the line number, or if for
+   *                       a range, the inclusive start position of the error.
+   * @param columnOrEndPos If for a single position, the column number, or if for
+   *                       a range, the exclusive end position of the error.
+   * @param source         Source code of the broken file.
+   * @param file           Absolute path to the broken file.
+   * @param plugin         PostCSS plugin name, if error came from plugin.
    */
   constructor(
     message: string,
-    line?: number,
-    column?: number,
+    lineOrStartPos?: number | RangePosition,
+    columnOrEndPos?: number | RangePosition,
     source?: string,
     file?: string,
     plugin?: string
@@ -120,6 +139,34 @@ export default class CssSyntaxError {
    * If you need the position in the PostCSS input, use `error.input.column`.
    */
   column?: number
+
+  /**
+   * Source line of the error's end, exclusive. Provided if the error pertains
+   * to a range.
+   *
+   * ```js
+   * error.endLine       //=> 3
+   * error.input.endLine //=> 4
+   * ```
+   *
+   * PostCSS will use the input source map to detect the original location.
+   * If you need the position in the PostCSS input, use `error.input.endLine`.
+   */
+  endLine?: number
+
+  /**
+   * Source column of the error's end, exclusive. Provided if the error pertains
+   * to a range.
+   *
+   * ```js
+   * error.endColumn       //=> 1
+   * error.input.endColumn //=> 4
+   * ```
+   *
+   * PostCSS will use the input source map to detect the original location.
+   * If you need the position in the PostCSS input, use `error.input.endColumn`.
+   */
+  endColumn?: number
 
   /**
    * Source code of the broken file.

--- a/lib/css-syntax-error.js
+++ b/lib/css-syntax-error.js
@@ -20,8 +20,15 @@ class CssSyntaxError extends Error {
       this.plugin = plugin
     }
     if (typeof line !== 'undefined' && typeof column !== 'undefined') {
-      this.line = line
-      this.column = column
+      if (typeof line === 'number') {
+        this.line = line
+        this.column = column
+      } else {
+        this.line = line.line
+        this.column = line.column
+        this.endLine = column.line
+        this.endColumn = column.column
+      }
     }
 
     this.setMessage()

--- a/lib/input.d.ts
+++ b/lib/input.d.ts
@@ -13,14 +13,24 @@ export interface FilePosition {
   file?: string
 
   /**
-   * Line in source file.
+   * Line of inclusive start position in source file.
    */
   line: number
 
   /**
-   * Column in source file.
+   * Column of inclusive start position in source file.
    */
   column: number
+
+  /**
+   * Line of exclusive end position in source file.
+   */
+  endLine?: number
+
+  /**
+   * Column of exclusive end position in source file.
+   */
+  endColumn?: number
 
   /**
    * Source code.
@@ -108,18 +118,28 @@ export default class Input {
   /**
    * Reads the input source map and returns a symbol position
    * in the input source (e.g., in a Sass file that was compiled
-   * to CSS before being passed to PostCSS).
+   * to CSS before being passed to PostCSS). Optionally takes an
+   * end position, exclusive.
    *
    * ```js
    * root.source.input.origin(1, 1) //=> { file: 'a.css', line: 3, column: 1 }
+   * root.source.input.origin(1, 1, 1, 4)
+   * //=> { file: 'a.css', line: 3, column: 1, endLine: 3, endColumn: 4 }
    * ```
    *
-   * @param line   Line in input CSS.
-   * @param column Column in input CSS.
+   * @param line      Line for inclusive start position in input CSS.
+   * @param column    Column for inclusive start position in input CSS.
+   * @param endLine   Line for exclusive end position in input CSS.
+   * @param endColumn Column for exclusive end position in input CSS.
    *
    * @return Position in input source.
    */
-  origin(line: number, column: number): FilePosition | false
+  origin(
+    line: number,
+    column: number,
+    endLine?: number,
+    endColumn?: number
+  ): FilePosition | false
 
   /**
    * Converts source offset to line and column.

--- a/lib/input.js
+++ b/lib/input.js
@@ -103,18 +103,43 @@ class Input {
   }
 
   error(message, line, column, opts = {}) {
-    let result
-    if (!column) {
+    let result, endLine, endColumn
+
+    if (line && typeof line === 'object') {
+      let start = line
+      let end = column
+      if (typeof line.offset === 'number') {
+        let pos = this.fromOffset(start.offset)
+        line = pos.line
+        column = pos.col
+      } else {
+        line = start.line
+        column = start.column
+      }
+      if (typeof end.offset === 'number') {
+        let pos = this.fromOffset(end.offset)
+        endLine = pos.line
+        endColumn = pos.col
+      } else {
+        endLine = end.line
+        endColumn = end.column
+      }
+    } else if (!column) {
       let pos = this.fromOffset(line)
       line = pos.line
       column = pos.col
     }
-    let origin = this.origin(line, column)
+
+    let origin = this.origin(line, column, endLine, endColumn)
     if (origin) {
       result = new CssSyntaxError(
         message,
-        origin.line,
-        origin.column,
+        origin.endLine === undefined
+          ? origin.line
+          : { line: origin.line, column: origin.column },
+        origin.endLine === undefined
+          ? origin.column
+          : { line: origin.endLine, column: origin.endColumn },
         origin.source,
         origin.file,
         opts.plugin
@@ -122,15 +147,15 @@ class Input {
     } else {
       result = new CssSyntaxError(
         message,
-        line,
-        column,
+        endLine === undefined ? line : { line, column },
+        endLine === undefined ? column : { line: endLine, column: endColumn },
         this.css,
         this.file,
         opts.plugin
       )
     }
 
-    result.input = { line, column, source: this.css }
+    result.input = { line, column, endLine, endColumn, source: this.css }
     if (this.file) {
       if (pathToFileURL) {
         result.input.url = pathToFileURL(this.file).toString()
@@ -141,12 +166,17 @@ class Input {
     return result
   }
 
-  origin(line, column) {
+  origin(line, column, endLine, endColumn) {
     if (!this.map) return false
     let consumer = this.map.consumer()
 
     let from = consumer.originalPositionFor({ line, column })
     if (!from.source) return false
+
+    let to
+    if (typeof endLine === 'number') {
+      to = consumer.originalPositionFor({ line: endLine, column: endColumn })
+    }
 
     let fromUrl
 
@@ -162,7 +192,9 @@ class Input {
     let result = {
       url: fromUrl.toString(),
       line: from.line,
-      column: from.column
+      column: from.column,
+      endLine: to && to.line,
+      endColumn: to && to.column
     }
 
     if (fromUrl.protocol === 'file:') {

--- a/lib/node.d.ts
+++ b/lib/node.d.ts
@@ -38,6 +38,18 @@ export interface Position {
   line: number
 }
 
+export interface Range {
+  /**
+   * Start position, inclusive.
+   */
+  start: Position
+
+  /**
+   * End position, exclusive.
+   */
+  end: Position
+}
+
 export interface Source {
   /**
    * The file source of the node.
@@ -72,6 +84,11 @@ interface NodeErrorOptions {
    * of error.
    */
   index?: number
+  /**
+   * An ending index inside a node's string that should be highlighted as
+   * source of error.
+   */
+  endIndex?: number
 }
 
 /**
@@ -441,4 +458,21 @@ export default abstract class Node {
    * @return Symbol position in file.
    */
   positionInside(index: number): Position
+
+  /**
+   * Get the position for a word or an index inside the node.
+   *
+   * @param opts Options.
+   * @return Position.
+   */
+  positionBy(opts?: Pick<WarningOptions, 'word' | 'index'>): Position
+
+  /**
+   * Get the range for a word or start and end index inside the node.
+   * The start index is inclusive; the end index is exclusive.
+   *
+   * @param opts Options.
+   * @return Range.
+   */
+  rangeBy(opts?: Pick<WarningOptions, 'word' | 'index' | 'endIndex'>): Range
 }

--- a/lib/node.js
+++ b/lib/node.js
@@ -56,8 +56,18 @@ class Node {
 
   error(message, opts = {}) {
     if (this.source) {
-      let pos = this.positionBy(opts)
-      return this.source.input.error(message, pos.line, pos.column, opts)
+      if (opts.word || opts.endIndex) {
+        let { start, end } = this.rangeBy(opts)
+        return this.source.input.error(
+          message,
+          { line: start.line, column: start.column },
+          { line: end.line, column: end.column },
+          opts
+        )
+      }
+
+      let start = this.positionBy(opts)
+      return this.source.input.error(message, start.line, start.column, opts)
     }
     return new CssSyntaxError(message)
   }
@@ -250,6 +260,28 @@ class Node {
       if (index !== -1) pos = this.positionInside(index)
     }
     return pos
+  }
+
+  rangeBy(opts) {
+    if (opts.word) {
+      let index = this.toString().indexOf(opts.word)
+      if (index !== -1) {
+        return {
+          start: this.positionInside(index),
+          end: this.positionInside(index + opts.word.length)
+        }
+      }
+    }
+
+    let { start } = this.source
+    let end = start
+    if (opts.index) {
+      start = this.positionInside(opts.index)
+    }
+    if (opts.endIndex) {
+      end = this.positionInside(opts.endIndex)
+    }
+    return { start, end }
   }
 
   getProxyProcessor() {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -511,15 +511,27 @@ class Parser {
   // Errors
 
   unclosedBracket(bracket) {
-    throw this.input.error('Unclosed bracket', bracket[2])
+    throw this.input.error(
+      'Unclosed bracket',
+      { offset: bracket[2] },
+      { offset: bracket[2] + 1 }
+    )
   }
 
   unknownWord(tokens) {
-    throw this.input.error('Unknown word', tokens[0][2])
+    throw this.input.error(
+      'Unknown word',
+      { offset: tokens[0][2] },
+      { offset: tokens[0][2] + tokens[0][1].length }
+    )
   }
 
   unexpectedClose(token) {
-    throw this.input.error('Unexpected }', token[2])
+    throw this.input.error(
+      'Unexpected }',
+      { offset: token[2] },
+      { offset: token[2] + 1 }
+    )
   }
 
   unclosedBlock() {
@@ -528,11 +540,19 @@ class Parser {
   }
 
   doubleColon(token) {
-    throw this.input.error('Double colon', token[2])
+    throw this.input.error(
+      'Double colon',
+      { offset: token[2] },
+      { offset: token[2] + token[1].length }
+    )
   }
 
   unnamedAtrule(node, token) {
-    throw this.input.error('At-rule without name', token[2])
+    throw this.input.error(
+      'At-rule without name',
+      { offset: token[2] },
+      { offset: token[2] + token[1].length }
+    )
   }
 
   precheckMissedSemicolon(/* tokens */) {

--- a/lib/warning.d.ts
+++ b/lib/warning.d.ts
@@ -12,9 +12,14 @@ export interface WarningOptions {
   word?: string
 
   /**
-   * Index in CSS node string that caused the warning.
+   * Start index, inclusive, in CSS node string that caused the warning.
    */
   index?: number
+
+  /**
+   * End index, exclusive, in CSS node string that caused the warning.
+   */
+  endIndex?: number
 
   /**
    * Name of the plugin that created this warning. `Result#warn` fills
@@ -68,7 +73,7 @@ export default class Warning {
   node: Node
 
   /**
-   * Line in the input file with this warning’s source.
+   * Line for inclusive start position in the input file with this warning’s source.
    *
    * ```js
    * warning.line //=> 5
@@ -77,13 +82,31 @@ export default class Warning {
   line: number
 
   /**
-   * Column in the input file with this warning’s source.
+   * Column for inclusive start position in the input file with this warning’s source.
    *
    * ```js
    * warning.column //=> 6
    * ```
    */
   column: number
+
+  /**
+   * Line for exclusive end position in the input file with this warning’s source.
+   *
+   * ```js
+   * warning.endLine //=> 6
+   * ```
+   */
+  endLine?: number
+
+  /**
+   * Column for exclusive end position in the input file with this warning’s source.
+   *
+   * ```js
+   * warning.endColumn //=> 4
+   * ```
+   */
+  endColumn?: number
 
   /**
    * @param text Warning message.

--- a/lib/warning.js
+++ b/lib/warning.js
@@ -6,9 +6,27 @@ class Warning {
     this.text = text
 
     if (opts.node && opts.node.source) {
-      let pos = opts.node.positionBy(opts)
-      this.line = pos.line
-      this.column = pos.column
+      if (
+        opts.word ||
+        typeof opts.endLine === 'number' ||
+        typeof opts.endIndex === 'number'
+      ) {
+        let range = opts.node.rangeBy(opts)
+        this.line = range.start.line
+        this.column = range.start.column
+
+        if (
+          range.start.line !== range.end.line ||
+          range.start.column !== range.end.column
+        ) {
+          this.endLine = range.end.line
+          this.endColumn = range.end.column
+        }
+      } else {
+        let pos = opts.node.positionBy(opts)
+        this.line = pos.line
+        this.column = pos.column
+      }
     }
 
     for (let opt in opts) this[opt] = opts[opt]

--- a/test/css-syntax-error.test.ts
+++ b/test/css-syntax-error.test.ts
@@ -62,6 +62,28 @@ it('saves source', () => {
   })
 })
 
+it('saves source with ranges', () => {
+  let error = parseError('badword')
+
+  expect(error instanceof CssSyntaxError).toBe(true)
+  expect(error.name).toBe('CssSyntaxError')
+  expect(error.message).toBe('<css input>:1:1: Unknown word')
+  expect(error.reason).toBe('Unknown word')
+  expect(error.line).toBe(1)
+  expect(error.column).toBe(1)
+  expect(error.endLine).toBe(1)
+  expect(error.endColumn).toBe(8)
+  expect(error.source).toBe('badword')
+
+  expect(error.input).toEqual({
+    line: error.line,
+    column: error.column,
+    endLine: error.endLine,
+    endColumn: error.endColumn,
+    source: error.source
+  })
+})
+
 it('has stack trace', () => {
   expect(parseError('a {\n  content: "\n}').stack).toMatch(
     /css-syntax-error\.test\.ts/

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -409,3 +409,37 @@ it('positionInside() returns position when node contains newlines', () => {
   let one = a.first as Declaration
   expect(one.positionInside(10)).toEqual({ line: 3, column: 4 })
 })
+
+it('positionBy() returns position for word', () => {
+  let css = parse('a {  one: X  }')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  expect(one.positionBy({ word: 'one' })).toEqual({ line: 1, column: 6 })
+})
+
+it('positionBy() returns position for index', () => {
+  let css = parse('a {  one: X  }')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  expect(one.positionBy({ index: 1 })).toEqual({ line: 1, column: 7 })
+})
+
+it('rangeBy() returns range for word', () => {
+  let css = parse('a {  one: X  }')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  expect(one.rangeBy({ word: 'one' })).toEqual({
+    start: { line: 1, column: 6 },
+    end: { line: 1, column: 9 }
+  })
+})
+
+it('rangeBy() returns range for index and endIndex', () => {
+  let css = parse('a {  one: X  }')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  expect(one.rangeBy({ index: 1, endIndex: 3 })).toEqual({
+    start: { line: 1, column: 7 },
+    end: { line: 1, column: 9 }
+  })
+})

--- a/test/previous-map.test.ts
+++ b/test/previous-map.test.ts
@@ -247,18 +247,23 @@ it('uses source map path as a root', () => {
     join(dir, 'maps', 'a.map'),
     JSON.stringify({
       version: 3,
-      mappings: 'AAAA,CAAC;EAAC,CAAC,EAAC,CAAC',
+      file: 'test.css',
       sources: ['../../test.scss'],
-      names: [],
-      file: 'test.css'
+      mappings: 'AACA,CAAC,CACG,GAAG,CAAC;EACF,KAAK,EAAE,GAAI;CACZ',
+      names: []
     })
   )
-  let root = parse('a{}\n/*# sourceMappingURL=maps/a.map */', { from })
-  expect(root.source?.input.origin(1, 1)).toEqual({
+  let root = parse(
+    '* div {\n  color: red;\n  }\n/*# sourceMappingURL=maps/a.map */',
+    { from }
+  )
+  expect(root.source?.input.origin(1, 3, 1, 5)).toEqual({
     url: pathToFileURL(join(dir, '..', 'test.scss')).href,
     file: join(dir, '..', 'test.scss'),
-    line: 1,
-    column: 1
+    line: 3,
+    column: 4,
+    endLine: 3,
+    endColumn: 7
   })
 })
 

--- a/test/warning.test.ts
+++ b/test/warning.test.ts
@@ -69,11 +69,13 @@ it('gets position from node', () => {
   expect(warning.column).toBe(1)
 })
 
-it('gets position from word', () => {
+it('gets range from word', () => {
   let root = parse('a b{}')
   let warning = new Warning('text', { node: root.first, word: 'b' })
   expect(warning.line).toBe(1)
   expect(warning.column).toBe(3)
+  expect(warning.endLine).toBe(1)
+  expect(warning.endColumn).toBe(4)
 })
 
 it('gets position from index', () => {
@@ -81,4 +83,13 @@ it('gets position from index', () => {
   let warning = new Warning('text', { node: root.first, index: 2 })
   expect(warning.line).toBe(1)
   expect(warning.column).toBe(3)
+})
+
+it('gets range from index and endIndex', () => {
+  let root = parse('a b{}')
+  let warning = new Warning('text', { node: root.first, index: 2, endIndex: 3 })
+  expect(warning.line).toBe(1)
+  expect(warning.column).toBe(3)
+  expect(warning.endLine).toBe(1)
+  expect(warning.endColumn).toBe(4)
 })


### PR DESCRIPTION
Context: https://github.com/stylelint/vscode-stylelint/issues/315, https://github.com/stylelint/stylelint/issues/5694

Allows for better diagnostics in linters, language servers, and plugins.

Currently, since only single positions are supported, this means that downstream, when we display errors in different tools, in my particular case, a language server and editor integration, we can only display a single position as part of the error, even when the error pertains to more than just one character.

These changes allow warnings and errors to be emitted with an additional `endLine` and `endColumn` which pertains to an end position, exclusive, of the problem. It also adjusts CSS syntax errors to always provide an end position for consistency. With these additions, we would be able to better highlight problems in Stylelint and other tools and use that information in integrations for a better developer experience.

- End position is exclusive for consistency with Language Server Protocol ranges
- Tests added for ranges
- Default warning message text is unchanged and still shows a single position
- Additional properties added to warnings, warning options, errors, and file positions
- `rangeBy` added, which provides a range for a given word or start and end indices
- Changes to functions made in such a way that they can still be called with their former signatures to avoid breaking existing dependent code