### PR TITLE
Change in type definition of property `css` of `result`

### DIFF
--- a/lib/result.d.ts
+++ b/lib/result.d.ts
@@ -67,7 +67,7 @@ declare class Result_<RootNode = Document | Root> {
    * postcss.parse('a{}').toResult().css //=> "a{}"
    * ```
    */
-  css: string
+  css?: string
 
   /**
    * Last runned PostCSS plugin.

--- a/lib/result.d.ts
+++ b/lib/result.d.ts
@@ -67,7 +67,7 @@ declare class Result_<RootNode = Document | Root> {
    * postcss.parse('a{}').toResult().css //=> "a{}"
    * ```
    */
-  css?: string
+  css: string | undefined
 
   /**
    * Last runned PostCSS plugin.
@@ -168,7 +168,7 @@ declare class Result_<RootNode = Document | Root> {
    *
    * @return String representing of `Result#root`.
    */
-  toString(): string
+  toString(): string | undefined
 
   /**
    * Creates an instance of `Warning` and adds it to `Result#messages`.

--- a/lib/result.d.ts
+++ b/lib/result.d.ts
@@ -67,7 +67,7 @@ declare class Result_<RootNode = Document | Root> {
    * postcss.parse('a{}').toResult().css //=> "a{}"
    * ```
    */
-  css: string | undefined
+  css: string
 
   /**
    * Last runned PostCSS plugin.
@@ -168,7 +168,7 @@ declare class Result_<RootNode = Document | Root> {
    *
    * @return String representing of `Result#root`.
    */
-  toString(): string | undefined
+  toString(): string
 
   /**
    * Creates an instance of `Warning` and adds it to `Result#messages`.

--- a/lib/result.js
+++ b/lib/result.js
@@ -12,7 +12,7 @@ class Result {
     this.messages = []
     this.root = root
     this.opts = opts
-    this.css = undefined
+    this.css = ''
     this.map = undefined
   }
 


### PR DESCRIPTION
In the `constructor` of class `Result` property `css` is initialized to `undefined` and the same is returned by the method `toString()`. 