### PR TITLE
Fix useless warnings in console during source maps generation

### DIFF
--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -98,9 +98,10 @@ class MapGenerator {
     } else if (this.previous().length === 1) {
       let prev = this.previous()[0].consumer()
       prev.file = this.outputFile()
-      this.map = SourceMapGenerator.fromSourceMap(prev, {
-        ignoreInvalidMapping: true
-      })
+      try {
+        this.map = SourceMapGenerator.fromSourceMap(prev)
+      } catch (e) {
+      }
     } else {
       this.map = new SourceMapGenerator({
         file: this.outputFile(),


### PR DESCRIPTION
It looks like [this fix](https://github.com/postcss/postcss/commit/1325896395a9a4693ba0d2d83e8ed99478ba6d36) didn't work completely. When using the postcss loader, quite a lot of warnings appear in the console, which do not really tell you anything. This appears to be due to the fact that ignoring an error in source-map-js directly calls `console.warn()`.

I think it's easier to just make an empty catch.