### PR TITLE
Fix code example for `name` in at-rule.d.ts

### DIFF
--- a/lib/at-rule.d.ts
+++ b/lib/at-rule.d.ts
@@ -81,8 +81,8 @@ declare class AtRule_ extends Container {
    *
    * ```js
    * const root  = postcss.parse('@media print {}')
-   * media.name //=> 'media'
    * const media = root.first
+   * media.name //=> 'media'
    * ```
    */
   name: string


### PR DESCRIPTION
The order of lines in the example for AtRule#name got mixed up somehow. This PR corrects the order s.t. the example makes sense and would not produce an error.

https://postcss.org/api/#atrule-name