### PR TITLE
fix `CssSyntaxError` type declaration

### DIFF
--- a/lib/css-syntax-error.d.ts
+++ b/lib/css-syntax-error.d.ts
@@ -49,7 +49,7 @@ declare namespace CssSyntaxError {
  * }
  * ```
  */
-declare class CssSyntaxError_ {
+declare class CssSyntaxError_ extends Error {
   /**
    * Source column of the error.
    *


### PR DESCRIPTION
see : https://typescript-eslint.io/rules/only-throw-error/

When using TypeScript it is useful to only throw instances of `Error` (or subclasses thereof)

Currently we get an error for this lint rule with PostCSS on lines like these :

```ts
throw atRule.error('Rule must have valid params')
```

`CssSyntaxError` is a subclass of `Error`, but not declared as such in the `.d.ts` file.