### PR TITLE
Fix end position of rules with `ownSemicon`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -347,6 +347,8 @@ class Parser {
       if (prev && prev.type === 'rule' && !prev.raws.ownSemicolon) {
         prev.raws.ownSemicolon = this.spaces
         this.spaces = ''
+        prev.source.end = this.getPosition(token[2])
+        prev.source.end.offset += prev.raws.ownSemicolon.length
       }
     }
   }


### PR DESCRIPTION
See: https://github.com/postcss/postcss-parser-tests/pull/28

Rules with semicolons had these assigned to `rule.raws.ownSemicolon` and these are also used when serializing: 

https://github.com/postcss/postcss/blob/7b02c75e5f093b3fdf8d46eeb17c21a52434d827/lib/stringifier.js#L330-L335

However the source positions of the rules weren't adjusted after appending to `rule.raws.ownSemicolon`.

This change makes it so that slicing out the source range for a rule from the input CSS better matches `rule.toString()`