### PR TITLE
Preserve node raws when rehydrating a JSON AST

### DIFF
--- a/lib/fromJSON.js
+++ b/lib/fromJSON.js
@@ -25,8 +25,13 @@ function fromJSON(json, inputs) {
       inputs.push(inputHydrated)
     }
   }
+  // Rehydrate children separately and attach them after construction.
+  // Passing them through the container constructor would re-run insertion
+  // spacing normalization and overwrite each child's own `raws.before`.
+  let nodes
   if (defaults.nodes) {
-    defaults.nodes = json.nodes.map(n => fromJSON(n, inputs))
+    nodes = json.nodes.map(n => fromJSON(n, inputs))
+    delete defaults.nodes
   }
   if (defaults.source) {
     let { inputId, ...source } = defaults.source
@@ -35,19 +40,28 @@ function fromJSON(json, inputs) {
       defaults.source.input = inputs[inputId]
     }
   }
+
+  let node
   if (defaults.type === 'root') {
-    return new Root(defaults)
+    node = new Root(defaults)
   } else if (defaults.type === 'decl') {
-    return new Declaration(defaults)
+    node = new Declaration(defaults)
   } else if (defaults.type === 'rule') {
-    return new Rule(defaults)
+    node = new Rule(defaults)
   } else if (defaults.type === 'comment') {
-    return new Comment(defaults)
+    node = new Comment(defaults)
   } else if (defaults.type === 'atrule') {
-    return new AtRule(defaults)
+    node = new AtRule(defaults)
   } else {
     throw new Error('Unknown node type: ' + json.type)
   }
+
+  if (nodes) {
+    node.nodes = nodes
+    for (let child of nodes) child.parent = node
+  }
+
+  return node
 }
 
 module.exports = fromJSON

--- a/test/fromJSON.test.ts
+++ b/test/fromJSON.test.ts
@@ -40,6 +40,19 @@ test('rehydrates a JSON AST', () => {
   )
 })
 
+test('preserves node raws when rehydrating a JSON AST', () => {
+  let css = 'a {}\nb {}\n\nc {}\n'
+  let root = postcss.parse(css)
+
+  let rehydrated = postcss.fromJSON(
+    JSON.parse(JSON.stringify(root.toJSON()))
+  ) as Root
+
+  is(rehydrated.toString(), css)
+  is(rehydrated.nodes[1].raws.before, '\n')
+  is(rehydrated.nodes[2].raws.before, '\n\n')
+})
+
 test('rehydrates an array of Nodes via JSON.stringify', () => {
   let root = postcss.parse('.cls { color: orange; }')
 


### PR DESCRIPTION
`fromJSON(root.toJSON())` isn't lossless when a stylesheet has uneven spacing between its top-level nodes:

```js
let css = 'a {}\nb {}\n\nc {}\n'
let root = postcss.parse(css)
postcss.fromJSON(JSON.parse(JSON.stringify(root.toJSON()))).toString()
// => 'a {}\nb {}\nc {}\n'   the blank line before `c` is gone
```

`toJSON()` serializes every `raws.before` correctly — the loss happens on the way back. `fromJSON` builds the child nodes and then passes them to the container constructor, which appends them; for root children that re-runs the insertion spacing logic in `Root.normalize`, overwriting each node's own `raws.before` with the previous sibling's. So every top-level node after the first inherits the first one's spacing.

It matters because round-tripping through JSON is meant to restore an AST exactly (e.g. caching a parsed AST), so a rehydrated root should stringify to the same CSS as the original.

I rehydrate the children and attach them directly instead of routing them through `append`, leaving their raws untouched. Runtime `append`/insertion behavior is unchanged. Found it round-tripping the postcss-parser-tests fixtures; added a regression test and `pnpm test` is green.
