### PR TITLE
update: parser.js to clarify error message

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -593,7 +593,7 @@ class Parser {
 
   unknownWord(tokens) {
     throw this.input.error(
-      'Unexpected character "' + tokens[0][1] + '" in selector. Check CSS selector documentation for proper syntax.''Unknown word',
+      'Unknown word: ' + tokens[0][1],
       { offset: tokens[0][2] },
       { offset: tokens[0][2] + tokens[0][1].length }
     )

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -593,7 +593,7 @@ class Parser {
 
   unknownWord(tokens) {
     throw this.input.error(
-      'Unknown word',
+      'Unexpected character "' + tokens[0][1] + '" in selector. Check CSS selector documentation for proper syntax.''Unknown word',
       { offset: tokens[0][2] },
       { offset: tokens[0][2] + tokens[0][1].length }
     )


### PR DESCRIPTION
clarify error message by specify error variable

instead of unknown word it is better for user to see the exacly token cause issue:

![image](https://github.com/user-attachments/assets/27b54aba-bfe0-4947-9dae-40c6c2d22b3d)


closes #2014 

also reference: 
https://github.com/tailwindlabs/tailwindcss/issues/16447#issuecomment-2667452873
https://github.com/saadeghi/daisyui/issues/3453