### PR TITLE
Fix Node#rangeBy() ignoring index 0

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -298,7 +298,7 @@ class Node {
           line: opts.start.line,
           offset: sourceOffset(inputString, opts.start)
         }
-      } else if (opts.index) {
+      } else if (typeof opts.index === 'number') {
         start = this.positionInside(opts.index)
       }
 
@@ -310,7 +310,7 @@ class Node {
         }
       } else if (typeof opts.endIndex === 'number') {
         end = this.positionInside(opts.endIndex)
-      } else if (opts.index) {
+      } else if (typeof opts.index === 'number') {
         end = this.positionInside(opts.index + 1)
       }
     }

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -849,6 +849,16 @@ test('rangeBy() returns range for index and endIndex', () => {
   })
 })
 
+test('rangeBy() returns range for index 0', () => {
+  let css = parse('a {  one: X  }')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+  equal(one.rangeBy({ index: 0 }), {
+    end: { column: 7, line: 1, offset: 6 },
+    start: { column: 6, line: 1, offset: 5 }
+  })
+})
+
 test('rangeBy() returns range for index and endIndex when offsets are missing', () => {
   let css = parse('a {  one: X  }')
   let a = css.first as Rule

--- a/test/warning.test.ts
+++ b/test/warning.test.ts
@@ -121,6 +121,15 @@ test('gets range from index', () => {
   is(warning.endColumn, 4)
 })
 
+test('gets range from index 0', () => {
+  let root = parse('a b{}')
+  let warning = new Warning('text', { index: 0, node: root.first })
+  is(warning.line, 1)
+  is(warning.column, 1)
+  is(warning.endLine, 1)
+  is(warning.endColumn, 2)
+})
+
 test('gets range from index and endIndex', () => {
   let root = parse('a b{}')
   let warning = new Warning('text', { endIndex: 3, index: 2, node: root.first })


### PR DESCRIPTION
## What

`Node#rangeBy()` ignored an `index` of `0`, returning a range that spanned the entire node instead of a single character at offset `0`. This also affected `Node#error()` and `Node#warn()`, which build their positions through `rangeBy()`.

```js
const root = postcss.parse('a b{}')

// before this PR
root.first.rangeBy({ index: 0 })
// => { start: { column: 1, ... }, end: { column: 6, offset: 5 } }  // whole "a b{}"

// any other index works correctly
root.first.rangeBy({ index: 1 })
// => { start: { column: 2, ... }, end: { column: 3, ... } }  // single character
```

## Root cause

In `lib/node.js`, the end-of-range branch used a truthy check on `opts.index`:

```js
} else if (opts.index) {
  end = this.positionInside(opts.index + 1)
}
```

With `index === 0` the condition is falsy, so the branch is skipped and `end` keeps the node's end position, producing a whole-node range. The start branch had the same truthy check, though for the start position `positionInside(0)` happens to equal the node start, so only the end was observably wrong.

This is the same off-by-zero that was previously fixed for `endIndex` in #1932 (`else if (opts.endIndex)` → `typeof opts.endIndex === 'number'`); the two `opts.index` branches were left unchanged at that time.

## Fix

Switch both `opts.index` checks to a numeric type check, matching the existing `endIndex` handling:

```js
} else if (typeof opts.index === 'number') {
```

`index: 0` now yields a single-character range, consistent with every other index value.

## Tests

Added regression tests (both confirmed failing before the fix, passing after):

- `test/node.test.ts` — `rangeBy()` returns a single-character range for `index: 0`.
- `test/warning.test.ts` — a warning created with `index: 0` reports `endColumn` one past the start rather than the node end.

Full suite locally:

- `pnpm unit` — 654/654 passing
- `pnpm test:lint` — clean
- `pnpm test:types` — clean
