### PR TITLE
Use `ReadonlyArray` for argument types that aren't modified

### DIFF
--- a/lib/container.d.ts
+++ b/lib/container.d.ts
@@ -20,11 +20,11 @@ declare namespace Container {
     /**
      * An array of property names.
      */
-    props?: string[]
+    props?: ReadonlyArray<string>
   }
 
   export interface ContainerProps extends NodeProps {
-    nodes?: (Node | ChildProps)[]
+    nodes?: ReadonlyArray<Node | ChildProps>
   }
 
   /**
@@ -33,11 +33,11 @@ declare namespace Container {
    */
   export type NewChild =
     | ChildProps
-    | ChildProps[]
+    | ReadonlyArray<ChildProps>
     | Node
-    | Node[]
+    | ReadonlyArray<Node>
     | string
-    | string[]
+    | ReadonlyArray<string>
     | undefined
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/lib/document.d.ts
+++ b/lib/document.d.ts
@@ -5,7 +5,7 @@ import Root from './root.js'
 
 declare namespace Document {
   export interface DocumentProps extends ContainerProps {
-    nodes?: Root[]
+    nodes?: ReadonlyArray<Root>
 
     /**
      * Information to generate byte-to-byte equal node string as it was

--- a/lib/list.d.ts
+++ b/lib/list.d.ts
@@ -47,7 +47,11 @@ declare namespace list {
      * @param last boolean indicator.
      * @return Split values.
      */
-    split(string: string, separators: string[], last: boolean): string[]
+    split(
+      string: string,
+      separators: ReadonlyArray<string>,
+      last: boolean
+    ): string[]
   }
 }
 

--- a/lib/node.d.ts
+++ b/lib/node.d.ts
@@ -246,7 +246,9 @@ declare abstract class Node_ {
    * @param newNode New node.
    * @return This node for methods chain.
    */
-  after(newNode: Node | Node.ChildProps | Node[] | string | undefined): this
+  after(
+    newNode: Node | Node.ChildProps | ReadonlyArray<Node> | string | undefined
+  ): this
 
   /**
    * It assigns properties to an existing node instance.
@@ -273,7 +275,9 @@ declare abstract class Node_ {
    * @param newNode New node.
    * @return This node for methods chain.
    */
-  before(newNode: Node | Node.ChildProps | Node[] | string | undefined): this
+  before(
+    newNode: Node | Node.ChildProps | ReadonlyArray<Node> | string | undefined
+  ): this
 
   /**
    * Clear the code style properties for the node and its children.
@@ -370,7 +374,7 @@ declare abstract class Node_ {
    * modified by the current plugin and may need to be processed again by other
    * plugins.
    */
-  protected markDirty(): void;
+  protected markDirty(): void
 
   /**
    * Returns the next child of the node’s parent.

--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -445,7 +445,9 @@ declare namespace postcss {
  * @param plugins PostCSS plugins.
  * @return Processor to process multiple CSS.
  */
-declare function postcss(plugins?: postcss.AcceptedPlugin[]): Processor
+declare function postcss(
+  plugins?: ReadonlyArray<postcss.AcceptedPlugin>
+): Processor
 declare function postcss(...plugins: postcss.AcceptedPlugin[]): Processor
 
 export = postcss

--- a/lib/processor.d.ts
+++ b/lib/processor.d.ts
@@ -51,7 +51,7 @@ declare class Processor_ {
   /**
    * @param plugins PostCSS plugins
    */
-  constructor(plugins?: AcceptedPlugin[])
+  constructor(plugins?: ReadonlyArray<AcceptedPlugin>)
 
   /**
    * Parses source CSS and returns a `LazyResult` Promise proxy.

--- a/lib/rule.d.ts
+++ b/lib/rule.d.ts
@@ -51,7 +51,7 @@ declare namespace Rule {
         }
       | {
           /** Selectors of the rule represented as an array of strings. */
-          selectors: string[]
+          selectors: ReadonlyArray<string>
           selector?: never
         }
     )


### PR DESCRIPTION
This makes it possible for callers to pass in their own
`ReadonlyArray`s, and implicitly documents that these arguments aren't
modified.