### PR TITLE
Rebuild nodes from another PostCSS copy in Warning

### DIFF
--- a/lib/warning.js
+++ b/lib/warning.js
@@ -1,11 +1,21 @@
 'use strict'
 
+let Container = require('./container')
+let { my } = require('./symbols')
+
 class Warning {
   constructor(text, opts = {}) {
     this.type = 'warning'
     this.text = text
 
     if (opts.node && opts.node.source) {
+      if (!opts.node[my]) {
+        // The node comes from another PostCSS copy in node_modules, so it does
+        // not have this copy’s methods. Container#normalize() rebuilds such
+        // nodes on insert, but a node passed straight to Result#warn() never
+        // goes through it.
+        Container.rebuild(opts.node)
+      }
       let range = opts.node.rangeBy(opts)
       this.line = range.start.line
       this.column = range.start.column

--- a/test/warning.test.ts
+++ b/test/warning.test.ts
@@ -2,7 +2,7 @@ import { resolve } from 'path'
 import { test } from 'uvu'
 import { is, type } from 'uvu/assert'
 
-import { decl, parse, Warning } from '../lib/postcss.js'
+import { decl, Declaration, parse, Rule, Warning } from '../lib/postcss.js'
 
 test('outputs simple warning', () => {
   let warning = new Warning('text')
@@ -192,6 +192,27 @@ test('always returns valid ranges', () => {
   is(warning.column, 3)
   is(warning.endLine, 1)
   is(warning.endColumn, 4)
+})
+
+test('takes position from node of another PostCSS copy', () => {
+  let root = parse('a { color: black }')
+  let rule = root.first as Rule
+  let parsed = rule.first as Declaration
+  // A node from another PostCSS version in node_modules has no methods
+  // of this copy, so it is a plain object here.
+  let foreign = {
+    prop: parsed.prop,
+    raws: { ...parsed.raws },
+    source: parsed.source,
+    type: 'decl',
+    value: parsed.value
+  } as unknown as Declaration
+
+  let warning = new Warning('text', { node: foreign })
+  is(warning.line, 1)
+  is(warning.column, 5)
+  is(warning.endLine, 1)
+  is(warning.endColumn, 17)
 })
 
 test.run()


### PR DESCRIPTION
Fixes #1685

You asked on the issue why the broken-AST protection doesn't fire here — I think I found it. `Container.rebuild()` is only ever called from `Container#normalize()`, i.e. when a node gets *inserted* into a container. A node that a plugin passes straight to `result.warn({ node })` never goes through normalize, so it's never rebuilt and still has the other copy's prototype. 8.3 had no `rangeBy`, it landed in 8.4, which is why the break starts exactly there.

So this applies the same protection at that second entry point: if the node doesn't carry this copy's `my` symbol, rebuild it before calling `rangeBy`. The `my` check works cross-copy because the symbol is module-scoped, so a foreign node never has ours.

Reproduced it on 8.5.19 first — a plain node with a `source` but no `rangeBy` gives the reporter's exact `TypeError: opts.node.rangeBy is not a function`, and after rebuild the warning resolves to the right position. Added a test for it in test/warning.test.ts; it throws that TypeError on main and passes here. Full suite (671), eslint and check-dts are green. No require cycle — container's deps never reach warning.js.

Two things worth your call:
- You've told people on this thread to dedupe node_modules, and that's still the right advice. This just means they get a correct warning instead of a crash while they sort it out. If you'd rather it threw a clear "PostCSS version mismatch" error instead of silently recovering, happy to change it.
- `rebuild` sets the prototype on an object owned by another copy of the library. `normalize()` already does exactly that today, so it isn't a new hazard, but it is worth being aware of.
