### PR TITLE
fix: always call `raw` to retrieve raw values

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -85,23 +85,15 @@ class Stringifier {
   }
 
   block(node, start) {
-    let raws = node.raws
-    let between =
-      typeof raws.between !== 'undefined'
-        ? raws.between
-        : this.raw(node, 'between', 'beforeOpen')
+    let between = this.raw(node, 'between', 'beforeOpen')
     this.builder(escapeHTMLInCSS(start + between) + '{', node, 'start')
 
     let after
     if (node.nodes && node.nodes.length) {
       this.body(node)
-      after =
-        typeof raws.after !== 'undefined' ? raws.after : this.raw(node, 'after')
+      after = this.raw(node, 'after')
     } else {
-      after =
-        typeof raws.after !== 'undefined'
-          ? raws.after
-          : this.raw(node, 'after', 'emptyBody')
+      after = this.raw(node, 'after', 'emptyBody')
     }
 
     if (after) this.builder(escapeHTMLInCSS(after))
@@ -120,34 +112,21 @@ class Stringifier {
     let isDocument = node.type === 'document'
     for (let i = 0; i < nodes.length; i++) {
       let child = nodes[i]
-      let before = child.raws.before
-      if (typeof before === 'undefined') {
-        before = this.raw(child, 'before')
-      }
+      let before = this.raw(child, 'before')
       if (before) this.builder(isDocument ? before : escapeHTMLInCSS(before))
       this.stringify(child, last !== i || semicolon)
     }
   }
 
   comment(node) {
-    let raws = node.raws
-    let left =
-      typeof raws.left !== 'undefined'
-        ? raws.left
-        : this.raw(node, 'left', 'commentLeft')
-    let right =
-      typeof raws.right !== 'undefined'
-        ? raws.right
-        : this.raw(node, 'right', 'commentRight')
+    let left = this.raw(node, 'left', 'commentLeft')
+    let right = this.raw(node, 'right', 'commentRight')
     this.builder(escapeHTMLInCSS('/*' + left + node.text + right + '*/'), node)
   }
 
   decl(node, semicolon) {
     let raws = node.raws
-    let between =
-      typeof raws.between !== 'undefined'
-        ? raws.between
-        : this.raw(node, 'between', 'colon')
+    let between = this.raw(node, 'between', 'colon')
 
     let string = node.prop + between + this.rawValue(node, 'value')
 

--- a/test/stringifier.test.js
+++ b/test/stringifier.test.js
@@ -320,4 +320,39 @@ test('does not escape Document raws', () => {
   is(document.toString(), 'a {}</style>b {}</style>')
 })
 
+test('always calls raw to retrieve raws', () => {
+  class CustomStringifier extends Stringifier {
+    raw(node, own, detect) {
+      return `\nRAW(${node.type}, ${own}, ${detect})\n`
+    }
+  }
+  let root = new Root()
+  let rootRule = new Rule({ selector: 'a' })
+  let decl = new Declaration({ prop: 'color', value: 'black' })
+  decl.raws.before = 'BEFORE'
+  decl.raws.between = 'BETWEEN'
+  decl.raws.after = 'AFTER'
+  root.append(rootRule)
+  rootRule.append(decl)
+
+  let stringify = (node, builder) => {
+    let customStringifier = new CustomStringifier(builder)
+    customStringifier.stringify(node)
+  }
+  let result = root.toString(stringify)
+  is(result, [
+    '',
+    'RAW(rule, before, undefined)',
+    'a',
+    'RAW(rule, between, beforeOpen)',
+    '{',
+    'RAW(decl, before, undefined)',
+    'color',
+    'RAW(decl, between, colon)',
+    'black;',
+    'RAW(rule, after, undefined)',
+    '}'
+  ].join('\n'))
+})
+
 test.run()


### PR DESCRIPTION
Without this, it becomes impossible to override the stringifier with
your own raw computation, etc.
