### PR TITLE
Preserve the BOM when stringifying

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -424,6 +424,9 @@ class Stringifier {
   }
 
   root(node) {
+    if (node.source && node.source.input.hasBOM) {
+      this.builder('\uFEFF', node, 'start')
+    }
     this.body(node)
     if (node.raws.after) {
       let after = node.raws.after

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -5,8 +5,6 @@ import { is } from 'uvu/assert'
 import { parse, stringify } from '../lib/postcss.js'
 
 eachTest((name, css) => {
-  if (name === 'bom.css') return
-
   test(`stringifies ${name}`, () => {
     let root = parse(css)
     let result = ''


### PR DESCRIPTION
PostCSS aims for byte-to-byte equal output, but the stringifier drops a leading byte order mark:

```js
postcss.parse('﻿a{color:red}').toString() // => 'a{color:red}', BOM lost
```

The BOM is already detected (`Input#hasBOM`), but it was never re-emitted, so the round-trip isn't lossless. The `bom.css` parser-test fixture was excluded from the stringify round-trip test for this reason (`if (name === 'bom.css') return`).

This emits the BOM in `Stringifier#root` when the source had one, and removes that skip so the `bom.css` round-trip is now covered. A programmatic root with no source emits no BOM, and non-BOM input is unchanged.

Disclosure: written with AI assistance (Claude Code); I reviewed it and verified against the full suite (unit, eslint, check-dts, size-limit all pass, incl. the newly re-enabled test).