### PR TITLE
Fix inconsistent position calculations

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -177,22 +177,23 @@ class Node {
   positionBy(opts, stringRepresentation) {
     let pos = this.source.start
     if (opts.index) {
-      pos = this.positionInside(opts.index, stringRepresentation)
+      pos = this.positionInside(opts.index)
     } else if (opts.word) {
-      stringRepresentation = this.toString()
+      stringRepresentation = this.source.input.css.slice(this.source.start.offset, this.source.end.offset)
       let index = stringRepresentation.indexOf(opts.word)
-      if (index !== -1) pos = this.positionInside(index, stringRepresentation)
+      if (index !== -1) pos = this.positionInside(index)
     }
     return pos
   }
 
-  positionInside(index, stringRepresentation) {
-    let string = stringRepresentation || this.toString()
+  positionInside(index) {
     let column = this.source.start.column
     let line = this.source.start.line
+    let offset = this.source.start.offset
+    let end = offset + index
 
-    for (let i = 0; i < index; i++) {
-      if (string[i] === '\n') {
+    for (let i = offset; i < end; i++) {
+      if (this.source.input.css[i] === '\n') {
         column = 1
         line += 1
       } else {
@@ -225,7 +226,7 @@ class Node {
         }
 
     if (opts.word) {
-      let stringRepresentation = this.toString()
+      let stringRepresentation = this.source.input.css.slice(this.source.start.offset, this.source.end.offset)
       let index = stringRepresentation.indexOf(opts.word)
       if (index !== -1) {
         start = this.positionInside(index, stringRepresentation)

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -412,11 +412,43 @@ test('positionInside() returns position when node contains newlines', () => {
   equal(one.positionInside(10), { column: 4, line: 3 })
 })
 
+test('positionInside() returns position after AST mutations', () => {
+  let css = parse('a {\n\tone: 1;\n\ttwo: 2;}')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  let two = one.next() as Declaration
+
+  equal(a.positionInside(15), { column: 3, line: 3 })
+  equal(two.positionInside(1), { column: 3, line: 3 })
+
+  one.remove()
+
+  equal(a.positionInside(15), { column: 3, line: 3 })
+  equal(two.positionInside(1), { column: 3, line: 3 })
+})
+
 test('positionBy() returns position for word', () => {
   let css = parse('a {  one: X  }')
   let a = css.first as Rule
   let one = a.first as Declaration
   equal(one.positionBy({ word: 'one' }), { column: 6, line: 1 })
+  equal(one.positionBy({ word: 'X' }), { column: 11, line: 1 })
+  equal(a.positionBy({ word: '}' }), { column: 14, line: 1 })
+})
+
+test('positionBy() returns position for word after AST mutations', () => {
+  let css = parse('a {\n\tone: 1;\n\ttwo: 2;}')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  let two = one.next() as Declaration
+
+  equal(a.positionBy({ word: 'two' }), { column: 2, line: 3 })
+  equal(two.positionBy({ word: 'two' }), { column: 2, line: 3 })
+
+  one.remove()
+
+  equal(a.positionBy({ word: 'two' }), { column: 2, line: 3 })
+  equal(two.positionBy({ word: 'two' }), { column: 2, line: 3 })
 })
 
 test('positionBy() returns position for index', () => {
@@ -424,6 +456,21 @@ test('positionBy() returns position for index', () => {
   let a = css.first as Rule
   let one = a.first as Declaration
   equal(one.positionBy({ index: 1 }), { column: 7, line: 1 })
+})
+
+test('positionBy() returns position for index after AST mutations', () => {
+  let css = parse('a {\n\tone: 1;\n\ttwo: 2;}')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  let two = one.next() as Declaration
+
+  equal(a.positionBy({ index: 15 }), { column: 3, line: 3 })
+  equal(two.positionBy({ index: 1 }), { column: 3, line: 3 })
+
+  one.remove()
+
+  equal(a.positionBy({ index: 15 }), { column: 3, line: 3 })
+  equal(two.positionBy({ index: 1 }), { column: 3, line: 3 })
 })
 
 test('rangeBy() returns range for word', () => {
@@ -436,6 +483,33 @@ test('rangeBy() returns range for word', () => {
   })
 })
 
+test('rangeBy() returns range for word even after AST mutations', () => {
+  let css = parse('a {\n\tone: 1;\n\ttwo: 2;}')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  let two = one.next() as Declaration
+
+  equal(a.rangeBy({ word: 'two' }), {
+    end: { column: 5, line: 3 },
+    start: { column: 2, line: 3 }
+  })
+  equal(two.rangeBy({ word: 'two' }), {
+    end: { column: 5, line: 3 },
+    start: { column: 2, line: 3 }
+  })
+
+  one.remove()
+
+  equal(a.rangeBy({ word: 'two' }), {
+    end: { column: 5, line: 3 },
+    start: { column: 2, line: 3 }
+  })
+  equal(two.rangeBy({ word: 'two' }), {
+    end: { column: 5, line: 3 },
+    start: { column: 2, line: 3 }
+  })
+})
+
 test('rangeBy() returns range for index and endIndex', () => {
   let css = parse('a {  one: X  }')
   let a = css.first as Rule
@@ -443,6 +517,33 @@ test('rangeBy() returns range for index and endIndex', () => {
   equal(one.rangeBy({ endIndex: 3, index: 1 }), {
     end: { column: 9, line: 1 },
     start: { column: 7, line: 1 }
+  })
+})
+
+test('rangeBy() returns range for index and endIndex after AST mutations', () => {
+  let css = parse('a {\n\tone: 1;\n\ttwo: 2;}')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  let two = one.next() as Declaration
+
+  equal(a.rangeBy({ endIndex: 17, index: 15 }), {
+    end: { column: 5, line: 3 },
+    start: { column: 3, line: 3 }
+  })
+  equal(two.rangeBy({ endIndex: 3, index: 1 }), {
+    end: { column: 5, line: 3 },
+    start: { column: 3, line: 3 }
+  })
+
+  one.remove()
+
+  equal(a.rangeBy({ endIndex: 17, index: 15 }), {
+    end: { column: 5, line: 3 },
+    start: { column: 3, line: 3 }
+  })
+  equal(two.rangeBy({ endIndex: 3, index: 1 }), {
+    end: { column: 5, line: 3 },
+    start: { column: 3, line: 3 }
   })
 })
 


### PR DESCRIPTION
fixes: https://github.com/postcss/postcss/issues/1979

----

Benchmarks:

```
[16:51:26] Running suite Preprocessors [/Users/romainmenke/projects/postcss-benchmark/preprocessors.js]...

PostCSS sync:      29 ms  (1.0 times faster)
Next PostCSS sync: 29 ms  (1.0 times faster)
PostCSS:           30 ms
Next PostCSS:      31 ms  (1.0 times slower)

...

[16:52:19] Running suite Parsers [/Users/romainmenke/projects/postcss-benchmark/parsers.js]...

PostCSS:      13 ms
Next PostCSS: 13 ms (1.0 times slower)

...

[16:54:02] Running suite Linters [/Users/romainmenke/projects/postcss-benchmark/linters.js]...

Next PostCSS: 207 ms (1.1 times faster)
PostCSS:      219 ms

...

[16:54:14] Running suite Sourcemaps [/Users/romainmenke/projects/postcss-benchmark/sourcemaps.js]...

Next PostCSS: 67 ms (1.0 times faster)
PostCSS:      67 ms
```

Stylelint even seems to run a bit faster after this update.

I assume that calling `String.prototype.slice` is noticeably faster than recursively calling `Node.prototype.toString()` and serializing all nodes.

