### PR TITLE
Fix custom property losing its semicolon before a comment

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -62,14 +62,15 @@ function pushBody(str, stack, node) {
   for (let i = nodes.length - 1; i >= 0; i--) {
     let child = nodes[i]
     let childSemicolon = last !== i || semicolon
-    // A childless at-rule that still has following siblings must be
-    // terminated. Without the semicolon those trailing comments are folded
-    // into the at-rule's prelude and disappear when the output is re-parsed.
+    // A childless at-rule or a custom property declaration that still has
+    // following siblings must be terminated. Without the semicolon those
+    // trailing comments are folded into the at-rule's prelude or the custom
+    // property's value and disappear when the output is re-parsed.
     if (
       !childSemicolon &&
       i < nodes.length - 1 &&
-      child.type === 'atrule' &&
-      !child.nodes
+      ((child.type === 'atrule' && !child.nodes) ||
+        (child.type === 'decl' && child.prop.startsWith('--')))
     ) {
       childSemicolon = true
     }

--- a/test/stringifier.test.js
+++ b/test/stringifier.test.js
@@ -188,6 +188,32 @@ test('terminates nested childless at-rule followed by a comment', () => {
   )
 })
 
+test('terminates custom property followed by a comment', () => {
+  let css = parse('a{--x:red}')
+  css.first.append(new Comment({ text: 'note' }))
+
+  is(css.toString(), 'a{--x:red;/* note */}')
+  is(
+    parse(css.toString())
+      .first.nodes.map(i => i.type)
+      .join(','),
+    'decl,comment'
+  )
+})
+
+test('terminates custom property with !important before a comment', () => {
+  let css = parse('a{--x:red !important}')
+  css.first.first.after(new Comment({ text: 'note' }))
+
+  is(css.toString(), 'a{--x:red !important;/* note */}')
+  is(
+    parse(css.toString())
+      .first.nodes.map(i => i.type)
+      .join(','),
+    'decl,comment'
+  )
+})
+
 test('clones only spaces in before', () => {
   let css = parse('a{*one:1}')
   css.first.append({ prop: 'two', value: '2' })


### PR DESCRIPTION
Mutating a rule so that a custom property declaration is immediately followed by a comment node, then stringifying, produces CSS that loses the comment on re-parse:

```js
let css = postcss.parse("a{--x:red}")
css.first.append(postcss.comment({ text: "note" }))

css.toString()          // => "a{--x:red/* note */}"
postcss.parse(css.toString()).first.nodes.length // => 1, the comment is gone
```

The stringifier skips trailing comment siblings when deciding whether the last real child needs a terminating `;`. That is fine for normal declarations, because the parser tokenizes a following `/*` as a separate comment. But a custom property keeps everything up to the next `;` or `}` as its value, so without the semicolon the comment is folded into the value and the comment node disappears. The same class of bug was fixed for childless at-rules in #2115; this is the declaration counterpart.

The fix emits the semicolon when a custom property still has following siblings, right next to the existing at-rule check in `pushBody`. Naturally parsed CSS is unaffected: a custom property can only be followed by a separate comment sibling if the source already had a `;` there (otherwise the comment is part of the value), and that case already sets `raws.semicolon`.

Tested with two new cases in `test/stringifier.test.js` covering `append()` and `after()`, both asserting the output and that it re-parses back to `decl,comment`. Full `pnpm test` (unit, lint, types, integration, size) is green.