### PR TITLE
Add postcss-styled-syntax syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ you can write a parser and/or stringifier to extend PostCSS.
 * [`postcss-syntax`] switch syntax automatically by file extensions.
 * [`postcss-html`] parsing styles in `<style>` tags of HTML-like files.
 * [`postcss-markdown`] parsing styles in code blocks of Markdown files.
+* [`postcss-styled-syntax`] parses styles in template literals CSS-in-JS
+  like styled-components.
 * [`postcss-jsx`] parsing CSS in template / object literals of source files.
 * [`postcss-styled`] parsing CSS in template literals of source files.
 * [`postcss-scss`] allows you to work with SCSS
@@ -174,19 +176,20 @@ you can write a parser and/or stringifier to extend PostCSS.
 * [`postcss-safe-parser`] finds and fixes CSS syntax errors.
 * [`midas`] converts a CSS string to highlighted HTML.
 
-[`postcss-less-engine`]: https://github.com/Crunch/postcss-less
-[`postcss-safe-parser`]: https://github.com/postcss/postcss-safe-parser
-[`postcss-syntax`]:      https://github.com/gucong3000/postcss-syntax
-[`postcss-html`]:        https://github.com/ota-meshi/postcss-html
-[`postcss-markdown`]:    https://github.com/ota-meshi/postcss-markdown
-[`postcss-jsx`]:         https://github.com/gucong3000/postcss-jsx
-[`postcss-styled`]:      https://github.com/gucong3000/postcss-styled
-[`postcss-scss`]:        https://github.com/postcss/postcss-scss
-[`postcss-sass`]:        https://github.com/AleshaOleg/postcss-sass
-[`postcss-less`]:        https://github.com/webschik/postcss-less
-[`postcss-js`]:          https://github.com/postcss/postcss-js
-[`sugarss`]:             https://github.com/postcss/sugarss
-[`midas`]:               https://github.com/ben-eb/midas
+[`postcss-styled-syntax`]: https://github.com/hudochenkov/postcss-styled-syntax
+[`postcss-less-engine`]:   https://github.com/Crunch/postcss-less
+[`postcss-safe-parser`]:   https://github.com/postcss/postcss-safe-parser
+[`postcss-syntax`]:        https://github.com/gucong3000/postcss-syntax
+[`postcss-html`]:          https://github.com/ota-meshi/postcss-html
+[`postcss-markdown`]:      https://github.com/ota-meshi/postcss-markdown
+[`postcss-jsx`]:           https://github.com/gucong3000/postcss-jsx
+[`postcss-styled`]:        https://github.com/gucong3000/postcss-styled
+[`postcss-scss`]:          https://github.com/postcss/postcss-scss
+[`postcss-sass`]:          https://github.com/AleshaOleg/postcss-sass
+[`postcss-less`]:          https://github.com/webschik/postcss-less
+[`postcss-js`]:            https://github.com/postcss/postcss-js
+[`sugarss`]:               https://github.com/postcss/sugarss
+[`midas`]:                 https://github.com/ben-eb/midas
 
 
 ## Articles

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ you can write a parser and/or stringifier to extend PostCSS.
 [`postcss-less-engine`]: https://github.com/Crunch/postcss-less
 [`postcss-safe-parser`]: https://github.com/postcss/postcss-safe-parser
 [`postcss-syntax`]:      https://github.com/gucong3000/postcss-syntax
-[`postcss-html`]:        https://github.com/gucong3000/postcss-html
-[`postcss-markdown`]:    https://github.com/gucong3000/postcss-markdown
+[`postcss-html`]:        https://github.com/ota-meshi/postcss-html
+[`postcss-markdown`]:    https://github.com/ota-meshi/postcss-markdown
 [`postcss-jsx`]:         https://github.com/gucong3000/postcss-jsx
 [`postcss-styled`]:      https://github.com/gucong3000/postcss-styled
 [`postcss-scss`]:        https://github.com/postcss/postcss-scss


### PR DESCRIPTION
I've been working on `@stylelint/postcss-css-in-js` replacement for styled-components for a long time. It was very out of comfort zone project. I'm glad I finished. It was interesting to learn how PostCSS parses and stringifies.

This PR adds it to the list of known syntaxes. It has no downloads yet, because I just released it. But it has a lot of tests and I tested it on my work projects, which has a lot of different syntax.

Thank you for all your hard work on PostCSS, it is really hard and complex work!

---

Additionally I noticed that two syntaxes need updated repo URL. So I fixed it.