### PR TITLE
Upgrade nanoid to 5.1.6

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -1,6 +1,21 @@
 'use strict'
 
-let { nanoid } = require('nanoid/non-secure')
+let nanoid
+try {
+  ;({ nanoid } = require('nanoid/non-secure'))
+} catch {
+  // nanoid 5+ ships ESM-only, so `require()` throws on Node versions
+  // without ESM interop (< 20.19 / < 22.12). Fall back to the same
+  // non-secure algorithm nanoid uses internally.
+  let urlAlphabet =
+    'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
+  nanoid = (size = 21) => {
+    let id = ''
+    let i = size | 0
+    while (i--) id += urlAlphabet[(Math.random() * 64) | 0]
+    return id
+  }
+}
 let { isAbsolute, resolve } = require('path')
 let { SourceMapConsumer, SourceMapGenerator } = require('source-map-js')
 let { fileURLToPath, pathToFileURL } = require('url')

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "old": "node --require ./test/old-node.js ./node_modules/uvu/bin.js -r module test \"\\.test\\.(ts|js)$\""
   },
   "dependencies": {
-    "nanoid": "^3.3.17",
+    "nanoid": "^5.1.6",
     "picocolors": "^1.1.1",
     "source-map-js": "^1.2.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       nanoid:
-        specifier: ^3.3.17
-        version: 3.3.17
+        specifier: ^5.1.6
+        version: 5.1.6
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -1273,13 +1273,13 @@ packages:
     resolution: {integrity: sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@5.1.16:
     resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanoid@5.1.6:
+    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -2661,9 +2661,9 @@ snapshots:
 
   nanoevents@9.1.0: {}
 
-  nanoid@3.3.17: {}
-
   nanoid@5.1.16: {}
+
+  nanoid@5.1.6: {}
 
   nanoid@6.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,4 @@ allowBuilds:
   simple-git-hooks: true
   unrs-resolver: false
 minimumReleaseAgeExclude:
-  - nanoid@3.3.17
+  - nanoid@5.1.6


### PR DESCRIPTION
Bump nanoid dependency from ^3.3.17 to ^5.1.6 in package.json, pnpm-lock.yaml, and pnpm-workspace.yaml.

nanoid v5+ ships as ESM-only (no CommonJS build), which would break 
equire('nanoid/non-secure') in lib/input.js on Node versions without require(esm) interop (< 20.19 / < 22.12). To avoid a breaking change across postcss's supported engines range, wrap the require in a try/catch that falls back to nanoid's own non-secure ID generation algorithm inlined locally when the ESM require fails.