### PR TITLE
fix: node end offset location

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -65,6 +65,7 @@ class Parser {
       if (brackets.length === 0) {
         if (type === ';') {
           node.source.end = this.getPosition(token[2])
+          node.source.end.offset++
           this.semicolon = true
           break
         } else if (type === '{') {
@@ -79,6 +80,7 @@ class Parser {
             }
             if (prev) {
               node.source.end = this.getPosition(prev[3] || prev[2])
+              node.source.end.offset++
             }
           }
           this.end(token)
@@ -103,6 +105,7 @@ class Parser {
       if (last) {
         token = params[params.length - 1]
         node.source.end = this.getPosition(token[3] || token[2])
+        node.source.end.offset++
         this.spaces = node.raws.between
         node.raws.between = ''
       }
@@ -171,6 +174,7 @@ class Parser {
     let node = new Comment()
     this.init(node, token[2])
     node.source.end = this.getPosition(token[3] || token[2])
+    node.source.end.offset++
 
     let text = token[1].slice(2, -2)
     if (/^\s*$/.test(text)) {
@@ -202,6 +206,7 @@ class Parser {
     node.source.end = this.getPosition(
       last[3] || last[2] || findLastWithPosition(tokens)
     )
+    node.source.end.offset++
 
     while (tokens[0][0] !== 'word') {
       if (tokens.length === 1) this.unknownWord(tokens)
@@ -320,6 +325,7 @@ class Parser {
 
     if (this.current.parent) {
       this.current.source.end = this.getPosition(token[2])
+      this.current.source.end.offset++
       this.current = this.current.parent
     } else {
       this.unexpectedClose(token)

--- a/test/location.test.ts
+++ b/test/location.test.ts
@@ -1,0 +1,300 @@
+import { test } from 'uvu'
+import { equal } from 'uvu/assert'
+
+import {
+  AtRule,
+  Comment,
+  Declaration,
+  Node,
+  parse,
+  Rule
+} from '../lib/postcss.js'
+
+function checkOffset(source: string, node: Node, expected: string): void {
+  let start = node.source!.start!.offset
+  let end = node.source!.end!.offset
+  equal(source.slice(start, end), expected)
+}
+
+test('rule', () => {
+  let source = '.a{}'
+  let css = parse(source)
+
+  let rule = css.first as Rule
+  checkOffset(source, rule, '.a{}')
+  equal(rule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(rule.source!.end, {
+    column: 4,
+    line: 1,
+    offset: 4
+  })
+})
+
+test('single decl (no semicolon)', () => {
+  let source = '.a{b:c}'
+  let css = parse(source)
+
+  let rule = css.first as Rule
+  let decl = rule.first as Declaration
+  checkOffset(source, rule, '.a{b:c}')
+  checkOffset(source, decl, 'b:c')
+  equal(rule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(rule.source!.end, {
+    column: 7,
+    line: 1,
+    offset: 7
+  })
+  equal(decl.source!.start, {
+    column: 4,
+    line: 1,
+    offset: 3
+  })
+  equal(decl.source!.end, {
+    column: 6,
+    line: 1,
+    offset: 6
+  })
+})
+
+test('single decl (with semicolon)', () => {
+  let source = '.a{b:c;}'
+  let css = parse(source)
+
+  let rule = css.first as Rule
+  let decl = rule.first as Declaration
+  checkOffset(source, rule, '.a{b:c;}')
+  checkOffset(source, decl, 'b:c;')
+  equal(rule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(rule.source!.end, {
+    column: 8,
+    line: 1,
+    offset: 8
+  })
+  equal(decl.source!.start, {
+    column: 4,
+    line: 1,
+    offset: 3
+  })
+  equal(decl.source!.end, {
+    column: 7,
+    line: 1,
+    offset: 7
+  })
+})
+
+test('two decls', () => {
+  let source = '.a{b:c;d:e}'
+  let css = parse(source)
+
+  let rule = css.first as Rule
+  let decl1 = rule.first as Declaration
+  let decl2 = decl1.next() as Declaration
+  checkOffset(source, decl1, 'b:c;')
+  checkOffset(source, decl2, 'd:e')
+  equal(rule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(rule.source!.end, {
+    column: 11,
+    line: 1,
+    offset: 11
+  })
+  equal(decl1.source!.start, {
+    column: 4,
+    line: 1,
+    offset: 3
+  })
+  equal(decl1.source!.end, {
+    column: 7,
+    line: 1,
+    offset: 7
+  })
+  equal(decl2.source!.start, {
+    column: 8,
+    line: 1,
+    offset: 7
+  })
+  equal(decl2.source!.end, {
+    column: 10,
+    line: 1,
+    offset: 10
+  })
+})
+
+test('...rule nested in rule', () => {
+  let source = '.a{.b{}}'
+  let css = parse(source)
+
+  let rule = css.first as Rule
+  let rule2 = rule.first as Rule
+  checkOffset(source, rule, '.a{.b{}}')
+  checkOffset(source, rule2, '.b{}')
+  equal(rule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(rule.source!.end, {
+    column: 8,
+    line: 1,
+    offset: 8
+  })
+  equal(rule2.source!.start, {
+    column: 4,
+    line: 1,
+    offset: 3
+  })
+  equal(rule2.source!.end, {
+    column: 7,
+    line: 1,
+    offset: 7
+  })
+})
+
+test('at-rule with semicolon', () => {
+  let source = '@a b;'
+  let css = parse(source)
+
+  let atrule = css.first as AtRule
+  checkOffset(source, atrule, '@a b;')
+  equal(atrule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(atrule.source!.end, {
+    column: 5,
+    line: 1,
+    offset: 5
+  })
+})
+
+test('unclosed at-rule', () => {
+  let source = '@a b'
+  let css = parse(source)
+
+  let atrule = css.first as AtRule
+  checkOffset(source, atrule, '@a b')
+  equal(atrule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(atrule.source!.end, {
+    column: 4,
+    line: 1,
+    offset: 4
+  })
+})
+
+test('unclosed at-rule in at-rule', () => {
+  let source = '@a{@b c}'
+  let css = parse(source)
+
+  let atrule = css.first as AtRule
+  let atrule2 = atrule.first as AtRule
+  checkOffset(source, atrule, '@a{@b c}')
+  checkOffset(source, atrule2, '@b c')
+  equal(atrule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(atrule.source!.end, {
+    column: 8,
+    line: 1,
+    offset: 8
+  })
+  equal(atrule2.source!.start, {
+    column: 4,
+    line: 1,
+    offset: 3
+  })
+  equal(atrule2.source!.end, {
+    column: 7,
+    line: 1,
+    offset: 7
+  })
+})
+
+test('at-rule with body', () => {
+  let source = '@a{}'
+  let css = parse(source)
+
+  let atrule = css.first as AtRule
+  checkOffset(source, atrule, '@a{}')
+  equal(atrule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(atrule.source!.end, {
+    column: 4,
+    line: 1,
+    offset: 4
+  })
+})
+
+test('at-rule nested in atrule', () => {
+  let source = '@a{@b{}}'
+  let css = parse(source)
+
+  let atrule = css.first as Rule
+  let atrule2 = atrule.first as Rule
+  checkOffset(source, atrule, '@a{@b{}}')
+  checkOffset(source, atrule2, '@b{}')
+  equal(atrule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(atrule.source!.end, {
+    column: 8,
+    line: 1,
+    offset: 8
+  })
+  equal(atrule2.source!.start, {
+    column: 4,
+    line: 1,
+    offset: 3
+  })
+  equal(atrule2.source!.end, {
+    column: 7,
+    line: 1,
+    offset: 7
+  })
+})
+
+test('comment', () => {
+  let source = '/*a*/'
+  let css = parse(source)
+
+  let rule = css.first as Comment
+  checkOffset(source, rule, '/*a*/')
+  equal(rule.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(rule.source!.end, {
+    column: 5,
+    line: 1,
+    offset: 5
+  })
+})
+
+test.run()


### PR DESCRIPTION
This PR addresses the [issue](https://github.com/postcss/postcss/issues/1876) of `source.end.offset` being off by one.

The problem stemmed from direct use of the token location as the offset when resolving line and column with `getPosition()`, which worked well for `start.offset`, but should point to the index immediately after the node for the `end.offset` to ensure that  `source.slice(start.offset, end.offset)` provides the correct node source.

The solution is straightforward: I've reviewed the parser's instances where the end offset is set and made a simple adjustment off adding 1 (except the final root location that works as expected).

There are still 30 failing tests originating from [postcss-parser-tests](https://github.com/postcss/postcss-parser-tests) that needs to have their expectation JSON adjusted - I probably need some help making that change, thank you in advance!