### PR TITLE
fix: make test script work on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: windows-latest
     name: Windows Quick
     env:
-      YARN_GPG: "no"
+      YARN_GPG: 'no'
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
@@ -60,6 +60,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Run unit tests
-        run: yarn uvu -r ts-node/register/transpile-only test "^.*test.([tj]s)"
+        run: yarn unit
         env:
           FORCE_COLOR: 2

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   ],
   "scripts": {
     "test": "c8 yarn unit && eslint . && node ./test/version.js && check-dts && node ./test/integration.js && size-limit",
-    "unit": "uvu -r ts-node/register/transpile-only test '\\.test\\.(ts|js)$'"
+    "unit": "uvu -r ts-node/register/transpile-only test \"\\.test\\.(ts|js)$\""
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
The unit script was using single quotes, so it wouldn't work on Windows. This PR updates the script to use double quotes, which allows it to work on all platforms.