### PR TITLE
Don't clone root-less child nodes in container constructor

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -73,7 +73,10 @@ class Node {
       if (name === 'nodes') {
         this.nodes = []
         for (let node of defaults[name]) {
-          if (typeof node.clone === 'function') {
+          // Clone only nodes that already belong to another tree, so passing a
+          // freshly created (parent-less) node adopts that instance instead of
+          // a copy and keeps the caller's reference usable. See #1987.
+          if (typeof node.clone === 'function' && node.parent) {
             this.append(node.clone())
           } else {
             this.append(node)

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -872,6 +872,20 @@ test('allows to clone nodes', () => {
   is(root2.toString(), 'a { color: black; z-index: 1 } b {}')
 })
 
+test('adopts root-less nodes in constructor instead of cloning them', () => {
+  let decl = new Declaration({ prop: 'foo', value: 'bar' })
+  let atRule = new AtRule({ name: 'foo', nodes: [decl] })
+
+  // The passed-in instance itself is adopted (its parent is updated), so the
+  // caller's reference stays usable rather than being silently cloned (#1987).
+  equal(decl.parent, atRule)
+  is(atRule.first, decl)
+
+  decl.before(new Declaration({ prop: 'baz', value: 'qux' }))
+  equal(atRule.nodes.length, 2)
+  is(atRule.last, decl)
+})
+
 test('container.nodes can be sorted', () => {
   let root = parse('@b; @c; @a;')
   let b = root.nodes[0]


### PR DESCRIPTION
Closes #1987.

## Problem

Passing a freshly created (parent-less) node as a child in a container constructor clones it, so the caller's original reference never gets a `parent` and later operations on it throw:

```js
const decl = postcss.decl({ prop: 'foo', value: 'bar' })
postcss.atRule({ name: 'foo', nodes: [decl] })
decl.before(postcss.comment({ text: 'hello' }))
// TypeError: Cannot read properties of undefined (reading 'insertBefore')
```

The constructor unconditionally clones any real `Node` child:

```js
if (typeof node.clone === 'function') {
  this.append(node.clone())
} else {
  this.append(node)
}
```

That clone was added in 9d19bce only to keep the **source** tree intact when moving nodes between two roots — but it also fires for brand-new, parent-less nodes that aren't part of any tree, where there's nothing to protect.

## Fix

As you suggested on the issue, only clone when the node already belongs to another tree (`node.parent` is set); otherwise adopt the instance directly so `append()` sets its `parent`:

```js
if (typeof node.clone === 'function' && node.parent) {
  this.append(node.clone())
} else {
  this.append(node)
}
```

Nodes that already have a parent (e.g. `new Root({ nodes: root1.nodes })`) are still cloned, so the move-between-trees behavior from 9d19bce is unchanged.

## Tests

Adds a regression test (`adopts root-less nodes in constructor instead of cloning them`) that builds a container from a parent-less node and asserts the original instance is adopted (`decl.parent` is the new container, `container.first === decl`) and that operating on the original reference no longer throws. It fails on the current code and passes with this change. The two existing tests from 9d19bce (`updates parent in overrides.nodes in constructor`, `allows to clone nodes`) still pass — the full unit suite (653 tests) is green and ESLint is clean.
