### PR TITLE
increase test coverage

### DIFF
--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -102,6 +102,22 @@ test('parses double semicolon after rule', () => {
   is(parse('a { };;').toString(), 'a { };;')
 })
 
+test('parses a functional property', () => {
+  let root = parse('a { b(c): d }')
+  let a = root.first as Rule
+  let b = a.first as Declaration
+
+  is(b.prop, 'b(c)')
+})
+
+test('parses a functional tagname', () => {
+  let root = parse('a { b(c): d {} }')
+  let a = root.first as Rule
+  let b = a.first as Rule
+
+  is(b.selector, 'b(c): d')
+})
+
 test('throws on unclosed blocks', () => {
   throws(() => {
     parse('\na {\n')
@@ -138,6 +154,9 @@ test('throws on property without value', () => {
   }, /:1:5: Unknown word/)
   throws(() => {
     parse('a { b b }')
+  }, /:1:5: Unknown word/)
+  throws(() => {
+    parse('a { b(); }')
   }, /:1:5: Unknown word/)
 })
 


### PR DESCRIPTION
While working on the different tokenizer I encountered a few cases which have specific behavior in PostCSS but aren't covered by tests.

_Because the tokenizer is less granular it doesn't show in line coverage that these cases are untested._