### PR TITLE
docs: :memo: Add plugin to docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -483,6 +483,7 @@ See also plugins in modular minifier [`cssnano`].
 * [`postcss-viewport-height-correction`] solves the popular problem when `100vh`
   doesn’t fit the mobile browser screen.
 * [`postcss-unit-processor`] flexible processing of CSS units.
+* [`postcss-rem-to-px`] converts `rem` values to `px` values.
 
 
 [flexbox bugs]: https://github.com/philipwalton/flexbugs
@@ -876,5 +877,6 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-icon-blender`]:                 https://github.com/icon-blender/postcss-icon-blender
 [`postcss-variable-compress`]:            https://github.com/navanshu/postcss-variable-compress
 [`postcss-unit-processor`]:               https://github.com/hex-ci/postcss-unit-processor
+[`postcss-rem-to-px`]:                    https://github.com/TheDutchCoder/postcss-rem-to-px
 [`postcss-prefix-hover`]:                 https://github.com/larsmunkholm/postcss-prefix-hover
 [`postcss-resolve-urls`]:                 https://github.com/bognarlaszlo/postcss-resolve-urls


### PR DESCRIPTION
Adds the `postcss-rem-to-px` plugin to the docs.
This seems to be the only plugin that correctly converts negative values as well.