### PR TITLE
Fix `ProcessOptions` interface

### DIFF
--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -309,7 +309,7 @@ declare namespace postcss {
      * The path of the CSS source file. You should always set `from`,
      * because it is used in source map generation and syntax error messages.
      */
-    from?: string
+    from?: string | undefined
 
     /**
      * Source map options


### PR DESCRIPTION
If I do something like:

```ts
const result = await postcss([plugin1, plugin2]).process(css)
```
This would correctly log the warning below:
```
Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.
```

As explained, changing to `process(css, { from: undefined })` prevent the warning. However, when `exactOptionalPropertyTypes` is set to `true` in the `tsconfig.json` it's not possible to do that at all, as `undefined` wouldn't be an allowed type.

TSConfig Reference: [exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes)

This PR only adds `undefined` to the type.