### PR TITLE
chore(docs): improve visual appearance of images in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ PostCSS needs your support. We are accepting donations
 
 <a href="https://tailwindcss.com/">
   <img src="https://refactoringui.nyc3.cdn.digitaloceanspaces.com/tailwind-logo.svg"
-       alt="Sponsored by Tailwind CSS" width="213" height="50">
-</a>      <a href="https://themeisle.com/">
+       alt="Sponsored by Tailwind CSS" width="213" height="50"></a>      
+<a href="https://themeisle.com/">
   <img src="https://mllj2j8xvfl0.i.optimole.com/d0cOXWA.3970~373ad/w:auto/h:auto/q:90/https://s30246.pcdn.co/wp-content/uploads/2019/03/logo.png"
-       alt="Sponsored by ThemeIsle" width="171" height="56">
-</a>
+       alt="Sponsored by ThemeIsle" width="171" height="56"></a>
 
 
 ## Plugins


### PR DESCRIPTION
# Description
This Pull Request improves the visual appearance of the images in the README.md file by removing unnecessary line breaks between them, eliminating the unwanted blue link lines that previously appeared and resulting in a cleaner and more cohesive look.


### before
![before](https://github.com/user-attachments/assets/0ac932aa-e647-4fc9-8d17-a8661a1f1a62)

### after
![after](https://github.com/user-attachments/assets/ebd8e7f9-2349-47d2-9af3-2678fe7adf12)

## Why
Previously, the images were displayed with line breaks between them, causing blue link lines to appear, which disrupted the clean look of the images. By removing these line breaks, the images now appear without the blue link lines, providing a more cohesive and visually appealing README.

x-ref: [New Default: Underlined Links for Improved Accessibility](https://github.blog/changelog/2023-10-18-new-default-underlined-links-for-improved-accessibility/)