### PR TITLE
Add `Input#fromLineAndColumn`, `CssSyntaxError.input.offset` and `CssSyntaxError.input.endOffset`

### DIFF
--- a/lib/input.d.ts
+++ b/lib/input.d.ts
@@ -19,6 +19,11 @@ declare namespace Input {
     endLine?: number
 
     /**
+     * Offset of exclusive end position in source file.
+     */
+    endOffset?: number
+
+    /**
      * Absolute path to the source file.
      */
     file?: string
@@ -27,6 +32,11 @@ declare namespace Input {
      * Line of inclusive start position in source file.
      */
     line: number
+
+    /**
+     * Offset of inclusive start position in source file.
+     */
+    offset: number
 
     /**
      * Source code.

--- a/lib/input.d.ts
+++ b/lib/input.d.ts
@@ -131,6 +131,9 @@ declare class Input_ {
    */
   constructor(css: string, opts?: ProcessOptions)
 
+  /**
+   * Returns `CssSyntaxError` with information about the error and its position.
+   */
   error(
     message: string,
     start:
@@ -151,9 +154,6 @@ declare class Input_ {
         },
     opts?: { plugin?: CssSyntaxError['plugin'] }
   ): CssSyntaxError
-  /**
-   * Returns `CssSyntaxError` with information about the error and its position.
-   */
   error(
     message: string,
     line: number,

--- a/lib/input.d.ts
+++ b/lib/input.d.ts
@@ -165,12 +165,23 @@ declare class Input_ {
     offset: number,
     opts?: { plugin?: CssSyntaxError['plugin'] }
   ): CssSyntaxError
+
+  /**
+   * Converts source line and column to offset.
+   *
+   * @param line   Source line.
+   * @param column Source column.
+   * @return Source offset.
+   */
+  fromLineAndColumn(line: number, column: number): number
+
   /**
    * Converts source offset to line and column.
    *
    * @param offset Source offset.
    */
   fromOffset(offset: number): { col: number; line: number } | null
+
   /**
    * Reads the input source map and returns a symbol position
    * in the input source (e.g., in a Sass file that was compiled

--- a/lib/input.js
+++ b/lib/input.js
@@ -9,7 +9,7 @@ let CssSyntaxError = require('./css-syntax-error')
 let PreviousMap = require('./previous-map')
 let terminalHighlight = require('./terminal-highlight')
 
-let fromOffsetCache = Symbol('fromOffsetCache')
+let lineToIndexCache = Symbol('lineToIndexCache')
 
 let sourceMapAvailable = Boolean(SourceMapConsumer && SourceMapGenerator)
 let pathAvailable = Boolean(resolve && isAbsolute)
@@ -65,6 +65,21 @@ class Input {
       this.id = '<input css ' + nanoid(6) + '>'
     }
     if (this.map) this.map.file = this.from
+  }
+
+  _getLineToIndex() {
+    if (this[lineToIndexCache]) return this[lineToIndexCache]
+    let lines = this.css.split('\n')
+    let lineToIndex = new Array(lines.length)
+    let prevIndex = 0
+
+    for (let i = 0, l = lines.length; i < l; i++) {
+      lineToIndex[i] = prevIndex
+      prevIndex += lines[i].length + 1
+    }
+
+    this[lineToIndexCache] = lineToIndex
+    return lineToIndex
   }
 
   error(message, line, column, opts = {}) {
@@ -132,22 +147,8 @@ class Input {
   }
 
   fromOffset(offset) {
-    let lastLine, lineToIndex
-    if (!this[fromOffsetCache]) {
-      let lines = this.css.split('\n')
-      lineToIndex = new Array(lines.length)
-      let prevIndex = 0
-
-      for (let i = 0, l = lines.length; i < l; i++) {
-        lineToIndex[i] = prevIndex
-        prevIndex += lines[i].length + 1
-      }
-
-      this[fromOffsetCache] = lineToIndex
-    } else {
-      lineToIndex = this[fromOffsetCache]
-    }
-    lastLine = lineToIndex[lineToIndex.length - 1]
+    let lineToIndex = this._getLineToIndex()
+    let lastLine = lineToIndex[lineToIndex.length - 1]
 
     let min = 0
     if (offset >= lastLine) {

--- a/lib/input.js
+++ b/lib/input.js
@@ -83,31 +83,38 @@ class Input {
   }
 
   error(message, line, column, opts = {}) {
-    let endColumn, endLine, result
+    let endColumn, endLine, endOffset, offset, result
 
     if (line && typeof line === 'object') {
       let start = line
       let end = column
       if (typeof start.offset === 'number') {
-        let pos = this.fromOffset(start.offset)
+        offset = start.offset
+        let pos = this.fromOffset(offset)
         line = pos.line
         column = pos.col
       } else {
         line = start.line
         column = start.column
+        offset = this.fromLineAndColumn(line, column)
       }
       if (typeof end.offset === 'number') {
-        let pos = this.fromOffset(end.offset)
+        endOffset = end.offset
+        let pos = this.fromOffset(endOffset)
         endLine = pos.line
         endColumn = pos.col
       } else {
         endLine = end.line
         endColumn = end.column
+        endOffset = this.fromLineAndColumn(end.line, end.column)
       }
     } else if (!column) {
-      let pos = this.fromOffset(line)
+      offset = line
+      let pos = this.fromOffset(offset)
       line = pos.line
       column = pos.col
+    } else {
+      offset = this.fromLineAndColumn(line, column)
     }
 
     let origin = this.origin(line, column, endLine, endColumn)
@@ -135,7 +142,7 @@ class Input {
       )
     }
 
-    result.input = { column, endColumn, endLine, line, source: this.css }
+    result.input = { column, endColumn, endLine, endOffset, line, offset, source: this.css }
     if (this.file) {
       if (pathToFileURL) {
         result.input.url = pathToFileURL(this.file).toString()

--- a/lib/input.js
+++ b/lib/input.js
@@ -146,6 +146,12 @@ class Input {
     return result
   }
 
+  fromLineAndColumn(line, column) {
+    let lineToIndex = this._getLineToIndex()
+    let index = lineToIndex[line - 1]
+    return index + column - 1
+  }
+
   fromOffset(offset) {
     let lineToIndex = this._getLineToIndex()
     let lastLine = lineToIndex[lineToIndex.length - 1]

--- a/test/css-syntax-error.test.ts
+++ b/test/css-syntax-error.test.ts
@@ -63,7 +63,9 @@ test('saves source', () => {
     column: error.column,
     endColumn: error.endColumn,
     endLine: error.endLine,
+    endOffset: undefined,
     line: error.line,
+    offset: 15,
     source: error.source
   })
 })
@@ -85,7 +87,9 @@ test('saves source with ranges', () => {
     column: error.column,
     endColumn: error.endColumn,
     endLine: error.endLine,
+    endOffset: 7,
     line: error.line,
+    offset: 0,
     source: error.source
   })
 })
@@ -111,7 +115,9 @@ test('saves source with ranges', () => {
     column: error.column,
     endColumn: error.endColumn,
     endLine: error.endLine,
+    endOffset: 7,
     line: error.line,
+    offset: 0,
     source: error.source
   })
 })
@@ -133,7 +139,9 @@ test('saves source with ranges', () => {
     column: error.column,
     endColumn: error.endColumn,
     endLine: error.endLine,
+    endOffset: 7,
     line: error.line,
+    offset: 0,
     source: error.source
   })
 })
@@ -296,8 +304,10 @@ test('uses source map', () => {
     column: 1,
     endColumn: error.endColumn,
     endLine: error.endLine,
+    endOffset: undefined,
     file: join(__dirname, 'build', 'all.css'),
     line: 3,
+    offset: 7,
     source: 'a { }\n\nb {\n',
     url: urlOf(join('build', 'all.css'))
   })
@@ -328,8 +338,10 @@ test('works with path in sources', () => {
     column: 1,
     endColumn: error.endColumn,
     endLine: error.endLine,
+    endOffset: undefined,
     file: join(__dirname, 'build', 'all.css'),
     line: 3,
+    offset: 7,
     source: 'a { }\n\nb {\n',
     url: pathToFileURL(pathOf(join('build', 'all.css'))).toString()
   })

--- a/test/css-syntax-error.test.ts
+++ b/test/css-syntax-error.test.ts
@@ -55,6 +55,8 @@ test('saves source', () => {
   is(error.reason, 'Unclosed string')
   is(error.line, 2)
   is(error.column, 12)
+  is(error.endLine, undefined)
+  is(error.endColumn, undefined)
   is(error.source, 'a {\n  content: "\n}')
 
   equal(error.input, {
@@ -285,6 +287,9 @@ test('uses source map', () => {
 
   is(error.file, join(__dirname, 'b.css'))
   is(error.line, 2)
+  is(error.column, 0) // Is this correct?
+  is(error.endLine, undefined)
+  is(error.endColumn, undefined)
   type(error.source, 'undefined')
 
   equal(error.input, {
@@ -314,6 +319,9 @@ test('works with path in sources', () => {
 
   is(error.file, join(__dirname, 'b.css'))
   is(error.line, 2)
+  is(error.column, 0) // Is this correct?
+  is(error.endLine, undefined)
+  is(error.endColumn, undefined)
   type(error.source, 'undefined')
 
   equal(error.input, {

--- a/test/input.test.ts
+++ b/test/input.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'uvu'
+import { equal, is } from 'uvu/assert'
+
+import { Input } from '../lib/postcss.js'
+
+test('fromLineAndColumn() returns offset', () => {
+  let input = new Input('a {\n}')
+  is(input.fromLineAndColumn(1, 1), 0)
+  is(input.fromLineAndColumn(1, 3), 2)
+  is(input.fromLineAndColumn(2, 1), 4)
+  is(input.fromLineAndColumn(2, 2), 5)
+})
+
+test('fromOffset() returns line and column', () => {
+  let input = new Input('a {\n}')
+  equal(input.fromOffset(0), { col: 1, line: 1 })
+  equal(input.fromOffset(2), { col: 3, line: 1 })
+  equal(input.fromOffset(4), { col: 1, line: 2 })
+  equal(input.fromOffset(5), { col: 2, line: 2 })
+})


### PR DESCRIPTION
fix: #2022 

I initially tried to add `CssSyntaxError.offset` and `CssSyntaxError.endOffset`. But in the case of CSS with source map, it is always undefined. The sourcemap has the original line and column, but not the offset.

Instead, I added `CssSyntaxError.input.offset` and `CssSyntaxError.input.endOffset`. `CssSyntaxError.input` is a property with a location that ignores the sourcemap. I thought it appropriate to add `offset` and `endOffset` here.