### PR TITLE
[Feat] Fail on invalid custom prop names

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -12,6 +12,8 @@ const SAFE_COMMENT_NEIGHBOR = {
   space: true
 }
 
+const CUSTOM_PROP_ACCEPTED_IDENT = /[-_0-9a-z]/i;
+
 function findLastWithPosition(tokens) {
   for (let i = tokens.length - 1; i >= 0; i--) {
     let token = tokens[i]
@@ -201,6 +203,9 @@ class Parser {
       let type = tokens[0][0]
       if (type === ':' || type === 'space' || type === 'comment') {
         break
+      }
+      if (customProperty) {
+        this.checkValidCustomPropName(tokens[0]);
       }
       node.prop += tokens.shift()[1]
     }
@@ -542,6 +547,20 @@ class Parser {
       { offset: tokens[0][2] },
       { offset: tokens[0][2] + tokens[0][1].length }
     )
+  }
+
+  checkValidCustomPropName(token) {
+    let start = token[2];
+    if (token[1].length < 3) {
+      throw this.input.error('Invalid custom prop name', start + 1)
+    } else {
+      let char = token[1].charAt(2);
+      let charCode = char.charCodeAt(0);
+      let isAcceptableASCII = CUSTOM_PROP_ACCEPTED_IDENT.test(char);
+      if (charCode < 127 && !isAcceptableASCII) {
+        throw this.input.error('Invalid custom prop name', start + 2)
+      }
+    }
   }
 
   unexpectedClose(token) {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -226,4 +226,24 @@ test('should give the correct column of missed semicolon without !important', ()
   match(error.message, /2:15: Missed semicolon/)
 })
 
+test('throws on empty custom prop name', () => {
+  let error: any
+  try {
+    parse(':root { \n    --: red\n}')
+  } catch (e) {
+    error = e
+  }
+  match(error.message, /2:6: Invalid custom prop name/)
+})
+
+test('throws on invalid custom prop name', () => {
+  let error: any
+  try {
+    parse(':root { \n    --.invalid-name : red\n}')
+  } catch (e) {
+    error = e
+  }
+  match(error.message, /2:7: Invalid custom prop name/)
+})
+
 test.run()


### PR DESCRIPTION
## Changes:

Closes: #1765 

- Changes do not use logical operators. Instead `regex` is being used for simplicity.
  - I tried benchmarking the logical operators and `regex` using `process.hrtime.bigint()`
    and there's a few 100 nanoseconds of difference between the two approaches (using 
    `regex` on a single character compared to logical operations on a single char code).
  - Please do suggest if you have any better approach for the solution.
- Minimal test cases added
  - Following manual tests were done:
    - `pcss.parse(':root { --var: #333 }')`
    - `pcss.parse(':root { --0ar: #333 }')`
    - `pcss.parse(':root { --_ar: #333 }')` and `pcss.parse(':root { ---ar: #333 }')`
    - `pcss.parse(':root { --~ar: #333 }')`, which should fail.

## Screenshots:
<p align="center">
<img width="45%" alt="Screenshot 2022-08-21 at 11 48 10 PM" src="https://user-images.githubusercontent.com/11786283/185846350-2c35cf5c-bbd1-48de-b9d0-de7bd845b104.png">
<img width="54%" alt="Screenshot 2022-08-21 at 11 48 19 PM" src="https://user-images.githubusercontent.com/11786283/185846386-7453c71e-fac6-4436-8767-3fb2ad978f47.png">
</p>
