### PR TITLE
fix: allow all `raws` to be extended

### DIFF
--- a/lib/at-rule.d.ts
+++ b/lib/at-rule.d.ts
@@ -1,6 +1,6 @@
 import Container, { ContainerProps } from './container.js'
 
-interface AtRuleRaws {
+interface AtRuleRaws extends Record<string, unknown> {
   /**
    * The space symbols before the node. It also stores `*`
    * and `_` symbols before the declaration (IE hack).

--- a/lib/comment.d.ts
+++ b/lib/comment.d.ts
@@ -1,7 +1,7 @@
 import Container from './container.js'
 import Node, { NodeProps } from './node.js'
 
-interface CommentRaws {
+interface CommentRaws extends Record<string, unknown> {
   /**
    * The space symbols before the node.
    */

--- a/lib/declaration.d.ts
+++ b/lib/declaration.d.ts
@@ -1,7 +1,7 @@
 import Container from './container.js'
 import Node from './node.js'
 
-interface DeclarationRaws {
+interface DeclarationRaws extends Record<string, unknown> {
   /**
    * The space symbols before the node. It also stores `*`
    * and `_` symbols before the declaration (IE hack).

--- a/lib/rule.d.ts
+++ b/lib/rule.d.ts
@@ -1,6 +1,6 @@
 import Container, { ContainerProps } from './container.js'
 
-interface RuleRaws {
+interface RuleRaws extends Record<string, unknown> {
   /**
    * The space symbols before the node. It also stores `*`
    * and `_` symbols before the declaration (IE hack).


### PR DESCRIPTION
Fixes #1691 

These didn't have extensible raws before:

- at-rule
- comment
- declaration
- rule

I've also used `unknown` here, as a way to push consumers to type check before usage. if you'd rather have `any`, let me know and i will change it.