### PR TITLE
The return type of the method rawValue in Stringifier should be `any`…

### DIFF
--- a/lib/stringifier.d.ts
+++ b/lib/stringifier.d.ts
@@ -35,7 +35,7 @@ declare class Stringifier_ {
   rawEmptyBody(root: Root): string | undefined
   rawIndent(root: Root): string | undefined
   rawSemicolon(root: Root): boolean | undefined
-  rawValue(node: AnyNode, prop: string): string
+  rawValue(node: AnyNode, prop: string): any
   root(node: Root): void
   rule(node: Rule): void
   stringify(node: AnyNode, semicolon?: boolean): void


### PR DESCRIPTION
The return type of the method rawValue in Stringifier should be `any` instead of just a `string`
Here:
- `let rule = new AtRule({ name: 'page', nodes: [], params: 1 });`
   The type of return value of the method rawValue in Stringifier is a number (This is taken from one of the unit tests)
- `let rule = new AtRule({ name: 'page', nodes: [], params: true });`
   The type of return value of the method rawValue in Stringifier is a boolean



