### PR TITLE
fix(node): always compute offset in positionBy() like rangeBy()

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -206,14 +206,18 @@ class Node {
   }
 
   positionBy(opts = {}) {
-    let pos = this.source.start
+    let inputString =
+      'document' in this.source.input
+        ? this.source.input.document
+        : this.source.input.css
+    let pos = {
+      column: this.source.start.column,
+      line: this.source.start.line,
+      offset: sourceOffset(inputString, this.source.start)
+    }
     if (opts.index) {
       pos = this.positionInside(opts.index)
     } else if (opts.word) {
-      let inputString =
-        'document' in this.source.input
-          ? this.source.input.document
-          : this.source.input.css
       let stringRepresentation = inputString.slice(
         sourceOffset(inputString, this.source.start),
         sourceOffset(inputString, this.source.end)

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -523,6 +523,17 @@ test('positionBy() returns position for word after AST mutations', () => {
   equal(two.positionBy({ word: 'two' }), { column: 2, line: 3, offset: 14 })
 })
 
+test('positionBy() returns position when offset is missing', () => {
+  let css = parse('a {  one: X  }')
+  let a = css.first as Rule
+  let one = a.first as Declaration
+
+  // @ts-expect-error Testing non-standard AST
+  if (one.source?.start) delete one.source.start.offset
+
+  equal(one.positionBy(), { column: 6, line: 1, offset: 5 })
+})
+
 test('positionBy() returns position for index', () => {
   let css = parse('a {  one: X  }')
   let a = css.first as Rule


### PR DESCRIPTION
Mirrors #2033 to the one sibling it left out.

#2033 (issue #2029) normalized `rangeBy()` and `positionInside()` to always compute `offset` via `sourceOffset()`, so they return a complete `Position`. `positionBy()`'s default branch was left returning `this.source.start` as-is:

`lib/node.js` (default branch of `positionBy`)
```js
position = this.source.start
```

For custom syntaxes whose `source.start` carries no `offset` (e.g. postcss-html), this returns a position missing `offset`, which violates the `Position` type that declares `offset: number` as required. `rangeBy()` two lines away already handles exactly this via `sourceOffset()`; `positionBy()` is the unmirrored twin.

Fix mirrors `rangeBy()` precisely (compute `offset` through `sourceOffset()` on the default branch).

Verification: added a regression test that fails on baseline (1/90 fail) and passes with the fix (90/90); the full existing suite is 89/89 on both baseline and patched, so zero regression; `tsc --noEmit` is clean. Branch is based on the current `main` tip.