### PR TITLE
Fix missing space when AtRule#params is set after parsing

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -6,6 +6,10 @@
 const STYLE_TAG = /(<)(\/?style\b)/gi
 const COMMENT_OPEN = /(<)(!--)/g
 
+// Characters that end an at-rule name, mirroring RE_AT_END in the tokenizer.
+// Params starting with anything else need a space to stay separate tokens.
+const AT_NAME_END = /[\t\n\f\r "#'()/;[\\\]{}]/
+
 function escapeHTMLInCSS(str) {
   if (typeof str !== 'string') return str
   if (!str.includes('<')) return str
@@ -34,14 +38,15 @@ function capitalize(str) {
 function atruleStart(str, node) {
   let name = '@' + node.name
   let params = node.params ? str.rawValue(node, 'params') : ''
+  let afterName = node.raws.afterName
 
-  if (typeof node.raws.afterName !== 'undefined') {
-    name += node.raws.afterName
-  } else if (params) {
-    name += ' '
+  if (typeof afterName === 'undefined') {
+    afterName = params ? ' ' : ''
+  } else if (afterName === '' && params && !AT_NAME_END.test(params[0])) {
+    afterName = ' '
   }
 
-  return name + params
+  return name + afterName + params
 }
 
 function pushBody(str, stack, node) {

--- a/test/stringifier.test.js
+++ b/test/stringifier.test.js
@@ -358,6 +358,26 @@ test('always calls raw to retrieve raws', () => {
   )
 })
 
+test('adds space before params set on an at-rule parsed without them', () => {
+  let root = parse('@layer{a{color:black}}')
+  root.first.params = 'utilities'
+  is(root.toString(), '@layer utilities{a{color:black}}')
+
+  let media = parse('@media;').first
+  media.params = 'print'
+  is(media.toString(), '@media print')
+})
+
+test('keeps params glued to at-rule name when CSS allows it', () => {
+  let root = parse('@media(min-width:0){}')
+  root.first.params = '(min-width:1px)'
+  is(root.toString(), '@media(min-width:1px){}')
+
+  let imported = parse('@import"a.css"').first
+  imported.params = '"b.css"'
+  is(imported.toString(), '@import"b.css"')
+})
+
 test('supports subclasses with overridden traversal methods', () => {
   class CustomStringifier extends Stringifier {
     rule(node) {


### PR DESCRIPTION
Setting `AtRule#params` on an at-rule that was parsed without params glues the params onto the name:

```js
let root = postcss.parse('@layer{a{color:black}}')
root.first.params = 'utilities'
root.toString() //=> '@layerutilities{a{color:black}}'
```

`@layerutilities` is a single at-word, so the output no longer parses back to the at-rule that produced it. Same for `@media{}`, `@scope{}`, `@font-face{}` — anything written without params.

`atruleStart()` already has a fallback that inserts the space when `raws.afterName` is missing, but the parser sets `raws.afterName = ''` explicitly for a params-less at-rule, so the fallback never gets a chance to run.

I still prefer the raw when it's there, and only fall back to a space when the params would otherwise merge into the at-rule name token. `@media(min-width:0)` and `@import"a.css"` stay byte-identical: `(` and `"` end the at-word on their own, and those delimiters are the only way the parser can produce an empty `afterName` together with non-empty params.

Found this fuzzing mutation round-trips over the postcss-parser-tests fixtures — across ~10k parse → set params → re-parse cases this was the only invariant that broke (100 distinct failures before, 0 after). Added tests for both directions; `pnpm test` is green.
