### PR TITLE
fix: print deprecation warning only when plugin is used

### DIFF
--- a/lib/postcss.js
+++ b/lib/postcss.js
@@ -27,25 +27,27 @@ function postcss(...plugins) {
 }
 
 postcss.plugin = function plugin(name, initializer) {
-  // eslint-disable-next-line no-console
-  if (console && console.warn) {
+  let warningPrinted = false
+  function creator(...args) {
     // eslint-disable-next-line no-console
-    console.warn(
-      name +
-        ': postcss.plugin was deprecated. Migration guide:\n' +
-        'https://evilmartians.com/chronicles/postcss-8-plugin-migration'
-    )
-    if (process.env.LANG && process.env.LANG.startsWith('cn')) {
-      /* c8 ignore next 7 */
+    if (console && console.warn && !warningPrinted) {
+      warningPrinted = true
       // eslint-disable-next-line no-console
       console.warn(
         name +
-          ': 里面 postcss.plugin 被弃用. 迁移指南:\n' +
-          'https://www.w3ctech.com/topic/2226'
+          ': postcss.plugin was deprecated. Migration guide:\n' +
+          'https://evilmartians.com/chronicles/postcss-8-plugin-migration'
       )
+      if (process.env.LANG && process.env.LANG.startsWith('cn')) {
+        /* c8 ignore next 7 */
+        // eslint-disable-next-line no-console
+        console.warn(
+          name +
+            ': 里面 postcss.plugin 被弃用. 迁移指南:\n' +
+            'https://www.w3ctech.com/topic/2226'
+        )
+      }
     }
-  }
-  function creator(...args) {
     let transformer = initializer(...args)
     transformer.postcssPlugin = name
     transformer.postcssVersion = new Processor().version

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -122,9 +122,12 @@ test('has deprecated method to creat plugins', () => {
     }
   })
 
+  equal(warn.callCount, 0)
+
   let func1: any = postcss(plugin).plugins[0]
   is(func1.postcssPlugin, 'test')
   match(func1.postcssVersion, /\d+.\d+.\d+/)
+  equal(warn.callCount, 1)
 
   let func2: any = postcss(plugin()).plugins[0]
   equal(func2.postcssPlugin, func1.postcssPlugin)
@@ -132,7 +135,6 @@ test('has deprecated method to creat plugins', () => {
 
   let result1 = postcss(plugin('one')).process('a{ one: 1; two: 2 }')
   is(result1.css, 'a{ two: 2 }')
-  equal(warn.callCount, 1)
 
   let result2 = postcss(plugin).process('a{ one: 1; two: 2 }')
   is(result2.css, 'a{ one: 1 }')

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -121,8 +121,6 @@ test('has deprecated method to creat plugins', () => {
       })
     }
   })
-  equal(warn.callCount, 1)
-  match(warn.calls[0][0], /postcss\.plugin was deprecated/)
 
   let func1: any = postcss(plugin).plugins[0]
   is(func1.postcssPlugin, 'test')
@@ -134,9 +132,13 @@ test('has deprecated method to creat plugins', () => {
 
   let result1 = postcss(plugin('one')).process('a{ one: 1; two: 2 }')
   is(result1.css, 'a{ two: 2 }')
+  equal(warn.callCount, 1)
 
   let result2 = postcss(plugin).process('a{ one: 1; two: 2 }')
   is(result2.css, 'a{ one: 1 }')
+
+  equal(warn.callCount, 1)
+  match(warn.calls[0][0], /postcss\.plugin was deprecated/)
 })
 
 test('creates a shortcut to process css', async () => {
@@ -148,7 +150,6 @@ test('creates a shortcut to process css', async () => {
       })
     }
   })
-  equal(warn.callCount, 1)
 
   let result1 = plugin.process('a{value:foo}')
   is(result1.css, 'a{value:bar}')
@@ -159,6 +160,8 @@ test('creates a shortcut to process css', async () => {
   let result = await plugin.process('a{value:foo}', { from: 'a' }, 'baz')
   equal(result.opts, { from: 'a' })
   is(result.css, 'a{value:baz}')
+
+  equal(warn.callCount, 1)
 })
 
 test('does not call plugin constructor', () => {
@@ -169,13 +172,14 @@ test('does not call plugin constructor', () => {
     return () => {}
   })
   is(calls, 0)
-  equal(warn.callCount, 1)
 
   postcss(plugin).process('a{}')
   is(calls, 1)
 
   postcss(plugin()).process('a{}')
   is(calls, 2)
+
+  equal(warn.callCount, 1)
 })
 
 test.run()

--- a/test/processor.test.ts
+++ b/test/processor.test.ts
@@ -390,8 +390,8 @@ test('checks plugin compatibility', () => {
       throw new Error('Er')
     }
   })
-  equal(warn.callCount, 1)
   let func = plugin()
+  equal(warn.callCount, 1)
   func.postcssVersion = '2.1.5'
 
   function processBy(version: string): void {
@@ -562,9 +562,9 @@ test('supports plugins returning processors', () => {
   let other: any = (postcss as any).plugin('test', () => {
     return new Processor([a])
   })
-  equal(warn.callCount, 1)
   processor.use(other)
   equal(processor.plugins, [a])
+  equal(warn.callCount, 1)
 })
 
 test('supports plugin creators returning processors', () => {


### PR DESCRIPTION
I use some CJS package and I import from its index.js the functionality I need, however it also exposes an old postcss plugin. I don't use it, so I think it makes more sense to print a warning only when the plugin is actually used. I also added a check to preserve behavior that the warning is being printed only once.