### PR TITLE
Backport `Fix carrier return parsing` to v7

### DIFF
--- a/lib/tokenize.es6
+++ b/lib/tokenize.es6
@@ -20,7 +20,7 @@ const AT = '@'.charCodeAt(0)
 
 const RE_AT_END = /[ \n\t\r\f{}()'"\\;/[\]#]/g
 const RE_WORD_END = /[ \n\t\r\f(){}:;@!'"\\\][#]|\/(?=\*)/g
-const RE_BAD_BRACKET = /.[\\/("'\n]/
+const RE_BAD_BRACKET = /.[\\/("'\r\n]/
 const RE_HEX_ESCAPE = /[a-f0-9]/i
 
 export default function tokenizer (input, options = {}) {

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -34,6 +34,12 @@ it('should has false at `hasBOM` property', () => {
   expect(css.first.source.input.hasBOM).toBeFalsy()
 })
 
+it('parses carrier return', () => {
+  expect(() => {
+    parse('@font-face{ font:(\r/*);} body { a: "a*/)} a{}"}')
+  }).toThrowError(/:1:46: Unclosed string/)
+})
+
 it('saves source file', () => {
   let css = parse('a {}', { from: 'a.css' })
   expect(css.first.source.input.css).toEqual('a {}')


### PR DESCRIPTION
This PR backports https://github.com/postcss/postcss/commit/58cc860b4c1707510c9cd1bc1fa30b423a9ad6c5, which fixes [CVE-2023-44270](https://nvd.nist.gov/vuln/detail/CVE-2023-44270), to v7.