### PR TITLE
Fix non-closed `<div align="center">` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ PostCSS needs your support. We are accepting donations
        alt="Sponsored by Atlas Cloud" width="300" height="48">
   </picture>
 </a>
+</div>
 
 <i><a href="https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=postcss">Atlas Cloud</a> is a full-modal AI inference platform that gives developers a single AI API to access video generation, image generation, and LLM APIs. Instead of managing multiple vendor integrations, you connect once and get unified access to 300+ curated models across all modalities.
 


### PR DESCRIPTION
Fixes the problem that all elements after `<div align="center">` are centered in `README.md`.

Ref: <https://github.com/postcss/postcss/blob/1bf9076867e70f5a01776aebebee5aacbf9771ce/README.md>

Screenshot:

<img width="908" height="798" alt="image" src="https://github.com/user-attachments/assets/95bccdcb-5723-4ab7-8e6f-5e5dc743855c" />
