### PR TITLE
[docs] add link to Svelte preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,11 +400,7 @@ const result = await postcss([autoprefixer]).process(css)
 * **Taskr**: [`taskr-postcss`](https://github.com/lukeed/taskr/tree/master/packages/postcss)
 * **Start**: [`start-postcss`](https://github.com/start-runner/postcss)
 * **Connect/Express**: [`postcss-middleware`](https://github.com/jedmao/postcss-middleware)
-
-
-### Preprocessors
-
-* **Svelte**: [`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess/blob/main/docs/preprocessing.md#postcss-sugarss)
+* **Svelte Preprocessor**: [`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess/blob/main/docs/preprocessing.md#postcss-sugarss)
 
 
 ### JS API

--- a/README.md
+++ b/README.md
@@ -402,6 +402,11 @@ const result = await postcss([autoprefixer]).process(css)
 * **Connect/Express**: [`postcss-middleware`](https://github.com/jedmao/postcss-middleware)
 
 
+### Preprocessors
+
+* **Svelte**: [`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess/blob/main/docs/preprocessing.md#postcss-sugarss)
+
+
 ### JS API
 
 For other environments, you can use the JS API:


### PR DESCRIPTION
To use PostCSS with Svelte, you must install the preprocessor which first converts PostCSS syntax into regular CSS so that the Svelte compiler can handle it