### PR TITLE
Fix Rule#selectors losing the empty selector

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -11,7 +11,7 @@ let list = {
   },
 
   split(string, separators, last) {
-    if (!string) return []
+    if (typeof string !== 'string') return []
     let array = []
     let current = ''
     let split = false

--- a/test/list.test.ts
+++ b/test/list.test.ts
@@ -36,6 +36,15 @@ test('comma() adds last empty', () => {
   equal(list.comma('a, b,'), ['a', 'b', ''])
 })
 
+test('comma() keeps empty value', () => {
+  equal(list.comma(''), [''])
+})
+
+test('comma() ignores non-string values', () => {
+  // @ts-expect-error Testing invalid API
+  equal(list.comma(undefined), [])
+})
+
 test('comma() checks quotes', () => {
   equal(list.comma('"a,b\\"", \'\''), ['"a,b\\""', "''"])
 })

--- a/test/rule.test.ts
+++ b/test/rule.test.ts
@@ -13,6 +13,11 @@ test('returns array in selectors', () => {
   equal(rule.selectors, ['a', 'b'])
 })
 
+test('returns empty selector in selectors', () => {
+  let rule = new Rule({ selector: '' })
+  equal(rule.selectors, [''])
+})
+
 test('trims selectors', () => {
   let rule = new Rule({ selector: '.a\n, .b  , .c' })
   equal(rule.selectors, ['.a', '.b', '.c'])


### PR DESCRIPTION
8.5.25 made `list.split()` return `[]` for an empty string (#2121), so `list.comma('')` went from `['']` to `[]`, and with it `Rule#selectors` on a rule whose selector is empty.

Plugins read that getter and assume at least one entry. `postcss-nested`'s `mergeSelectors()` loops over `parent.selectors` and joins the result back into the child, so an empty parent selector now wipes the child's:

```js
postcss([nested]).process('{ color: red; .dark & { color: blue } }', { from: undefined }).css
// 8.5.24: '{ color: red; } .dark  { color: blue }'
// 8.5.25: '{ color: red; }  { color: blue }'
```

That is what the Panda CSS reproduction in #2128 hits: the selector is wiped, the block is merged away, and `.dark` is gone from the tokens layer.

`''` is a string, and its `last: true` split has always been `['']`, same as the trailing item in `list.comma('a, b,')`. So this narrows the guard to non-strings, which keeps what #2121 was after (`list.split(undefined)` no longer throws) without changing the empty-string result.

Fixes #2128