### PR TITLE
Fix tokenizer handling of escaped identifiers

### DIFF
--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -50,6 +50,54 @@ module.exports = function tokenizer(input, options = {}) {
     return returned.length === 0 && pos >= length
   }
 
+  function escapedEnd(start) {
+    next = start
+    escape = true
+    while (css.charCodeAt(next + 1) === BACKSLASH) {
+      next += 1
+      escape = !escape
+    }
+    code = css.charCodeAt(next + 1)
+    if (
+      escape &&
+      code !== SLASH &&
+      code !== SPACE &&
+      code !== NEWLINE &&
+      code !== TAB &&
+      code !== CR &&
+      code !== FEED
+    ) {
+      next += 1
+      if (RE_HEX_ESCAPE.test(css.charAt(next))) {
+        while (RE_HEX_ESCAPE.test(css.charAt(next + 1))) {
+          next += 1
+        }
+        if (css.charCodeAt(next + 1) === SPACE) {
+          next += 1
+        }
+      }
+    }
+    return next
+  }
+
+  function wordEnd(start) {
+    next = start
+    do {
+      RE_WORD_END.lastIndex = next + 1
+      RE_WORD_END.test(css)
+      if (RE_WORD_END.lastIndex === 0) {
+        next = css.length - 1
+      } else {
+        next = RE_WORD_END.lastIndex - 2
+      }
+      if (css.charCodeAt(next + 1) !== BACKSLASH) break
+      escapePos = escapedEnd(next + 1)
+      if (escapePos === next + 1) break
+      next = escapePos
+    } while (next < length - 1)
+    return next
+  }
+
   function nextToken(opts) {
     if (returned.length) return returned.pop()
     if (pos >= length) return
@@ -189,32 +237,8 @@ module.exports = function tokenizer(input, options = {}) {
       }
 
       case BACKSLASH: {
-        next = pos
-        escape = true
-        while (css.charCodeAt(next + 1) === BACKSLASH) {
-          next += 1
-          escape = !escape
-        }
-        code = css.charCodeAt(next + 1)
-        if (
-          escape &&
-          code !== SLASH &&
-          code !== SPACE &&
-          code !== NEWLINE &&
-          code !== TAB &&
-          code !== CR &&
-          code !== FEED
-        ) {
-          next += 1
-          if (RE_HEX_ESCAPE.test(css.charAt(next))) {
-            while (RE_HEX_ESCAPE.test(css.charAt(next + 1))) {
-              next += 1
-            }
-            if (css.charCodeAt(next + 1) === SPACE) {
-              next += 1
-            }
-          }
-        }
+        next = escapedEnd(pos)
+        if (next !== pos) next = wordEnd(next)
 
         currentToken = ['word', css.slice(pos, next + 1), pos, next]
 
@@ -236,13 +260,7 @@ module.exports = function tokenizer(input, options = {}) {
           currentToken = ['comment', css.slice(pos, next + 1), pos, next]
           pos = next
         } else {
-          RE_WORD_END.lastIndex = pos + 1
-          RE_WORD_END.test(css)
-          if (RE_WORD_END.lastIndex === 0) {
-            next = css.length - 1
-          } else {
-            next = RE_WORD_END.lastIndex - 2
-          }
+          next = wordEnd(pos)
 
           currentToken = ['word', css.slice(pos, next + 1), pos, next]
           buffer.push(currentToken)

--- a/test/tokenize.test.js
+++ b/test/tokenize.test.js
@@ -55,12 +55,20 @@ test('tokenizes control chars', () => {
 
 test('escapes control symbols', () => {
   run('\\(\\{\\"\\@\\\\""', [
-    ['word', '\\(', 0, 1],
-    ['word', '\\{', 2, 3],
-    ['word', '\\"', 4, 5],
-    ['word', '\\@', 6, 7],
-    ['word', '\\\\', 8, 9],
+    ['word', '\\(\\{\\"\\@\\\\', 0, 9],
     ['string', '""', 10, 11]
+  ])
+})
+
+test('keeps escaped punctuation in identifiers', () => {
+  run('C\\(\\#0280ae\\) C\\(brandColor\\) C\\(\\#fff\\)\\:h:hover', [
+    ['word', 'C\\(\\#0280ae\\)', 0, 12],
+    ['space', ' '],
+    ['word', 'C\\(brandColor\\)', 14, 28],
+    ['space', ' '],
+    ['word', 'C\\(\\#fff\\)\\:h', 30, 42],
+    [':', ':', 43],
+    ['word', 'hover', 44, 48]
   ])
 })
 
@@ -285,9 +293,7 @@ test('ignores unclosing function on request', () => {
 
 test('tokenizes hexadecimal escape', () => {
   run('\\0a \\09 \\z ', [
-    ['word', '\\0a ', 0, 3],
-    ['word', '\\09 ', 4, 7],
-    ['word', '\\z', 8, 9],
+    ['word', '\\0a \\09 \\z', 0, 9],
     ['space', ' ']
   ])
 })


### PR DESCRIPTION
Fixes #1349

## Reproduction

Before this change, tokenizing the issue examples split one escaped identifier into many `word` tokens:

```js
const tokenizer = require('./lib/tokenize')
const { Input } = require('./lib/postcss')
let input = String.raw`C\(\#0280ae\)`
```

Current `main` produced `C`, `\(`, `\#`, `0280ae`, `\)` as separate words instead of one identifier token.

## Root cause

The word scanner stopped at every backslash because `RE_WORD_END` treats `\` as a word boundary. The dedicated backslash branch consumed only the escape sequence itself, so escaped punctuation inside identifiers could never stay attached to the surrounding identifier text.

## Fix

Reuse the existing escape-consumption rules while scanning word endings. When the scanner reaches a valid CSS escape, it skips over that escape and continues the same word token; invalid escapes keep the previous token boundaries. This also keeps consecutive hexadecimal escapes in the same identifier token.

## Compatibility

No new dependencies. Parsing/stringification behavior is unchanged for normal CSS; the tokenizer now matches CSS identifier semantics for valid escaped punctuation.

## Validation

- `node -r ts-node/register/transpile-only test/tokenize.test.js`: 34/34 passed.
- Regression test with `lib/tokenize.js` reverted: failed as expected (`keeps escaped punctuation in identifiers`).
- `pnpm run test:coverage`: 682/682 unit tests passed.
- `pnpm run test:lint`: passed with 0 errors and one existing warning in `test/visitor.test.ts`.
- `pnpm run test:types`: passed.
- `pnpm run test:version`: passed.
- `pnpm run test:integration`: 33 real-world CSS fixtures passed.
- `pnpm run test:size`: passed, 16.37 kB / 16.5 kB.

Note: on Windows, raw `pnpm test` fails before running because the package script uses POSIX `FORCE_COLOR=1`; I ran the equivalent `test:*` scripts individually with `$env:FORCE_COLOR=1`.