### PR TITLE
docs: show ESM and TypeScript plugin declaration

### DIFF
--- a/docs/guidelines/plugin.md
+++ b/docs/guidelines/plugin.md
@@ -119,6 +119,10 @@ module.exports = opts => {
 module.exports.postcss = true
 ```
 
+For ESM / TypeScript modules, use the same `postcss = true` flag on the
+creator function and `export default plugin` (see
+[Writing a PostCSS Plugin](../writing-a-plugin.md)).
+
 ## 2. Processing
 
 ### 2.1. Plugin must be tested

--- a/docs/guidelines/plugin.md
+++ b/docs/guidelines/plugin.md
@@ -108,7 +108,7 @@ It is better even not to import `postcss`.
 Plugin name will be used in error messages and warnings.
 
 ```js
-module.exports = opts => {
+const plugin = opts => {
   return {
     postcssPlugin: 'postcss-name',
     Once(root) {
@@ -116,12 +116,10 @@ module.exports = opts => {
     }
   }
 }
-module.exports.postcss = true
-```
+plugin.postcss = true
 
-For ESM / TypeScript modules, use the same `postcss = true` flag on the
-creator function and `export default plugin` (see
-[Writing a PostCSS Plugin](../writing-a-plugin.md)).
+export default plugin
+```
 
 ## 2. Processing
 

--- a/docs/writing-a-plugin.md
+++ b/docs/writing-a-plugin.md
@@ -101,6 +101,37 @@ module.exports = (opts = {}) => {
 module.exports.postcss = true
 ```
 
+For ESM, attach `postcss = true` to the creator function and default-export it:
+
+```js
+const plugin = (opts = {}) => {
+  // Plugin creator to check options or prepare shared state
+  return {
+    postcssPlugin: 'PLUGIN NAME'
+    // Plugin listeners
+  }
+}
+plugin.postcss = true
+
+export default plugin
+```
+
+In TypeScript, type the creator as `PluginCreator` so `postcss = true` is valid:
+
+```ts
+import type { PluginCreator } from 'postcss'
+
+const plugin: PluginCreator<object> = (opts = {}) => {
+  return {
+    postcssPlugin: 'PLUGIN NAME'
+    // Plugin listeners
+  }
+}
+plugin.postcss = true
+
+export default plugin
+```
+
 [PostCSS plugin boilerplate]: https://github.com/postcss/postcss-plugin-boilerplate/
 [plugin template]: https://github.com/postcss/postcss-plugin-boilerplate/blob/main/template/index.t.js
 

--- a/docs/writing-a-plugin.md
+++ b/docs/writing-a-plugin.md
@@ -91,19 +91,6 @@ For public plugins:
 3. Publish your code there.
 
 ```js
-module.exports = (opts = {}) => {
-  // Plugin creator to check options or prepare shared state
-  return {
-    postcssPlugin: 'PLUGIN NAME'
-    // Plugin listeners
-  }
-}
-module.exports.postcss = true
-```
-
-For ESM, attach `postcss = true` to the creator function and default-export it:
-
-```js
 const plugin = (opts = {}) => {
   // Plugin creator to check options or prepare shared state
   return {


### PR DESCRIPTION
## Summary

- Adds ESM and TypeScript examples for declaring a PostCSS plugin with `plugin.postcss = true` and `export default plugin`
- Points the plugin guidelines at the same pattern
- Fixes #1771

## Test plan

- [ ] Confirm the ESM example matches the `PluginCreator` / `postcss = true` API in `lib/processor.js`
- [ ] Skim docs site rendering for the new snippets in Writing a Plugin and Plugin Guidelines