### PR TITLE
Keep explicitly set raws.before when inserting nodes into root

### DIFF
--- a/lib/root.js
+++ b/lib/root.js
@@ -12,6 +12,19 @@ class Root extends Container {
   }
 
   normalize(child, sample, type) {
+    let keepBefore = new Set()
+    for (let node of Array.isArray(child) ? child : [child]) {
+      if (
+        node &&
+        typeof node === 'object' &&
+        !node.parent &&
+        node.raws &&
+        typeof node.raws.before !== 'undefined'
+      ) {
+        keepBefore.add(node.raws)
+      }
+    }
+
     let nodes = super.normalize(child)
 
     if (sample) {
@@ -23,7 +36,9 @@ class Root extends Container {
         }
       } else if (this.first !== sample) {
         for (let node of nodes) {
-          node.raws.before = sample.raws.before
+          if (!keepBefore.has(node.raws)) {
+            node.raws.before = sample.raws.before
+          }
         }
       }
     }

--- a/test/root.test.ts
+++ b/test/root.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'uvu'
 import { is, match, type } from 'uvu/assert'
 
-import { parse, Result } from '../lib/postcss.js'
+import postcss, { parse, Result } from '../lib/postcss.js'
 
 test('prepend() fixes spaces on insert before first', () => {
   let css = parse('a {} b {}')
@@ -42,6 +42,23 @@ test('fixes spaces on removing first rule', () => {
   if (!css.first) throw new Error('No nodes were parsed')
   css.first.remove()
   is(css.toString(), 'b{}\n')
+})
+
+test('keeps explicitly set raws.before on inserted node', () => {
+  let css = parse('/*a*/\n\n/*b*/')
+  let node = postcss.comment({ raws: { before: '' }, text: 'new' })
+  if (!css.nodes[1]) throw new Error('No nodes were parsed')
+  css.nodes[1].before(node)
+  is(node.raws.before, '')
+  is(css.toString(), '/*a*//*new*/\n\n/*b*/')
+})
+
+test('updates raws.before on node moved from another root', () => {
+  let css1 = parse('a{}\nb{}')
+  let css2 = parse('em{}\n\n\nstrong{}')
+  if (!css1.nodes[1] || !css2.nodes[1]) throw new Error('No nodes were parsed')
+  css2.nodes[1].before(css1.nodes[1])
+  is(css2.toString(), 'em{}\n\n\nb{}\n\n\nstrong{}')
 })
 
 test('keeps spaces on moving root', () => {

--- a/test/stringifier.test.js
+++ b/test/stringifier.test.js
@@ -301,7 +301,7 @@ test('escapes </style & <!-- with \\3c CSS escape', () => {
     '\\3c /style> {}\n' +
       '@media \\3c style>;\n' +
       '/* \\3c /style>\\3c !--\\3c style> */\n' +
-      'a {\n' +
+      '\\3c /style>a {\n' +
       '    color: \\3c /style>' +
       '\\3c /style>}'
   )


### PR DESCRIPTION
Fixes #2017

`Root.normalize` unconditionally copies `sample.raws.before` onto every inserted node, so a node created with an explicit `raws.before` (like the loud comment in the issue, built with `postcss.comment({ text, raws: { before: '' } })`) loses it on insertion. `Container.normalize` already treats `raws.before` as user-owned and only fills it when missing — this brings the root-level path in line with that, which is also what you suggested in the issue thread.

The rule I went with is type-agnostic: if an incoming node is detached (no parent) and has `raws.before` set, that value is kept. Nodes that are attached somewhere else at insertion time are still renormalized to the target root's spacing, so moving nodes between roots behaves exactly as before — there's a guard test for that, and the existing "keeps spaces on moving root" test still passes.

One existing test needed its expected string updated: the `</style>` escape test sets `rule.raws.before = '\n</style>'` on a detached rule, but the old overwrite silently discarded that value before the stringifier ever saw it, so the escape of `before` was never actually exercised. With the fix the explicit `before` survives and renders escaped (`\3c /style>`), which as far as I can tell is what that test meant to check all along, since it sets both `before` and `after`.

Full suite passes (670/670), plus eslint and check-dts.
