### PR TITLE
fix whitespace bug

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -177,7 +177,7 @@ class Container extends Node {
 
   insertBefore(exist, add) {
     let existIndex = this.index(exist)
-    let type = exist === 0 ? 'prepend' : false
+    let type = existIndex === 0 ? 'prepend' : false
     let nodes = this.normalize(add, this.proxyOf.nodes[existIndex], type).reverse()
     existIndex = this.index(exist)
     for (let node of nodes) this.proxyOf.nodes.splice(existIndex, 0, node)

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -654,6 +654,28 @@ test('insertBefore() receives pre-existing child node - b', () => {
   is(a.toString(), 'a{ z-index: 1; align-items: start; color: red }')
 })
 
+test('insertBefore() has defined way of adding newlines', () => {
+  let root = parse('a {}')
+  root.insertBefore(root.first as Rule, 'b {}')
+  root.insertBefore(root.first as Rule, 'c {}')
+  is(root.toString(), 'c {}\nb {}\na {}')
+
+  root = parse('other {}a {}')
+  root.insertBefore(root.first as Rule, 'b {}')
+  root.insertBefore(root.first as Rule, 'c {}')
+  is(root.toString(), 'c {}b {}other {}a {}')
+
+  root = parse('other {}\na {}')
+  root.insertBefore(root.nodes[1] as Rule, 'b {}')
+  root.insertBefore(root.nodes[1] as Rule, 'c {}')
+  is(root.toString(), 'other {}\nc {}\nb {}\na {}')
+
+  root = parse('other {}a {}')
+  root.insertBefore(root.nodes[1] as Rule, 'b {}')
+  root.insertBefore(root.nodes[1] as Rule, 'c {}')
+  is(root.toString(), 'other {}c {}b {}a {}')
+})
+
 test('insertAfter() inserts child', () => {
   let rule = parse('a { a: 1; b: 2 }').first as Rule
   rule.insertAfter(0, { prop: 'c', value: '3' })


### PR DESCRIPTION
I missed one instance of `exist` vs `existIndex` : https://github.com/postcss/postcss/pull/1781/files#diff-f839dd1fbca92f7ee34436cc4b8380aee0793a279c56e1daf9c2f38a8593a3f1R180


<details>
<summary>
screenshot of the relevant diff :
</summary>

<img width="800" alt="Screenshot 2022-11-10 at 23 43 29" src="https://user-images.githubusercontent.com/11521496/201221588-2499f373-22c3-4bde-828d-637b80f3db2c.png">

</details>

see : https://github.com/postcss/postcss/issues/1785