### PR TITLE
update plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -52,14 +52,14 @@ Or enable plugins directly in CSS using [`postcss-use`]:
   on your targeted browsers or runtime environments.
 * [`postcss-ui-theme`] gives you syntax sugar and allow you change theme.
 
-[`postcss-preset-env`]: https://github.com/jonathantneal/postcss-preset-env/
+[`postcss-preset-env`]: https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env
 [`postcss-utilities`]:  https://github.com/ismamz/postcss-utilities
 [`postcss-hamster`]:    https://github.com/h0tc0d3/postcss-hamster
 [`stylelint`]:          https://github.com/stylelint/stylelint
 [`rucksack`]:           https://github.com/seaneking/rucksack
 [`cssnano`]:            https://cssnano.co/
 [`level4`]:             https://github.com/stephenway/level4
-[`oldie`]:              https://github.com/jonathantneal/oldie
+[`oldie`]:              https://github.com/csstools/oldie
 [`atcss`]:              https://github.com/morishitter/atcss
 [`postcss-ui-theme`]:   https://github.com/cleverboy32/postcss-ui-theme
 
@@ -230,6 +230,8 @@ for targeting all button elements.
   to CSS variables.
 * [`postcss-easy-z`] lets you organize z-indices by declaring relations
   between them.
+* [`@csstools/postcss-design-tokens`] lets you import and use design tokens
+  from CSS.
 
 [Rust-style pattern matching]: https://doc.rust-lang.org/book/match.html
 
@@ -584,7 +586,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-background-image-auto-size`]:   https://github.com/JustClear/postcss-background-image-auto-size
 [`postcss-letter-tracking`]:              https://github.com/letsjaam/postcss-letter-tracking
 [`postcss-combine-duplicated-selectors`]: https://github.com/ChristianMurphy/postcss-combine-duplicated-selectors
-[`postcss-attribute-case-insensitive`]:   https://github.com/Semigradsky/postcss-attribute-case-insensitive
+[`postcss-attribute-case-insensitive`]:   https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-attribute-case-insensitive
 [`postcss-alter-property-value`]:         https://github.com/kunukn/postcss-alter-property-value
 [`postcss-attribute-selector-prefix`]:    https://github.com/GitScrum/postcss-attribute-selector-prefix
 [`postcss-gradient-transparency-fix`]:    https://github.com/gilmoreorless/postcss-gradient-transparency-fix
@@ -597,7 +599,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-andalusian-stylesheets`]:       https://github.com/bameda/postcss-andalusian-stylesheets
 [`postcss-australian-stylesheets`]:       https://github.com/dp-lewis/postcss-australian-stylesheets
 [`postcss-responsive-properties`]:        https://github.com/alexandr-solovyov/postcss-responsive-properties
-[`postcss-pseudo-class-any-link`]:        https://github.com/jonathantneal/postcss-pseudo-class-any-link
+[`postcss-pseudo-class-any-link`]:        https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-pseudo-class-any-link
 [`postcss-pseudo-content-insert`]:        https://github.com/liquidlight/postcss-pseudo-content-insert
 [`postcss-canadian-stylesheets`]:         https://github.com/chancancode/postcss-canadian-stylesheets
 [`postcss-increase-specificity`]:         https://github.com/MadLittleMods/postcss-increase-specificity
@@ -605,7 +607,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-italian-stylesheets`]:          https://github.com/Pustur/postcss-italian-stylesheets
 [`postcss-russian-stylesheets`]:          https://github.com/Semigradsky/postcss-russian-stylesheets
 [`postcss-swedish-stylesheets`]:          https://github.com/johnie/postcss-swedish-stylesheets
-[`postcss-color-rebeccapurple`]:          https://github.com/postcss/postcss-color-rebeccapurple
+[`postcss-color-rebeccapurple`]:          https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-color-rebeccapurple
 [`postcss-color-rgba-fallback`]:          https://github.com/postcss/postcss-color-rgba-fallback
 [`postcss-spanish-stylesheets`]:          https://github.com/ismamz/postcss-spanish-stylesheets
 [`postcss-at-rules-variables`]:           https://github.com/GitScrum/postcss-at-rules-variables
@@ -615,10 +617,10 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-bidirection`]:                  https://github.com/gasolin/postcss-bidirection
 [`postcss-lolcat-stylesheets`]:           https://github.com/sandralundgren/postcss-lolcat-stylesheets
 [`postcss-minify-font-weight`]:           https://github.com/ben-eb/postcss-minify-font-weight
