### PR TITLE
Add JSDoc type for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,15 @@ module.exports = {
 Then create `postcss.config.js`:
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+const config = {
   plugins: [
     require('autoprefixer'),
     require('postcss-nested')
   ]
 }
+
+module.exports = config
 ```
 
 [`astroturf`]: https://github.com/4Catalyzer/astroturf

--- a/README.md
+++ b/README.md
@@ -262,12 +262,15 @@ and cssnano. If you want to change plugins, create `postcss.config.js`
 in project’s root:
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+const config = {
   plugins: [
     require('autoprefixer'),
     require('postcss-nested')
   ]
 }
+
+module.exports = config
 ```
 
 Parcel will even automatically install these plugins for you.
@@ -311,12 +314,15 @@ module.exports = {
 Then create `postcss.config.js`:
 
 ```js
-module.exports = {
+/** @type {import('postcss-load-config').Config} */
+const config = {
   plugins: [
     require('autoprefixer'),
     require('postcss-nested')
   ]
 }
+
+module.exports = config
 ```
 
 [`postcss-loader`]: https://github.com/postcss/postcss-loader


### PR DESCRIPTION
First of all, thanks so much for PostCSS and the ecosystem, amazing tool! 🙌

Just wanted to surface the JSDoc types in the config recommendation to allow for autocompletion. (also type-checking if you configure `checkJs: true` in `tsconfig.json`)