### PR TITLE
Fix mismatched JSDoc comments on Position

### DIFF
--- a/lib/node.d.ts
+++ b/lib/node.d.ts
@@ -31,12 +31,12 @@ declare namespace Node {
 
   export interface Position {
     /**
-     * Source line in file. In contrast to `offset` it starts from 1.
+     * Source column in file. It starts from 1.
      */
     column: number
 
     /**
-     * Source column in file.
+     * Source line in file. It starts from 1.
      */
     line: number
 


### PR DESCRIPTION
Also, clarify that `column` is 1-based, like `line`.

I noticed this while looking at the [API docs](https://postcss.org/api/#position).