### PR TITLE
Replace `indexOf === 0` with `startsWith`

### DIFF
--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -70,7 +70,7 @@ class MapGenerator {
       for (let i = this.root.nodes.length - 1; i >= 0; i--) {
         node = this.root.nodes[i]
         if (node.type !== 'comment') continue
-        if (node.text.indexOf('# sourceMappingURL=') === 0) {
+        if (node.text.startsWith('# sourceMappingURL=')) {
           this.root.removeChild(i)
         }
       }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -267,12 +267,12 @@ class Parser {
         let str = ''
         for (let j = i; j > 0; j--) {
           let type = cache[j][0]
-          if (str.trim().indexOf('!') === 0 && type !== 'space') {
+          if (str.trim().startsWith('!') && type !== 'space') {
             break
           }
           str = cache.pop()[1] + str
         }
-        if (str.trim().indexOf('!') === 0) {
+        if (str.trim().startsWith('!')) {
           node.important = true
           node.raws.important = str
           tokens = cache


### PR DESCRIPTION
A small PR.

It is more readable to call `startsWith` than to call `indexOf` and compare the result with zero to determine whether a string starts with a given prefix.

`startsWith` is also more efficient as it only compares at the beginning of the string, while `indexOf` searches the entire string.