### PR TITLE
Fix `append()` failing after mutating nodes through .parent

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -326,7 +326,7 @@ class Container extends Node {
           i.raws.before = sample.raws.before.replace(/\S/g, '')
         }
       }
-      i.parent = this
+      i.parent = this.proxyOf
       return i
     })
 


### PR DESCRIPTION
Fixes #1738

I wasn't quite sure where to put the test but the gist of the issue is that

1. `node.append` calls `node.normalize`
2. `node.normalize` sets the parent to `this`.

The problem arises when `node` is a proxy. This means that `this` ends up being a proxy instead of the raw node. Assigning the proxy to the "raw" child node's parent has a side-effect of causing `proxyOf.nodes` to contain proxies rather than raw postcss nodes.

This causes `indexOf` lookups to fail since they're sadly not transparent to Proxies b/c of object identity.
Later on `append` tries to use this index assuming that the nodes passed in are definitely children and have been found and crashes.

I'm not 100% sure this is the right fix because the interactions just to get this to happen are fairly specific. Change any number of things and it all magically works. But, it seems reasonable.

I noticed that the `.push` method sets the parent as well but I don't have a test case where it's affected so I've not updated it. I might be able to come up with a test case if needed. Also, if you have any suggestions for reducing the test case I've got in this PR I would love some because it seems like it's a bit much for such a "simple" fix.