### PR TITLE
Do not terminate a hack-prefixed property before a comment

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -49,12 +49,8 @@ function atruleStart(str, node) {
   return name + afterName + params
 }
 
-// The parser reads a declaration as a custom property when the first token of
-// the declaration starts with `--`, not when `prop` does. A `*`/`_` hack prefix
-// is moved from `prop` into `before` after that decision, so `*--x` is a normal
-// declaration that stops at the first comment. Re-checking `before` here keeps
-// this in sync: with anything but spaces in front of the property, the output
-// will not re-parse as a custom property and needs no terminating semicolon.
+// `*--x` is not a custom property: the parser checks the first token, and the
+// `*`/`_` hack prefix moves from `prop` into `before` only after that.
 function isCustomProperty(node) {
   if (!node.prop.startsWith('--')) return false
   let before = node.raws.before

--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -49,6 +49,18 @@ function atruleStart(str, node) {
   return name + afterName + params
 }
 
+// The parser reads a declaration as a custom property when the first token of
+// the declaration starts with `--`, not when `prop` does. A `*`/`_` hack prefix
+// is moved from `prop` into `before` after that decision, so `*--x` is a normal
+// declaration that stops at the first comment. Re-checking `before` here keeps
+// this in sync: with anything but spaces in front of the property, the output
+// will not re-parse as a custom property and needs no terminating semicolon.
+function isCustomProperty(node) {
+  if (!node.prop.startsWith('--')) return false
+  let before = node.raws.before
+  return typeof before === 'undefined' || !/\S$/.test(before)
+}
+
 function pushBody(str, stack, node) {
   let nodes = node.nodes
   let last = nodes.length - 1
@@ -70,7 +82,7 @@ function pushBody(str, stack, node) {
       !childSemicolon &&
       i < nodes.length - 1 &&
       ((child.type === 'atrule' && !child.nodes) ||
-        (child.type === 'decl' && child.prop.startsWith('--')))
+        (child.type === 'decl' && isCustomProperty(child)))
     ) {
       childSemicolon = true
     }

--- a/test/stringifier.test.js
+++ b/test/stringifier.test.js
@@ -214,6 +214,32 @@ test('terminates custom property with !important before a comment', () => {
   )
 })
 
+test('keeps hack-prefixed property before a comment unchanged', () => {
+  for (let css of ['a{*--x:red/*c*/}', 'a{_--x:red/*c*/}']) {
+    let root = parse(css)
+    is(root.toString(), css)
+    is(
+      parse(root.toString())
+        .first.nodes.map(i => i.type)
+        .join(','),
+      'decl,comment'
+    )
+  }
+})
+
+test('terminates indented custom property followed by a comment', () => {
+  let css = parse('a{  --x:red}')
+  css.first.first.after(new Comment({ text: 'note' }))
+
+  is(css.toString(), 'a{  --x:red;  /* note */}')
+  is(
+    parse(css.toString())
+      .first.nodes.map(i => i.type)
+      .join(','),
+    'decl,comment'
+  )
+})
+
 test('clones only spaces in before', () => {
   let css = parse('a{*one:1}')
   css.first.append({ prop: 'two', value: '2' })


### PR DESCRIPTION
PostCSS aims for byte-to-byte equal output, but since 8.5.22 the stringifier invents a semicolon in a declaration list:

```js
postcss.parse('a{*--x:red/*c*/}').toString()
// => 'a{*--x:red;/*c*/}'   (8.5.21 and earlier: unchanged)
```

`_--x` behaves the same. The output stays valid CSS and re-parses to the same AST, so nothing breaks downstream — but a tool that only means to touch what it edits now emits an unrelated `;`.

### Why

The parser decides whether a declaration is a custom property from the **first token** of the declaration:

```js
let customProperty = start[1].startsWith('--')   // lib/parser.js, other()
```

`#2117` re-derived that decision in the stringifier from `prop`:

```js
child.type === 'decl' && child.prop.startsWith('--')
```

Those two agree almost always, but `decl()` strips the `*`/`_` hack prefix out of `prop` and into `raws.before` *after* the parser has made its choice:

```js
if (node.prop[0] === '_' || node.prop[0] === '*') {
  node.raws.before += node.prop[0]
  node.prop = node.prop.slice(1)
}
```

So `*--x:red` is parsed as a **normal** declaration — its value stops at the first comment, and the comment is already a separate node — while the stringifier sees `prop === '--x'` and terminates it. The semicolon `#2117` adds is there to stop a custom property's value from swallowing a following comment; here there is nothing to protect, because `*--x:red` will not re-parse as a custom property either. The same mismatch happens whenever anything but spaces precedes the property, since `decl()` collects those tokens into `before` too (`a{'s'--x:1/*c*/}`).

### Fix

Check `before` alongside `prop`, so the stringifier asks the same question the parser did — *will this re-parse as a custom property?* — and terminates only the declarations that need it.

### Tests

- `keeps hack-prefixed property before a comment unchanged` — `*--x` / `_--x` round-trip byte-for-byte, and still re-parse to `decl,comment`.
- `terminates indented custom property followed by a comment` — a whitespace-only `before` is still a custom property and still gets its semicolon, so the narrowing can't be over-read as `before === ''`.

The two tests from `#2115`/`#2117` pass unchanged. `pnpm unit` is 683/683, types and size-limit pass, and lint is clean apart from the pre-existing `RootExit` sort warning on `main`.

I also re-ran a round-trip check over ~320k generated stylesheets (`parse(css).toString() === css`, plus AST-shape stability across a re-parse) at both root level and nested in a rule/at-rule: every failure it reported was this one cause, and after the change it reports none.
