### PR TITLE
refactor: `import` should be listed before `require`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "exports": {
     ".": {
-      "require": "./lib/postcss.js",
-      "import": "./lib/postcss.mjs"
+      "import": "./lib/postcss.mjs",
+      "require": "./lib/postcss.js"
     },
     "./lib/at-rule": "./lib/at-rule.js",
     "./lib/comment": "./lib/comment.js",


### PR DESCRIPTION
related https://github.com/un-ts/eslint-plugin-import-x/issues/334#issuecomment-2958489115

See also https://nodejs.org/api/packages.html#conditional-exports