### PR TITLE
Fix typo'd setter name in declaration.d.ts

### DIFF
--- a/lib/declaration.d.ts
+++ b/lib/declaration.d.ts
@@ -138,7 +138,7 @@ declare class Declaration_ extends Node {
    * ```
    */
   get variable(): boolean
-  set varaible(value: string)
+  set variable(value: string)
 
   constructor(defaults?: Declaration.DeclarationProps)
   assign(overrides: Declaration.DeclarationProps | object): this


### PR DESCRIPTION
Hello, I just happened to notice this typo whilst reviewing the changes in the most recent release. (Thanks Dependabot!)

This was introduced in #1950.

I'm not familiar with PostCSS's internals or release process. As a release of PostCSS has already gone out with this setter name spelled incorrectly, I'm not sure if this warrants additional work to support the prior name and avoid a breaking change. 

Feel free to modify this PR as needed.