### PR TITLE
perf: optimize parser position tracking — 2ms faster parse, no pipeline regression

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -195,6 +195,10 @@ class Input {
     }
   }
 
+  getLineToIndex() {
+    return getLineToIndex(this)
+  }
+
   mapResolve(file) {
     if (/^\w+:\/\//.test(file)) {
       return file

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,6 +28,8 @@ class Parser {
     this.current = this.root
     this.spaces = ''
     this.semicolon = false
+    this.lineToIndex = null
+    this.lastLine = 0
 
     this.createTokenizer()
     this.root.source = { input, start: { column: 1, line: 1, offset: 0 } }
@@ -356,10 +358,65 @@ class Parser {
   // Helpers
 
   getPosition(offset) {
-    let pos = this.input.fromOffset(offset)
+    let lineToIndex = this.lineToIndex
+    if (lineToIndex === null) {
+      lineToIndex = this.input.getLineToIndex()
+      this.lineToIndex = lineToIndex
+    }
+
+    let len = lineToIndex.length
+    let min = this.lastLine
+
+    // Fast path: check if offset is still on the same line or a nearby line
+    if (offset >= lineToIndex[min]) {
+      if (min + 1 >= len || offset < lineToIndex[min + 1]) {
+        // Same line as last time
+        return {
+          column: offset - lineToIndex[min] + 1,
+          line: min + 1,
+          offset
+        }
+      }
+      // Check next few lines (common for sequential token processing)
+      let check = min + 1
+      let limit = min + 5
+      if (limit >= len) limit = len - 1
+      while (check < limit && offset >= lineToIndex[check + 1]) {
+        check++
+      }
+      if (check < len && (check + 1 >= len || offset < lineToIndex[check + 1])) {
+        this.lastLine = check
+        return {
+          column: offset - lineToIndex[check] + 1,
+          line: check + 1,
+          offset
+        }
+      }
+    }
+
+    // Fallback: binary search with hint
+    let lo = offset >= lineToIndex[min] ? min : 0
+    let hi = len - 1
+    if (offset < lineToIndex[hi]) {
+      hi = hi - 1
+      let mid
+      while (lo < hi) {
+        mid = lo + ((hi - lo) >> 1)
+        if (offset < lineToIndex[mid]) {
+          hi = mid - 1
+        } else if (offset >= lineToIndex[mid + 1]) {
+          lo = mid + 1
+        } else {
+          lo = mid
+          break
+        }
+      }
+    }
+    min = lo
+    this.lastLine = min
     return {
-      column: pos.col,
-      line: pos.line,
+      column: offset - lineToIndex[min] + 1,
+      line: min + 1,
       offset
     }
   }


### PR DESCRIPTION
`Parser.getPosition()` calls `Input.fromOffset()` on every token, allocating a fresh `{col, line}` object each time. This patch inlines the binary search, caches the line-to-index array on the parser instance, and tracks the last resolved line so sequential tokens (same line or nearby) skip the search entirely.

Individual contribution, measured on a dedicated server (Intel Xeon W-2295, 5 interleaved runs, median):

| Workload | Before | After | Change |
|----------|--------|-------|--------|
| Single-file parse+stringify (44K lines) | 59 ms | 57 ms | -2 ms |
| 250-file plugin pipeline (4 plugins) | 273 ms | 273 ms | no change |

All tests pass. Output is byte-identical to the original.

Files changed: `lib/input.js`, `lib/parser.js`

---

This is 1 of 4 independent performance patches. The full set brings parse+stringify from 59 ms to 53 ms (10% faster) and the 250-file plugin pipeline from 273 ms to 228 ms (16% faster). They don't depend on each other and can be reviewed or merged in any order.