### PR TITLE
Fix `Input#origin()` mixing null and undefined for unmapped end position

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -211,10 +211,16 @@ class Input {
 
     let to
     if (typeof endLine === 'number') {
-      to = consumer.originalPositionFor({
+      let toPosition = consumer.originalPositionFor({
         column: endColumn - 1,
         line: endLine
       })
+      // The source map may not have a mapping that covers the end position
+      // (`originalPositionFor()` then returns `null` for `line`/`column`
+      // instead of omitting them). Treat that the same as not requesting
+      // an end position at all, so `endLine`/`endColumn` stay a consistent
+      // `undefined` pair instead of a mix of `null` and a bogus number.
+      if (toPosition.source) to = toPosition
     }
 
     let fromUrl

--- a/test/input.test.ts
+++ b/test/input.test.ts
@@ -105,4 +105,32 @@ test('origin() returns source position with source map', () => {
   })
 })
 
+test('origin() does not mix undefined and null when end position is unmapped', () => {
+  // @ts-expect-error source-map-js accepts null, but it's not in the types
+  let node = new SourceNode(null, null, null, [
+    new SourceNode(1, 0, 'a.css', 'a'),
+    new SourceNode(1, 1, 'a.css', ' '),
+    new SourceNode(1, 2, 'a.css', '{'),
+    new SourceNode(1, 3, 'a.css', '}')
+  ])
+  let from = join(__dirname, 'all.css')
+  let codeWithSourceMap = node.toStringWithSourceMap({ file: from })
+  let input = new Input(codeWithSourceMap.code, {
+    from,
+    map: { prev: codeWithSourceMap.map }
+  })
+
+  // The start position (1, 1) is mapped, but the requested end position
+  // (99, 1) is far beyond anything the source map covers, so
+  // `originalPositionFor()` cannot resolve it.
+  equal(input.origin(1, 1, 99, 1), {
+    column: 1,
+    endColumn: undefined,
+    endLine: undefined,
+    file: join(__dirname, 'a.css'),
+    line: 1,
+    url: urlOf('a.css')
+  })
+})
+
 test.run()


### PR DESCRIPTION
When the end position passed to `origin()` isn't covered by the source map, `originalPositionFor()` comes back with `line`/`column` set to `null` instead of just not having a mapping. `endLine` ends up `null` in that case, but `endColumn` was being built as `to && to.column + 1`, which because of precedence is actually `to && (to.column + 1)`, so `null` silently becomes `1`. You can end up with something like `{ endColumn: 1, endLine: null }`, which is inconsistent with how the rest of the function treats an unresolved position (both stay `undefined`).

Looks like #2036 fixed the off-by-one for the case where the end position does resolve, but didn't account for it not resolving at all.

Guarded `to` the same way `from` already is a few lines above, and added a test that reproduces it with a source map that doesn't cover the requested end line.