### PR TITLE
Improve AtRule#nodes type

### DIFF
--- a/lib/at-rule.d.ts
+++ b/lib/at-rule.d.ts
@@ -95,9 +95,9 @@ declare class AtRule_ extends Container {
    * layer.nodes.length           //=> 1
    * layer.nodes[0].selector      //=> 'a'
    * ```
-   * 
+   *
    * Can be `undefinded` if the at-rule has no body.
-   * 
+   *
    * ```js
    * const root = postcss.parse('@layer a, b, c;')
    * const layer = root.first

--- a/lib/at-rule.d.ts
+++ b/lib/at-rule.d.ts
@@ -87,6 +87,25 @@ declare class AtRule_ extends Container {
    */
   name: string
   /**
+   * An array containing the layer’s children.
+   *
+   * ```js
+   * const root = postcss.parse('@layer example { a { color: black } }')
+   * const layer = root.first
+   * layer.nodes.length           //=> 1
+   * layer.nodes[0].selector      //=> 'a'
+   * ```
+   * 
+   * Can be `undefinded` if the at-rule has no body.
+   * 
+   * ```js
+   * const root = postcss.parse('@layer a, b, c;')
+   * const layer = root.first
+   * layer.nodes                  //=> undefined
+   * ```
+   */
+  nodes: Container['nodes']
+  /**
    * The at-rule’s parameters, the values that follow the at-rule’s name
    * but precede any `{}` block.
    *

--- a/lib/at-rule.d.ts
+++ b/lib/at-rule.d.ts
@@ -101,7 +101,7 @@ declare class AtRule_ extends Container {
    * ```js
    * const root = postcss.parse('@layer a, b, c;')
    * const layer = root.first
-   * layer.nodes                  //=> undefined
+   * layer.nodes //=> undefined
    * ```
    */
   nodes: Container['nodes']

--- a/lib/container.d.ts
+++ b/lib/container.d.ts
@@ -43,7 +43,7 @@ declare abstract class Container_<Child extends Node = ChildNode> extends Node {
    * root.nodes[0].nodes[0].prop //=> 'color'
    * ```
    */
-  nodes: Child[]
+  nodes: Child[] | undefined
 
   /**
    * Inserts new nodes to the end of the container.

--- a/lib/document.d.ts
+++ b/lib/document.d.ts
@@ -35,6 +35,7 @@ declare namespace Document {
  * ```
  */
 declare class Document_ extends Container<Root> {
+  nodes: Root[]
   parent: undefined
   type: 'document'
 

--- a/lib/root.d.ts
+++ b/lib/root.d.ts
@@ -54,6 +54,7 @@ declare namespace Root {
  * ```
  */
 declare class Root_ extends Container {
+  nodes: NonNullable<Container['nodes']>
   parent: Document | undefined
   raws: Root.RootRaws
   type: 'root'

--- a/lib/rule.d.ts
+++ b/lib/rule.d.ts
@@ -69,6 +69,7 @@ declare namespace Rule {
  * ```
  */
 declare class Rule_ extends Container {
+  nodes: NonNullable<Container['nodes']>
   parent: Container | undefined
   raws: Rule.RuleRaws
   /**

--- a/test/at-rule.test.ts
+++ b/test/at-rule.test.ts
@@ -24,7 +24,7 @@ test('creates nodes property on prepend()', () => {
   type(rule.nodes, 'undefined')
 
   rule.prepend('color: black')
-  is(rule.nodes.length, 1)
+  is(rule.nodes?.length, 1)
 })
 
 test('creates nodes property on append()', () => {
@@ -32,7 +32,7 @@ test('creates nodes property on append()', () => {
   type(rule.nodes, 'undefined')
 
   rule.append('color: black')
-  is(rule.nodes.length, 1)
+  is(rule.nodes?.length, 1)
 })
 
 test('inserts default spaces', () => {

--- a/test/at-rule.test.ts
+++ b/test/at-rule.test.ts
@@ -48,4 +48,10 @@ test('clone spaces from another at-rule', () => {
   is(rule.toString(), '@page 1{}')
 })
 
+test('at-rule without body has no nodes property', () => {
+  let root = parse('@layer a, b, c;');
+  let layer = root.first as AtRule
+  type(layer.nodes, 'undefined')
+});
+
 test.run()

--- a/test/visitor.test.ts
+++ b/test/visitor.test.ts
@@ -18,9 +18,9 @@ import postcss, {
 
 function hasAlready(parent: Container | undefined, selector: string): boolean {
   if (typeof parent === 'undefined') return false
-  return parent.nodes.some(i => {
+  return parent.nodes?.some(i => {
     return i.type === 'rule' && i.selectors.includes(selector)
-  })
+  }) ?? false
 }
 
 function addIndex(array: any[][]): any[][] {
@@ -1559,9 +1559,9 @@ test('append works after reassigning nodes through .parent', async () => {
     OnceExit(root) {
       let firstNode = root.nodes[0] as AtRule
       let secondNode = root.nodes[1] as AtRule
-      let rule2 = secondNode.nodes[0]
+      let rule2 = secondNode.nodes![0]
       rule2.parent!.nodes = rule2.parent!.nodes
-      firstNode.append(...secondNode.nodes)
+      firstNode.append(...secondNode.nodes!)
       secondNode.remove()
     },
 
@@ -1580,7 +1580,7 @@ test('append works after reassigning nodes through .parent', async () => {
 
       let atrule = rule.nodes[0]
 
-      atrule.append(rule.clone({ nodes: [] }).append(...atrule.nodes))
+      atrule.append(rule.clone({ nodes: [] }).append(...atrule.nodes!))
 
       rule.after(atrule)
       rule.remove()


### PR DESCRIPTION
Parsing something like
```css
@layer a, b, c;
```
with `postcss` will result in an `AtRule` object without a `nodes` property. This however is not reflected by the types.

This PR changes the type of `AtRule#nodes` from `ChildNodes[]` to `ChildNodes[] | undefined` and updates the documentation.

I had to change the types of `Container#nodes` (and undo that change for `Root#nodes`, `Rule#nodes` and `Document#nodes`), I did not find a better approach. Other things I have tried are  #1921 and changing this:
```js
declare class AtRule_ extends Container<ChildNode | undefined>
```
which sadly also does not work because `ChildNode | undefined` does not extend `Node`.

Closes #1920.