### PR TITLE
add test for sorting container.nodes

### DIFF
--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -814,4 +814,31 @@ test('allows to clone nodes', () => {
   is(root2.toString(), 'a { color: black; z-index: 1 } b {}')
 })
 
+test('container.nodes can be sorted', () => {
+  let root = parse('@b; @c; @a;')
+  let b = root.nodes[0];
+
+  root.nodes.sort((x, y) => {
+    return (x as AtRule).name.localeCompare((y as AtRule).name)
+  })
+
+  // Sorted nodes are reflected in "toString".
+  is(root.toString(), ' @a;@b; @c;')
+
+  // Sorted nodes are reflected in "walk".
+  let result: string[] = [];
+  root.walkAtRules((atRule) => {
+    result.push(atRule.name.trim())
+  });
+
+  is(result.join(' '), 'a b c')
+
+  // Sorted nodes have the corect "index".
+  is(root.index(b), 1)
+
+  // Inserting after a sorted node results in the correct order.
+  b.after('@d;');
+  is(root.toString(), ' @a;@b;@d; @c;')
+})
+
 test.run()


### PR DESCRIPTION
In [`@csstools/postcss-cascade-layers`](https://github.com/csstools/postcss-plugins/blob/main/plugins/postcss-cascade-layers/src/sort-root-nodes.ts#L73) we use `container.nodes.sort(...)`.
I noticed that there weren't any tests for this.

Maybe we are using it wrong and should use a different way to sort nodes?