### PR TITLE
Ignore .tgz files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 
 docs/api/index.html
 docs/api/assets/
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test/
 
 docs/
 tsconfig.json
+*.tgz


### PR DESCRIPTION
Running `npm pack` will generate this file. Running `npm pack` again would include the previously built package in the package.