### PR TITLE
Declare Node subclass attributes as getters

### DIFF
--- a/lib/at-rule.d.ts
+++ b/lib/at-rule.d.ts
@@ -88,7 +88,9 @@ declare class AtRule_ extends Container {
    * media.name //=> 'media'
    * ```
    */
-  name: string
+  get name(): string
+  set name(value: string)
+
   /**
    * An array containing the layer’s children.
    *
@@ -118,7 +120,8 @@ declare class AtRule_ extends Container {
    * media.params //=> 'print, screen'
    * ```
    */
-  params: string
+  get params(): string
+  set params(value: string)
   parent: ContainerWithChildren | undefined
 
   raws: AtRule.AtRuleRaws

--- a/lib/comment.d.ts
+++ b/lib/comment.d.ts
@@ -51,7 +51,8 @@ declare class Comment_ extends Node {
   /**
    * The comment's text.
    */
-  text: string
+  get text(): string
+  set text(value: string)
 
   type: 'comment'
 

--- a/lib/declaration.d.ts
+++ b/lib/declaration.d.ts
@@ -77,7 +77,8 @@ declare class Declaration_ extends Node {
    * root.first.last.important  //=> undefined
    * ```
    */
-  important: boolean
+  get important(): boolean
+  set important(value: boolean)
 
   parent: ContainerWithChildren | undefined
 
@@ -91,7 +92,8 @@ declare class Declaration_ extends Node {
    * decl.prop //=> 'color'
    * ```
    */
-  prop: string
+  get prop(): string
+  set prop(value: string)
 
   raws: Declaration.DeclarationRaws
 
@@ -114,7 +116,8 @@ declare class Declaration_ extends Node {
    * decl.value //=> 'black'
    * ```
    */
-  value: string
+  get value(): string
+  set value(value: string)
 
   /**
    * It represents a getter that returns `true` if a declaration starts with
@@ -134,7 +137,8 @@ declare class Declaration_ extends Node {
    * one.variable //=> true
    * ```
    */
-  variable: boolean
+  get variable(): boolean
+  set varaible(value: string)
 
   constructor(defaults?: Declaration.DeclarationProps)
   assign(overrides: Declaration.DeclarationProps | object): this

--- a/lib/rule.d.ts
+++ b/lib/rule.d.ts
@@ -84,7 +84,8 @@ declare class Rule_ extends Container {
    * rule.selector //=> 'a, b'
    * ```
    */
-  selector: string
+  get selector(): string
+  set selector(value: string);
 
   /**
    * An array containing the rule’s individual selectors.
@@ -101,7 +102,8 @@ declare class Rule_ extends Container {
    * rule.selector //=> 'a, strong'
    * ```
    */
-  selectors: string[]
+  get selectors(): string[]
+  set selectors(values: string[]);
 
   type: 'rule'
 


### PR DESCRIPTION
This makes it easier to extend these classes and override these fields
with information that's derived from other, internal fields.

This helps enable https://github.com/sass/dart-sass/issues/88