### PR TITLE
Fix explicit comment spacing on root insertion

### DIFF
--- a/lib/root.js
+++ b/lib/root.js
@@ -13,20 +13,20 @@ function hasExplicitBefore(node) {
   )
 }
 
-function isNewCommentWithExplicitBefore(node) {
+function isNewNodeWithExplicitBefore(node) {
   return (
     node &&
     typeof node === 'object' &&
     !node.parent &&
-    (node.type === 'comment' || node.text) &&
     hasExplicitBefore(node)
   )
 }
 
 function explicitBeforeValues(child) {
   if (!child || typeof child === 'string') return []
-  if (Array.isArray(child) || child.type === 'root') return []
-  return [isNewCommentWithExplicitBefore(child)]
+  if (Array.isArray(child)) return child.map(isNewNodeWithExplicitBefore)
+  if (child.type === 'root') return []
+  return [isNewNodeWithExplicitBefore(child)]
 }
 
 class Root extends Container {

--- a/lib/root.js
+++ b/lib/root.js
@@ -4,12 +4,13 @@ let Container = require('./container')
 
 let LazyResult, Processor
 
-function hasExplicitBefore(node) {
+function hasExplicitWhitespaceBefore(node) {
   return (
     node &&
     typeof node === 'object' &&
     node.raws &&
-    typeof node.raws.before !== 'undefined'
+    typeof node.raws.before !== 'undefined' &&
+    /^\s*$/.test(node.raws.before)
   )
 }
 
@@ -18,15 +19,19 @@ function isNewNodeWithExplicitBefore(node) {
     node &&
     typeof node === 'object' &&
     !node.parent &&
-    hasExplicitBefore(node)
+    hasExplicitWhitespaceBefore(node)
   )
 }
 
-function explicitBeforeValues(child) {
-  if (!child || typeof child === 'string') return []
-  if (Array.isArray(child)) return child.map(isNewNodeWithExplicitBefore)
-  if (child.type === 'root') return []
-  return [isNewNodeWithExplicitBefore(child)]
+function collectNewNodesWithExplicitBefore(child, values = new Set()) {
+  if (!child || typeof child === 'string') return values
+  if (Array.isArray(child)) {
+    for (let node of child) collectNewNodesWithExplicitBefore(node, values)
+    return values
+  }
+  if (child.type === 'root') return values
+  if (isNewNodeWithExplicitBefore(child)) values.add(child)
+  return values
 }
 
 class Root extends Container {
@@ -37,7 +42,7 @@ class Root extends Container {
   }
 
   normalize(child, sample, type) {
-    let explicitBefore = explicitBeforeValues(child)
+    let explicitBefore = collectNewNodesWithExplicitBefore(child)
     let nodes = super.normalize(child)
 
     if (sample) {
@@ -48,8 +53,8 @@ class Root extends Container {
           delete sample.raws.before
         }
       } else if (this.first !== sample) {
-        for (let [index, node] of nodes.entries()) {
-          if (explicitBefore[index]) continue
+        for (let node of nodes) {
+          if (explicitBefore.has(node)) continue
           node.raws.before = sample.raws.before
         }
       }

--- a/lib/root.js
+++ b/lib/root.js
@@ -13,10 +13,20 @@ function hasExplicitBefore(node) {
   )
 }
 
+function isNewCommentWithExplicitBefore(node) {
+  return (
+    node &&
+    typeof node === 'object' &&
+    !node.parent &&
+    (node.type === 'comment' || node.text) &&
+    hasExplicitBefore(node)
+  )
+}
+
 function explicitBeforeValues(child) {
   if (!child || typeof child === 'string') return []
   if (Array.isArray(child) || child.type === 'root') return []
-  return [(child.type === 'comment' || child.text) && hasExplicitBefore(child)]
+  return [isNewCommentWithExplicitBefore(child)]
 }
 
 class Root extends Container {

--- a/lib/root.js
+++ b/lib/root.js
@@ -3,6 +3,7 @@
 let Container = require('./container')
 
 let LazyResult, Processor
+let preserveBefore = Symbol('preserveBefore')
 
 function hasExplicitWhitespaceBefore(node) {
   return (
@@ -23,15 +24,20 @@ function isNewNodeWithExplicitBefore(node) {
   )
 }
 
-function collectNewNodesWithExplicitBefore(child, values = new Set()) {
-  if (!child || typeof child === 'string') return values
+function markNewNodesWithExplicitBefore(child) {
+  if (!child || typeof child === 'string') return
   if (Array.isArray(child)) {
-    for (let node of child) collectNewNodesWithExplicitBefore(node, values)
-    return values
+    for (let node of child) markNewNodesWithExplicitBefore(node)
+    return
   }
-  if (child.type === 'root') return values
-  if (isNewNodeWithExplicitBefore(child)) values.add(child)
-  return values
+  if (child.type === 'root') return
+  if (isNewNodeWithExplicitBefore(child)) child[preserveBefore] = true
+}
+
+function shouldPreserveExplicitBefore(node) {
+  let preserve = node[preserveBefore]
+  delete node[preserveBefore]
+  return preserve
 }
 
 class Root extends Container {
@@ -42,7 +48,10 @@ class Root extends Container {
   }
 
   normalize(child, sample, type) {
-    let explicitBefore = collectNewNodesWithExplicitBefore(child)
+    if (sample && type !== 'prepend' && this.first !== sample) {
+      markNewNodesWithExplicitBefore(child)
+    }
+
     let nodes = super.normalize(child)
 
     if (sample) {
@@ -54,7 +63,7 @@ class Root extends Container {
         }
       } else if (this.first !== sample) {
         for (let node of nodes) {
-          if (explicitBefore.has(node)) continue
+          if (shouldPreserveExplicitBefore(node)) continue
           node.raws.before = sample.raws.before
         }
       }

--- a/lib/root.js
+++ b/lib/root.js
@@ -4,6 +4,21 @@ let Container = require('./container')
 
 let LazyResult, Processor
 
+function hasExplicitBefore(node) {
+  return (
+    node &&
+    typeof node === 'object' &&
+    node.raws &&
+    typeof node.raws.before !== 'undefined'
+  )
+}
+
+function explicitBeforeValues(child) {
+  if (!child || typeof child === 'string') return []
+  if (Array.isArray(child) || child.type === 'root') return []
+  return [(child.type === 'comment' || child.text) && hasExplicitBefore(child)]
+}
+
 class Root extends Container {
   constructor(defaults) {
     super(defaults)
@@ -12,6 +27,7 @@ class Root extends Container {
   }
 
   normalize(child, sample, type) {
+    let explicitBefore = explicitBeforeValues(child)
     let nodes = super.normalize(child)
 
     if (sample) {
@@ -22,7 +38,8 @@ class Root extends Container {
           delete sample.raws.before
         }
       } else if (this.first !== sample) {
-        for (let node of nodes) {
+        for (let [index, node] of nodes.entries()) {
+          if (explicitBefore[index]) continue
           node.raws.before = sample.raws.before
         }
       }

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -855,6 +855,18 @@ test('normalize() preserves explicit before for root insertions', () => {
   is(node.raws.before, '')
 })
 
+test('normalize() updates before for moved root comments', () => {
+  let source = parse('a {}\n/* moved */')
+  let target = parse('b {}\n\n/* old */')
+  let moved = source.last as Comment
+  let comment = target.last as Comment
+
+  comment.before(moved)
+
+  is(target.nodes[1], moved)
+  is(moved.raws.before, '\n\n')
+})
+
 test('forces Declaration#value to be string', () => {
   let rule = parse('a { a: 1; b: 2 }').first as Rule
   // @ts-expect-error Testing invalid API

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'uvu'
 import { equal, is, match, throws, type } from 'uvu/assert'
 
-import { AtRule, Declaration, parse, Root, Rule } from '../lib/postcss.js'
+import { AtRule, Comment, Declaration, parse, Root, Rule } from '../lib/postcss.js'
 
 let example =
   'a { a: 1; b: 2 }' +
@@ -839,6 +839,20 @@ test('normalize() does not normalize new children with exists before', () => {
   let rule = parse('a { a: 1; b: 2 }').first as Rule
   rule.append({ prop: 'c', raws: { before: '\n ' }, value: '3' })
   is(rule.toString(), 'a { a: 1; b: 2;\n c: 3 }')
+})
+
+test('normalize() preserves explicit before for root insertions', () => {
+  let root = parse('a {}\n\n/* old */')
+  let comment = root.last as Comment
+  let node = new Comment({
+    raws: { before: '', inline: true, left: ' ', right: '' },
+    text: 'New Comment'
+  })
+
+  comment.before(node)
+
+  is(root.nodes[1], node)
+  is(node.raws.before, '')
 })
 
 test('forces Declaration#value to be string', () => {

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -841,18 +841,27 @@ test('normalize() does not normalize new children with exists before', () => {
   is(rule.toString(), 'a { a: 1; b: 2;\n c: 3 }')
 })
 
-test('normalize() preserves explicit before for root insertions', () => {
+test('normalize() preserves explicit before for new root nodes', () => {
   let root = parse('a {}\n\n/* old */')
   let comment = root.last as Comment
-  let node = new Comment({
+  let newComment = new Comment({
     raws: { before: '', inline: true, left: ' ', right: '' },
     text: 'New Comment'
   })
 
-  comment.before(node)
+  comment.before(newComment)
 
-  is(root.nodes[1], node)
-  is(node.raws.before, '')
+  is(root.nodes[1], newComment)
+  is(newComment.raws.before, '')
+
+  root = parse('a {}\n\nb {}')
+  let rule = root.last as Rule
+  let newRule = new Rule({ raws: { before: '' }, selector: 'em' })
+
+  rule.before(newRule)
+
+  is(root.nodes[1], newRule)
+  is(newRule.raws.before, '')
 })
 
 test('normalize() updates before for moved root comments', () => {


### PR DESCRIPTION
## Summary

Fixes #2017.

Root-level insertion was overwriting a newly supplied node's explicit whitespace-only `raws.before` with spacing from the following sample node. This preserves intentionally supplied spacing for new nodes while leaving parsed, moved, root, string, and non-whitespace raw values normalized as before.

## Motivation

The linked issue does not name a public plugin. It shows direct PostCSS API usage that a plugin or transform can use: create a new comment node, set explicit raw spacing, and insert it before an existing root-level loud comment.

Input SCSS:

```scss
@mixin x {
    margin: 10px;
}

/*
* loud
* comment
*
*/

.a {
    @include x;
}
```

Insertion code from the issue:

```js
const node = postcss.comment({
  text: 'New Comment',
  raws: { inline: true, right: '', left: ' ', before: '' },
})

comment.before(node)
```

Before insertion, the created node has the intended `raws.before: ''`. After `comment.before(node)`, the current behavior overwrites that explicit value with the existing root comment's spacing:

```js
{
  raws: {
    inline: true,
    right: '',
    left: ' ',
    before: '\n\n', // expected ''
  },
  text: 'New Comment',
  type: 'comment',
}
```

That means the inserted comment inherits the blank-line spacing from the following loud comment. In CSS terms, the current output shape adds the old root-comment spacing before the new generated comment:

```scss
@mixin x {
    margin: 10px;
}

// New Comment

/*
* loud
* comment
*
*/
```

The expected output shape keeps the caller's explicit `before: ''`, so the inserted comment is placed without inheriting the two-newline prefix from the existing comment:

```scss
@mixin x {
    margin: 10px;
}

// New Comment
/*
* loud
* comment
*
*/
```

Setting `raws.before` in user code is not enough today because the insertion normalization overwrites it after the node is inserted.

The ecosystem safety comes from the scoped condition in this change: only newly supplied nodes without a parent and with whitespace-only explicit `raws.before` keep that value. Existing or moved nodes still get normalized from the target sample, and non-whitespace `raws.before` values such as embedded `</style>` content still go through the old normalization path so stringifier escaping behavior is preserved.

## Changes

- Preserve whitespace-only explicit `raws.before` for newly supplied root nodes during root normalization.
- Keep existing normalization for moved nodes, strings, roots, and non-whitespace `raws.before` values.
- Add regression coverage for new comments/rules preserving explicit spacing and moved comments updating to target spacing.

## Testing

- `pnpm exec uvu -r ts-node/register/transpile-only test "stringifier\\.test\\.js$"`
- `pnpm exec uvu -r ts-node/register/transpile-only test "container\\.test\\.ts$"`
- `pnpm exec uvu -r ts-node/register/transpile-only test "(container|root|stringifier|visitor)\\.test\\.(ts|js)$"`
- `pnpm test:lint && pnpm test:types`
- `git diff --check`
- `pnpm unit` (all non-color-related tests passed; two existing `css-syntax-error` color-output assertions fail in this environment because `FORCE_COLOR` is set while `NO_COLOR=1`.)

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.
