### PR TITLE
fix: return empty array for empty string in list.split

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -11,6 +11,7 @@ let list = {
   },
 
   split(string, separators, last) {
+    if (!string) return []
     let array = []
     let current = ''
     let split = false


### PR DESCRIPTION
## Description
This PR updates `list.split` in `lib/list.js`.

## Details
- Returns an empty array `[]` early when `string` is empty or falsy to prevent spurious empty element insertion when parsing empty CSS value strings.