### PR TITLE
chore: update vscode extension infomation

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,9 +475,9 @@ module.exports = {
 
 ### VS Code
 
-* [`mhmadhamster.postcss-language`] adds PostCSS and SugarSS support.
+* [`csstools.postcss`] adds PostCSS support.
 
-[`mhmadhamster.postcss-language`]: https://marketplace.visualstudio.com/items?itemName=mhmadhamster.postcss-language
+[`csstools.postcss`]: https://marketplace.visualstudio.com/items?itemName=csstools.postcss
 
 
 ### Atom


### PR DESCRIPTION
Looks like `mhmadhamster` unplublished the `postcss-language` extension.

> https://marketplace.visualstudio.com/items?itemName=mhmadhamster.postcss-language
![2022-06-15 14 36 27](https://user-images.githubusercontent.com/14012511/173758866-6aae2d58-6ee6-4a6b-b560-f2c660ee36f6.png)

So replace it with [csstools.postcss](https://marketplace.visualstudio.com/items?itemName=csstools.postcss) .. cc @ai 

