### PR TITLE
fix: export stringifier as a default

### DIFF
--- a/lib/stringifier.d.ts
+++ b/lib/stringifier.d.ts
@@ -10,7 +10,8 @@ import {
   Container
 } from './postcss.js'
 
-export class Stringifier {
+export default class Stringifier {
+  builder: Builder
   constructor(builder: Builder)
   stringify(node: AnyNode, semicolon?: boolean): void
   document(node: Document): void


### PR DESCRIPTION
@ai is there any chance we can get some kind of hotfix release out for 8.4?

i was an idiot and exported the stringifier named, rather than as a default... it is actually a default export 🤦‍♂️ 