### PR TITLE
Fix the documentation for `RuleRaws.ownSemicolon`

### DIFF
--- a/lib/rule.d.ts
+++ b/lib/rule.d.ts
@@ -22,7 +22,7 @@ declare namespace Rule {
     between?: string
 
     /**
-     * Contains `true` if there is semicolon after rule.
+     * Contains the text of the semicolon after this rule.
      */
     ownSemicolon?: string
 


### PR DESCRIPTION
This didn't match the actual type or behavior of the field.