### PR TITLE
refactor: check all falsy conditions of plugins and opts before returning NoWorkResult in process()

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -43,10 +43,10 @@ class Processor {
 
   process(css, opts = {}) {
     if (
-      this.plugins.length === 0 &&
-      typeof opts.parser === 'undefined' &&
-      typeof opts.stringifier === 'undefined' &&
-      typeof opts.syntax === 'undefined'
+      !this.plugins.length &&
+      !opts.parser &&
+      !opts.stringifier &&
+      !opts.syntax
     ) {
       return new NoWorkResult(this, css, opts)
     } else {


### PR DESCRIPTION
resolves #1869

#### Fixes:
- refactor check of all falsy condition of plugins and opts before returing NoWorkResult in Processor.process().

> https://github.com/postcss/postcss/blob/a0a82d3530ce7dfbfe1f12aa76c20f1b3f95eb7c/lib/processor.js#L44-L55
> 
> For a full repro see : https://github.com/romainmenke/postcss-no-work-result-sourcemaps
> 
> By setting `parser: null` as a processing option you can force a `LazyResult`.
> 
> Setting `null` instead of `undefined` is a common mistake, especially when not using TypeScript.
> 
> Is it intentional that `NoWorkResult` and `LazyResult` have different CSS outputs?

