### PR TITLE
fix: add a mention for postcssense extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,9 @@ module.exports = {
 
 [`csstools.postcss`]: https://marketplace.visualstudio.com/items?itemName=csstools.postcss
 
+- [`smallcase.postcssense`] adds Intellisense for global classes
+
+[`smallcase.postcssense`]: https://marketplace.visualstudio.com/items?itemName=smallcase.postcssense
 
 ### Sublime Text
 


### PR DESCRIPTION
### ADDED
- Added a mention for `PostCssense` extension which provide support for intellisense of global classes
- Adds a CSS panel to list down all global classes
- Displays the contents of the global class when hovered over

