### PR TITLE
Clarify documentation for `node.source.end.offset`

### DIFF
--- a/lib/node.d.ts
+++ b/lib/node.d.ts
@@ -67,10 +67,21 @@ declare namespace Node {
      * The inclusive ending position for the source
      * code of a node.
      *
-     * However, only `end.offset` may be an exclusive position.
-     * The offset of `Root` node is the inclusive position,
-     * and the offset of other nodes is the exclusive position.
+     * However, `end.offset` of a non `Root` node is the exclusive position.
      * See https://github.com/postcss/postcss/pull/1879 for details.
+     *
+     * ```js
+     * const root = postcss.parse('a { color: black }')
+     * const a = root.first
+     * const color = a.first
+     *
+     * // The offset of `Root` node is the inclusive position
+     * css.source.end   // { line: 1, column: 19, offset: 18 }
+     *
+     * // The offset of non `Root` node is the exclusive position
+     * a.source.end     // { line: 1, column: 18, offset: 18 }
+     * color.source.end // { line: 1, column: 16, offset: 16 }
+     * ```
      */
     end?: Position
 

--- a/lib/node.d.ts
+++ b/lib/node.d.ts
@@ -66,6 +66,11 @@ declare namespace Node {
     /**
      * The inclusive ending position for the source
      * code of a node.
+     *
+     * However, only `end.offset` may be an exclusive position.
+     * The offset of `Root` node is the inclusive position,
+     * and the offset of other nodes is the exclusive position.
+     * See https://github.com/postcss/postcss/pull/1879 for details.
      */
     end?: Position
 

--- a/test/location.test.ts
+++ b/test/location.test.ts
@@ -16,6 +16,23 @@ function checkOffset(source: string, node: Node, expected: string): void {
   equal(source.slice(start, end), expected)
 }
 
+test('root', () => {
+  let source = '.a{}'
+  let css = parse(source)
+
+  checkOffset(source, css, '.a{}')
+  equal(css.source!.start, {
+    column: 1,
+    line: 1,
+    offset: 0
+  })
+  equal(css.source!.end, {
+    column: 5,
+    line: 1,
+    offset: 4
+  })
+})
+
 test('rule', () => {
   let source = '.a{}'
   let css = parse(source)


### PR DESCRIPTION
ref: #2030

The behavior of `node.source.end.offset` is confusing to users. I want to reduce this confusion. So I have tried to describe the behavior in the documentation.