-[`postcss-pseudo-class-enter`]:           https://github.com/jonathantneal/postcss-pseudo-class-enter
-[`postcss-transform-shortcut`]:           https://github.com/jonathantneal/postcss-transform-shortcut
+[`postcss-pseudo-class-enter`]:           https://github.com/csstools/postcss-pseudo-class-enter
+[`postcss-transform-shortcut`]:           https://github.com/csstools/postcss-transform-shortcut
 [`postcss-unicode-characters`]:           https://github.com/ben-eb/postcss-unicode-characters
-[`postcss-custom-properties`]:            https://github.com/postcss/postcss-custom-properties
+[`postcss-custom-properties`]:            https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-custom-properties
 [`postcss-czech-stylesheets`]:            https://github.com/HoBi/postcss-czech-stylesheets
 [`postcss-discard-font-face`]:            https://github.com/ben-eb/postcss-discard-font-face
 [`postcss-responsive-images`]:            https://github.com/azat-io/postcss-responsive-images
@@ -626,7 +628,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-tatar-stylesheets`]:            https://github.com/azat-io/postcss-tatar-stylesheets
 [`postcss-browser-reporter`]:             https://github.com/postcss/postcss-browser-reporter
 [`postcss-current-selector`]:             https://github.com/komlev/postcss-current-selector
-[`postcss-custom-selectors`]:             https://github.com/postcss/postcss-custom-selectors
+[`postcss-custom-selectors`]:             https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-custom-selectors
 [`postcss-discard-comments`]:             https://github.com/ben-eb/postcss-discard-comments
 [`postcss-forced-variables`]:             https://github.com/alekhrycaiko/postcss-forced-variables
 [`postcss-magic-animations`]:             https://github.com/nucliweb/postcss-magic-animations/
@@ -639,7 +641,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-theme-colors`]:                 https://github.com/ambar/postcss-theme-colors
 [`postcss-all-link-colors`]:              https://github.com/jedmao/postcss-all-link-colors
 [`postcss-border-shortcut`]:              https://github.com/michelemazzucco/postcss-border-shortcut
-[`postcss-color-hex-alpha`]:              https://github.com/postcss/postcss-color-hex-alpha
+[`postcss-color-hex-alpha`]:              https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-color-hex-alpha
 [`postcss-define-property`]:              https://github.com/daleeidd/postcss-define-property
 [`postcss-define-function`]:              https://github.com/titancat/postcss-define-function
 [`postcss-filter-gradient`]:              https://github.com/yuezk/postcss-filter-gradient
