### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 
 [PostCSS plugin development]:   https://github.com/postcss/postcss/blob/main/docs/writing-a-plugin.md
 [`postcss-inline-svg`]:         https://github.com/TrySound/postcss-inline-svg
-[`postcss-preset-env`]:         https://github.com/jonathantneal/postcss-preset-env
+[`postcss-preset-env`]:         https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env
 [`react-css-modules`]:          https://github.com/gajus/react-css-modules
 [`postcss-autoreset`]:          https://github.com/maximkoretskiy/postcss-autoreset
 [`postcss-write-svg`]:          https://github.com/jonathantneal/postcss-write-svg


### PR DESCRIPTION
Update the link to postcss-preset-env plugin.
The repo was moved to https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env