### PR TITLE
docs: fix invalid JS in writing-a-plugin examples

### DIFF
--- a/docs/writing-a-plugin.md
+++ b/docs/writing-a-plugin.md
@@ -157,7 +157,7 @@ you can use quick search:
     Declaration: {
       color: decl => {
         // All `color` declarations
-      }
+      },
       '*': decl => {
         // All declarations
       }
@@ -316,7 +316,7 @@ Second argument also have `result` object to add warnings:
 
 ```js
     Declaration: {
-      bad: (decl, { result }) {
+      bad: (decl, { result }) => {
         decl.warn(result, 'Deprecated property bad')
       }
     }
@@ -328,7 +328,7 @@ when this file changes:
 
 ```js
     AtRule: {
-      import: (atRule, { result }) {
+      import: (atRule, { result }) => {
         const importedFile = parseImport(atRule)
         result.messages.push({
           type: 'dependency',


### PR DESCRIPTION
Three snippets in `docs/writing-a-plugin.md` don't parse as JavaScript:

1. In the `Declaration` visitor example, a comma is missing between the `color` and `'*'` handlers.
2. Two examples use `name: (args) {` — property syntax mixed with a method body; they need an arrow (`=> {`).

All three now copy-paste cleanly.

Found while running [docrot](https://github.com/getdocrot/docrot), a small checker that verifies docs examples and links against the code. Happy to adjust anything.