### PR TITLE
Refactor regex usage

### DIFF
--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -75,7 +75,7 @@ class MapGenerator {
         }
       }
     } else if (this.css) {
-      this.css = this.css.replace(/\n*?\/\*#[\S\s]*?\*\/$/gm, '')
+      this.css = this.css.replace(/\n*\/\*#[\S\s]*?\*\/$/gm, '')
     }
   }
 

--- a/lib/previous-map.js
+++ b/lib/previous-map.js
@@ -40,14 +40,15 @@ class PreviousMap {
     let baseUri = /^data:application\/json;base64,/
     let charsetUri = /^data:application\/json;charset=utf-?8,/
     let uri = /^data:application\/json,/
-    let m
 
-    if ((m = text.match(charsetUri)) || (m = text.match(uri))) {
-      return decodeURIComponent(text.substr(m[0].length))
+    let uriMatch = text.match(charsetUri) || text.match(uri)
+    if (uriMatch) {
+      return decodeURIComponent(text.substr(uriMatch[0].length))
     }
 
-    if ((m = text.match(baseCharsetUri)) || (m = text.match(baseUri))) {
-      return fromBase64(text.substr(m[0].length))
+    let baseUriMatch = text.match(baseCharsetUri) || text.match(baseUri)
+    if (baseUriMatch) {
+      return fromBase64(text.substr(baseUriMatch[0].length))
     }
 
     let encoding = text.match(/data:application\/json;([^,]+),/)[1]

--- a/lib/previous-map.js
+++ b/lib/previous-map.js
@@ -40,13 +40,14 @@ class PreviousMap {
     let baseUri = /^data:application\/json;base64,/
     let charsetUri = /^data:application\/json;charset=utf-?8,/
     let uri = /^data:application\/json,/
+    let m
 
-    if (charsetUri.test(text) || uri.test(text)) {
-      return decodeURIComponent(text.substr(RegExp.lastMatch.length))
+    if ((m = text.match(charsetUri)) || (m = text.match(uri))) {
+      return decodeURIComponent(text.substr(m[0].length))
     }
 
-    if (baseCharsetUri.test(text) || baseUri.test(text)) {
-      return fromBase64(text.substr(RegExp.lastMatch.length))
+    if ((m = text.match(baseCharsetUri)) || (m = text.match(baseUri))) {
+      return fromBase64(text.substr(m[0].length))
     }
 
     let encoding = text.match(/data:application\/json;([^,]+),/)[1]
@@ -67,7 +68,7 @@ class PreviousMap {
   }
 
   loadAnnotation(css) {
-    let comments = css.match(/\/\*\s*# sourceMappingURL=/gm)
+    let comments = css.match(/\/\*\s*# sourceMappingURL=/g)
     if (!comments) return
 
     // sourceMappingURLs from comments, strings, etc.


### PR DESCRIPTION
I was linting the code with [eslint-plugin-regexp](https://ota-meshi.github.io/eslint-plugin-regexp/) and found some improvements that we could do here.

- Refactor away legacy `RegExp.lastMatch` usage ([they're deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch#browser_compatibility)) 
- Removed an unneeded non-greedy constant quantifier
- Removed an unneeded m flag

Here are the lint results that caught these issues:

```
/Users/bjorn/Work/oss/vite/node_modules/.pnpm/postcss@8.4.39/node_modules/postcss/lib/map-generator.js
  78:39  error  Unexpected non-greedy constant quantifier. The quantifier is effectively possessive, so it doesn't matter whether it is greedy or not  regexp/no-useless-lazy

/Users/bjorn/Work/oss/vite/node_modules/.pnpm/postcss@8.4.39/node_modules/postcss/lib/previous-map.js
  45:45  error  'RegExp.lastMatch' static property is forbidden                                                   regexp/no-legacy-features
  49:37  error  'RegExp.lastMatch' static property is forbidden                                                   regexp/no-legacy-features
  70:59  error  The 'm' flag is unnecessary because the pattern does not contain start (^) or end ($) assertions  regexp/no-useless-flag
```

I tested each regex calls manually to make sure the lint errors are accurate, and they should still work as before.
