### PR TITLE
Fix resulting `end` position when `endIndex` is `0` for `rangeBy`

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -241,7 +241,7 @@ class Node {
           column: opts.end.column,
           line: opts.end.line
         }
-      } else if (opts.endIndex) {
+      } else if (typeof opts.endIndex === 'number') {
         end = this.positionInside(opts.endIndex)
       } else if (opts.index) {
         end = this.positionInside(opts.index + 1)

--- a/test/warning.test.ts
+++ b/test/warning.test.ts
@@ -85,6 +85,24 @@ test('gets range from node without end', () => {
   is(warning.endColumn, 2)
 })
 
+test('gets range from node with endIndex 3', () => {
+  let root = parse('a{}')
+  let warning = new Warning('text', { node: root.first, index: 0, endIndex: 3 })
+  is(warning.line, 1)
+  is(warning.column, 1)
+  is(warning.endLine, 1)
+  is(warning.endColumn, 4)
+})
+
+test('gets range from node with endIndex 0', () => {
+  let root = parse('a{}')
+  let warning = new Warning('text', { node: root.first, index: 0, endIndex: 0 })
+  is(warning.line, 1)
+  is(warning.column, 1)
+  is(warning.endLine, 1)
+  is(warning.endColumn, 2)
+})
+
 test('gets range from word', () => {
   let root = parse('a b{}')
   let warning = new Warning('text', { node: root.first, word: 'b' })


### PR DESCRIPTION
When `endIndex` is exactly `0` it is ignored and the `end` position will fallback to the end of the node.

Checking that it is a number instead of a simpler boolean check does seem to work as I would expect.