### PR TITLE
Replaced the redundant map function and removed the unused variable

### DIFF
--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -52,7 +52,7 @@ class MapGenerator {
       if (this.mapOpts.sourcesContent === false) {
         map = new SourceMapConsumer(prev.text)
         if (map.sourcesContent) {
-          map.sourcesContent = map.sourcesContent.map(() => null)
+          map.sourcesContent = null
         }
       } else {
         map = prev.consumer()

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,7 +28,6 @@ class Parser {
     this.current = this.root
     this.spaces = ''
     this.semicolon = false
-    this.customProperty = false
 
     this.createTokenizer()
     this.root.source = { input, start: { column: 1, line: 1, offset: 0 } }


### PR DESCRIPTION
1) Hi, i was just looking for how to improve your library, and see strange string when we replace all items on null, i try find when it's need and why we save our array but with null items

Motivation, if we replacy all items, on null, we try to save sourcesContent array length but for what

I only found one place when we use length, when check Content https://github.com/postcss/postcss/blob/219dd756f6867dc0a679567975763b777ac23af3/lib/previous-map.js#L133-L138
But you don't have this case in unit test, and i don't know need thik about this case because all case when we use this func we after nofing do with this data

All rigth, let's imagine what we really check length, next question "we only check wath our array is not empty" or "we use length of array for calcuted/itteration"? 
It's important, because it's potential for optimization
If we use after that itterator based on sourcesContent length, we'll leave map.sourcesContent.map(() => null), but if we only check wath our array is not empty, we can create constant operation and write just [ null ]

Also i check code in "source-map-js" and applySourceMap() don't work with that key

P.s. i'm not understand why in a test:size we get the result
map.sourcesContent.map(() => null) =>  14.66kB
null =>  14.67kB

2) this.customProperty = false, i just see what it's not using on your documentation and project code