### PR TITLE
fix: make test script work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "transpiler"
   ],
   "scripts": {
-    "test": "jest --coverage && eslint . && ./test/version.js && check-dts && ./test/integration.js && size-limit"
+    "test": "jest --coverage && eslint . && node ./test/version.js && check-dts && node ./test/integration.js && size-limit"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
Running `./script.js` doesn't work on Windows, only `node ./script.js` does. This patch updates the test script so that it works on Windows as well as on other platforms.