### PR TITLE
Fix childless at-rule losing its semicolon before a comment

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -60,10 +60,23 @@ function pushBody(str, stack, node) {
   let semicolon = str.raw(node, 'semicolon')
   let isDocument = node.type === 'document'
   for (let i = nodes.length - 1; i >= 0; i--) {
+    let child = nodes[i]
+    let childSemicolon = last !== i || semicolon
+    // A childless at-rule that still has following siblings must be
+    // terminated. Without the semicolon those trailing comments are folded
+    // into the at-rule's prelude and disappear when the output is re-parsed.
+    if (
+      !childSemicolon &&
+      i < nodes.length - 1 &&
+      child.type === 'atrule' &&
+      !child.nodes
+    ) {
+      childSemicolon = true
+    }
     stack.push({
       document: isDocument,
-      node: nodes[i],
-      semicolon: last !== i || semicolon
+      node: child,
+      semicolon: childSemicolon
     })
   }
 }

--- a/test/stringifier.test.js
+++ b/test/stringifier.test.js
@@ -3,6 +3,7 @@ let { is } = require('uvu/assert')
 
 let {
   AtRule,
+  Comment,
   Declaration,
   Document,
   Node,
@@ -155,6 +156,36 @@ test('clones indent by before and after', () => {
 test('clones semicolon only from rules with children', () => {
   let css = parse('a{}b{one:1;}')
   is(str.raw(css.first, 'semicolon'), true)
+})
+
+test('terminates childless at-rule followed by a comment', () => {
+  let css = parse('a {}\n/* comment */')
+  css.insertBefore(css.last, new AtRule({ name: 'import', params: '"x.css"' }))
+
+  is(css.toString(), 'a {}\n@import "x.css";\n/* comment */')
+  is(
+    parse(css.toString())
+      .nodes.map(i => i.type)
+      .join(','),
+    'rule,atrule,comment'
+  )
+})
+
+test('terminates nested childless at-rule followed by a comment', () => {
+  let css = parse('@media screen {\n  a {}\n}')
+  css.first.append(new AtRule({ name: 'import', params: '"y.css"' }))
+  css.first.append(new Comment({ text: 'note' }))
+
+  is(
+    css.toString(),
+    '@media screen {\n  a {}\n  @import "y.css";\n  /* note */\n}'
+  )
+  is(
+    parse(css.toString())
+      .first.nodes.map(i => i.type)
+      .join(','),
+    'rule,atrule,comment'
+  )
 })
 
 test('clones only spaces in before', () => {


### PR DESCRIPTION
While building a tree I put a childless at-rule (for example `@import`) just before a comment node using `append()`/`insertBefore()`, and the comment vanished after a stringify + re-parse round-trip.

The stringifier treats the last non-comment child as the one whose semicolon is optional, ignoring any trailing comments. That is fine for a declaration, but a childless at-rule reads everything up to the next `;`/`{` as its prelude, so without the semicolon the following comments get folded into the at-rule and are dropped on re-parse.

```js
let root = postcss.parse('a {}\n/* keep me */')
root.insertBefore(root.last, new AtRule({ name: 'import', params: '"x.css"' }))
root.toString()
// before: 'a {}\n@import "x.css"\n/* keep me */'  -> comment lost on re-parse
// after:  'a {}\n@import "x.css";\n/* keep me */'
```

The fix emits the semicolon when a childless at-rule still has following siblings, so the output round-trips. A genuinely last at-rule with nothing after it is unchanged.

Tested with two new unit tests (root and nested cases) and the full `pnpm test` suite.