@@ -653,23 +655,23 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-range-value`]:                  https://github.com/soberwp/postcss-range-value
 [`postcss-responsive-type`]:              https://github.com/seaneking/postcss-responsive-type
 [`postcss-round-subpixels`]:              https://github.com/himynameisdave/postcss-round-subpixels
-[`postcss-short-font-size`]:              https://github.com/jonathantneal/postcss-short-font-size
+[`postcss-short-font-size`]:              https://github.com/csstools/postcss-short-font-size
 [`postcss-vertical-rhythm`]:              https://github.com/markgoodyear/postcss-vertical-rhythm
 [`postcss-border-9-patch`]:               https://github.com/teaualune/postcss-border-9-patch
 [`postcss-color-function`]:               https://github.com/postcss/postcss-color-function
-[`postcss-conic-gradient`]:               https://github.com/jonathantneal/postcss-conic-gradient
+[`postcss-conic-gradient`]:               https://github.com/csstools/postcss-conic-gradient
 [`postcss-convert-values`]:               https://github.com/ben-eb/postcss-convert-values
 [`postcss-flexbugs-fixes`]:               https://github.com/luisrudge/postcss-flexbugs-fixes
 [`postcss-font-format-keywords`]:         https://github.com/valtlai/postcss-font-format-keywords
 [`postcss-font-normalize`]:               https://github.com/iahu/postcss-font-normalize
 [`postcss-hash-classname`]:               https://github.com/ctxhou/postcss-hash-classname
 [`postcss-oldschool-grid`]:               https://github.com/lordgiotto/postcss-oldschool-grid
-[`postcss-partial-import`]:               https://github.com/jonathantneal/postcss-partial-import
+[`postcss-partial-import`]:               https://github.com/csstools/postcss-partial-import
 [`postcss-pseudoelements`]:               https://github.com/axa-ch/postcss-pseudoelements
 [`postcss-resemble-image`]:               https://github.com/ben-eb/postcss-resemble-image
 [`postcss-safe-important`]:               https://github.com/Crimx/postcss-safe-important
 [`postcss-shades-of-gray`]:               https://github.com/laureanoarcanio/postcss-shades-of-gray
-[`postcss-short-position`]:               https://github.com/jonathantneal/postcss-short-position
+[`postcss-short-position`]:               https://github.com/csstools/postcss-short-position
 [`postcss-single-charset`]:               https://github.com/hail2u/postcss-single-charset
 [`css-declaration-sorter`]:               https://github.com/Siilwyn/css-declaration-sorter
 [`postcss-alias-atrules`]:                https://github.com/maximkoretskiy/postcss-alias-atrules
@@ -688,15 +690,15 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-regexp-detect`]:                https://github.com/devex-web-frontend/postcss-regexp-detect
 [`postcss-reverse-media`]:                https://github.com/MadLittleMods/postcss-reverse-media
 [`postcss-russian-units`]:                https://github.com/Semigradsky/postcss-russian-units
-[`postcss-short-spacing`]:                https://github.com/jonathantneal/postcss-short-spacing
+[`postcss-short-spacing`]:                https://github.com/csstools/postcss-short-spacing
 [`postcss-simple-extend`]:                https://github.com/davidtheclark/postcss-simple-extend
 [`postcss-speech-bubble`]:                https://github.com/archana-s/postcss-speech-bubble
 [`postcss-aspect-ratio`]:                 https://github.com/arccoza/postcss-aspect-ratio
 [`postcss-brand-colors`]:                 https://github.com/postcss/postcss-brand-colors
-[`postcss-no-important`]: https://github.com/DUBANGARCIA/postcss-no-important
+[`postcss-no-important`]:                 https://github.com/DUBANGARCIA/postcss-no-important
 [`postcss-class-prefix`]:                 https://github.com/thompsongl/postcss-class-prefix
 [`postcss-conditionals`]:                 https://github.com/andyjansson/postcss-conditionals
-[`postcss-custom-media`]:                 https://github.com/postcss/postcss-custom-media
+[`postcss-custom-media`]:                 https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-custom-media
 [`postcss-default-unit`]:                 https://github.com/antyakushev/postcss-default-unit
 [`postcss-flexboxfixer`]:                 https://github.com/hallvors/postcss-flexboxfixer
 [`postcss-font-awesome`]:                 https://github.com/dan-gamble/postcss-font-awesome
@@ -708,7 +710,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-mq-keyframes`]:                 https://github.com/TCotton/postcss-mq-keyframes
 [`postcss-nested-props`]:                 https://github.com/jedmao/postcss-nested-props
 [`postcss-sassy-mixins`]:                 https://github.com/andyjansson/postcss-sassy-mixins
-[`postcss-selector-not`]:                 https://github.com/postcss/postcss-selector-not
+[`postcss-selector-not`]:                 https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-selector-not
 [`postcss-svg-fallback`]:                 https://github.com/justim/postcss-svg-fallback
 [`postcss-cachebuster`]:                  https://github.com/glebmachine/postcss-cachebuster
 [`postcss-color-alpha`]:                  https://github.com/avanes/postcss-color-alpha
@@ -744,7 +746,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-grid-fluid`]:                   https://github.com/francoisromain/postcss-grid-fluid
 [`postcss-inline-rtl`]:                   https://github.com/jakob101/postcss-inline-rtl
 [`postcss-inline-svg`]:                   https://github.com/TrySound/postcss-inline-svg
