### PR TITLE
Improve AtRule#nodes type

### DIFF
--- a/lib/at-rule.d.ts
+++ b/lib/at-rule.d.ts
@@ -87,6 +87,25 @@ declare class AtRule_ extends Container {
    */
   name: string
   /**
+   * An array containing the layer’s children.
+   *
+   * ```js
+   * const root = postcss.parse('@layer example { a { color: black } }')
+   * const layer = root.first
+   * layer.nodes.length           //=> 1
+   * layer.nodes[0].selector      //=> 'a'
+   * ```
+   *
+   * Can be `undefinded` if the at-rule has no body.
+   *
+   * ```js
+   * const root = postcss.parse('@layer a, b, c;')
+   * const layer = root.first
+   * layer.nodes //=> undefined
+   * ```
+   */
+  node: Container['nodes'] | undefined
+  /**
    * The at-rule’s parameters, the values that follow the at-rule’s name
    * but precede any `{}` block.
    *

--- a/test/at-rule.test.ts
+++ b/test/at-rule.test.ts
@@ -48,4 +48,10 @@ test('clone spaces from another at-rule', () => {
   is(rule.toString(), '@page 1{}')
 })
 
+test('at-rule without body has no nodes property', () => {
+  let root = parse('@layer a, b, c;');
+  let layer = root.first as AtRule
+  type(layer.nodes, 'undefined')
+});
+
 test.run()


### PR DESCRIPTION
Parsing something like
```css
@layer a, b, c;
```
with `postcss` will result in an `AtRule` object without a `nodes` property. This however is not reflected by the types.

This PR changes the type of `AtRule#nodes` from `ChildNodes[]` to `ChildNodes[] | undefined` and updates the documentation.

I used `Container['nodes']` instead of `ChildNodes[]`, I can change that if you prefer it that way. I have also added a unit test to enforce this behavior (`AtRule#nodes` being `undefined` when the body is missing).

Closes #1920.