### PR TITLE
Update remaining workflow jobs to use latest version of actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Create the release
         if: steps.changelog.outputs.changelog_content != ''
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.ref_name }}
           body: '${{ steps.changelog.outputs.changelog_content }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v1
+        uses: pnpm/action-setup@v4
         with:
           version: 3
         env:
@@ -86,7 +86,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
       - name: Install Node.js LTS


### PR DESCRIPTION
There are leftover actions from commit b952be76f0c7704a99dceb34294117d13e3470a4 that were not updated.

The workflow runs are annotated with the deprecation warnings. (Image from https://github.com/postcss/postcss/actions/runs/10699054789)

![image](https://github.com/user-attachments/assets/53fce8a4-1dfc-41e0-b18b-8d9e76836081)