-[`postcss-short-text`]:                   https://github.com/jonathantneal/postcss-short-text
+[`postcss-short-text`]:                   https://github.com/csstools/postcss-short-text
 [`postcss-animation`]:                    https://github.com/zhouwenbin/postcss-animation
 [`postcss-autoreset`]:                    https://github.com/maximkoretskiy/postcss-autoreset
 [`postcss-color-hcl`]:                    https://github.com/devgru/postcss-color-hcl
@@ -762,7 +764,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-placehold`]:                    https://github.com/awayken/postcss-placehold
 [`postcss-reference`]:                    https://github.com/dehuszar/postcss-reference
 [`postcss-typescale`]:                    https://github.com/francoisromain/postcss-typescale
-[`postcss-write-svg`]:                    https://github.com/jonathantneal/postcss-write-svg
+[`postcss-write-svg`]:                    https://github.com/csstools/postcss-write-svg
 [`postcss-disabled`]:                     https://github.com/cocco3/postcss-disabled
 [`postcss-clearfix`]:                     https://github.com/seaneking/postcss-clearfix
 [`postcss-colormin`]:                     https://github.com/ben-eb/colormin
@@ -824,7 +826,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-match`]:                        https://github.com/rtsao/postcss-match
 [`postcss-scrib`]:                        https://github.com/sneakertack/postcss-scrib
 [`css2modernizr`]:                        https://github.com/vovanbo/css2modernizr
-[`font-magician`]:                        https://github.com/jonathantneal/postcss-font-magician
+[`font-magician`]:                        https://github.com/csstools/postcss-font-magician
 [`immutable-css`]:                        https://github.com/johnotander/immutable-css
 [`perfectionist`]:                        https://github.com/ben-eb/perfectionist
 [`postcss-uncss`]:                        https://github.com/RyanZim/postcss-uncss
@@ -842,7 +844,7 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-size`]:                         https://github.com/postcss/postcss-size
 [`postcss-size-advanced`]:                https://github.com/jhpratt/postcss-size-advanced
 [`postcss-svgo`]:                         https://github.com/ben-eb/postcss-svgo
-[`postcss-unmq`]:                         https://github.com/jonathantneal/postcss-unmq
+[`postcss-unmq`]:                         https://github.com/csstools/postcss-unmq
 [`postcss-vmin`]:                         https://github.com/iamvdo/postcss-vmin
 [`postcss-nope`]:                         https://github.com/dariopog/postcss-nope
 [`autoprefixer`]:                         https://github.com/postcss/autoprefixer
@@ -867,7 +869,7 @@ See also plugins in modular minifier [`cssnano`].
 [`pixrem`]:                               https://github.com/robwierzbowski/node-pixrem
 [`postcss-fixie`]:                        https://github.com/tivac/fixie
 [`rtlcss`]:                               https://github.com/MohammadYounes/rtlcss
-[`short`]:                                https://github.com/jonathantneal/postcss-short
+[`short`]:                                https://github.com/csstools/postcss-short
 [`lost`]:                                 https://github.com/corysimmons/lost
 [`postcss-text-remove-gap`]:              https://github.com/m18ru/postcss-text-remove-gap
 [`postcss-closest`]:                      https://github.com/m18ru/postcss-closest
@@ -928,3 +930,4 @@ See also plugins in modular minifier [`cssnano`].
 [`postcss-resolve-urls`]:                 https://github.com/bognarlaszlo/postcss-resolve-urls
 [`postcss-design-tokens`]:                https://github.com/jptaranto/postcss-design-tokens
 [`postcss-pixel-to-remvw`]:               https://github.com/ben-lau/postcss-pixel-to-remvw
+[`@csstools/postcss-design-tokens`]:      https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-design-tokens


### PR DESCRIPTION
With so many plugins being absorbed into the csstool mono repo the plugins list here had a few entries that linked to archived repos for plugins that are actively maintained.

I did not add each new plugin we created that is intended for `postcss-preset-env`.
These have a generated list which is easier to maintain : https://github.com/csstools/postcss-plugins/blob/main/plugin-packs/postcss-preset-env/FEATURES.md#list-of-features-in-postcss-preset-env