### PR TITLE
Replace two unmaintained plugins on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 
 ### Other
 
-* [`postcss-rtlcss`] postcss plugin to build CSS files with LTR and RTL rules.
 * [`cssnano`] is a modular CSS minifier.
 * [`lost`] is a feature-rich `calc()` grid system.
 * [`rtlcss`] mirrors styles for right-to-left locales.
@@ -135,7 +134,6 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 [`font-magician`]:              https://github.com/jonathantneal/postcss-font-magician
 [`autoprefixer`]:               https://github.com/postcss/autoprefixer
 [`cq-prolyfill`]:               https://github.com/ausi/cq-prolyfill
-[`postcss-rtlcss`]:             https://github.com/elchininet/postcss-rtlcss
 [`postcss-url`]:                https://github.com/postcss/postcss-url
 [`postcss-use`]:                https://github.com/postcss/postcss-use
 [`css-modules`]:                https://github.com/css-modules/css-modules

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 
 ### Images and Fonts
 
-* [`postcss-assets`] inserts image dimensions and inlines files.
+* [`postcss-url`] postcss plugin to rebase url(), inline or copy asset.
 * [`postcss-sprites`] generates image sprites.
 * [`font-magician`] generates all the `@font-face` rules needed in CSS.
 * [`postcss-inline-svg`] allows you to inline SVG and customize its styles.
@@ -116,7 +116,7 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 
 ### Other
 
-* [`postcss-rtl`] combines both-directional (left-to-right and right-to-left) styles in one CSS file.
+* [`postcss-rtlcss`] postcss plugin to build CSS files with LTR and RTL rules.
 * [`cssnano`] is a modular CSS minifier.
 * [`lost`] is a feature-rich `calc()` grid system.
 * [`rtlcss`] mirrors styles for right-to-left locales.
@@ -132,11 +132,11 @@ If you have any new ideas, [PostCSS plugin development] is really easy.
 [`postcss-sprites`]:            https://github.com/2createStudio/postcss-sprites
 [`postcss-modules`]:            https://github.com/outpunk/postcss-modules
 [`postcss-sorting`]:            https://github.com/hudochenkov/postcss-sorting
-[`postcss-assets`]:             https://github.com/assetsjs/postcss-assets
 [`font-magician`]:              https://github.com/jonathantneal/postcss-font-magician
 [`autoprefixer`]:               https://github.com/postcss/autoprefixer
 [`cq-prolyfill`]:               https://github.com/ausi/cq-prolyfill
-[`postcss-rtl`]:                https://github.com/vkalinichev/postcss-rtl
+[`postcss-rtlcss`]:             https://github.com/elchininet/postcss-rtlcss
+[`postcss-url`]:                https://github.com/postcss/postcss-url
 [`postcss-use`]:                https://github.com/postcss/postcss-use
 [`css-modules`]:                https://github.com/css-modules/css-modules
 [`webp-in-css`]:                https://github.com/ai/webp-in-css


### PR DESCRIPTION
This pull request replaces two unmaintained plugins on the favorite plugin list:

* `postcss-assets` by `postcss-url`
* `postcss-rtl` by `postcss-rtlcss`