### PR TITLE
Return type of method `raw` of `Stringifier` can be boolean.

### DIFF
--- a/lib/stringifier.d.ts
+++ b/lib/stringifier.d.ts
@@ -25,7 +25,7 @@ declare class Stringifier_ {
   comment(node: Comment): void
   decl(node: Declaration, semicolon?: boolean): void
   document(node: Document): void
-  raw(node: AnyNode, own: null | string, detect?: string): string
+  raw(node: AnyNode, own: null | string, detect?: string): string | boolean
   rawBeforeClose(root: Root): string | undefined
   rawBeforeComment(root: Root, node: Comment): string | undefined
   rawBeforeDecl(root: Root, node: Declaration): string | undefined


### PR DESCRIPTION
The property `semicolon` of raws in nodes is boolean, so the `raw` of `Stringifier` can return `boolean` value when `own === 'semicolon'`