### PR TITLE
Keep empty values in the middle and at the start of list.comma()

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -42,7 +42,7 @@ let list = {
       }
 
       if (split) {
-        if (current !== '') array.push(current.trim())
+        if (last || current !== '') array.push(current.trim())
         current = ''
         split = false
       } else {

--- a/test/list.test.ts
+++ b/test/list.test.ts
@@ -11,6 +11,10 @@ test('space() trims values', () => {
   equal(list.space(' a  b '), ['a', 'b'])
 })
 
+test('space() ignores repeated spaces', () => {
+  equal(list.space('a  b'), ['a', 'b'])
+})
+
 test('space() checks quotes', () => {
   equal(list.space('"a b\\"" \'\''), ['"a b\\""', "''"])
 })
@@ -43,6 +47,22 @@ test('comma() keeps empty value', () => {
 test('comma() ignores non-string values', () => {
   // @ts-expect-error Testing invalid API
   equal(list.comma(undefined), [])
+})
+
+test('comma() keeps first empty', () => {
+  equal(list.comma(', b'), ['', 'b'])
+})
+
+test('comma() keeps empty between values', () => {
+  equal(list.comma('a,, b'), ['a', '', 'b'])
+})
+
+test('comma() keeps empty regardless of spaces', () => {
+  equal(list.comma('a,,b'), list.comma('a, ,b'))
+})
+
+test('comma() keeps every empty value', () => {
+  equal(list.comma(',,'), ['', '', ''])
 })
 
 test('comma() checks quotes', () => {

--- a/test/rule.test.ts
+++ b/test/rule.test.ts
@@ -18,6 +18,16 @@ test('returns empty selector in selectors', () => {
   equal(rule.selectors, [''])
 })
 
+test('keeps empty selector between other selectors', () => {
+  let rule = new Rule({ selector: 'a,,b' })
+  equal(rule.selectors, ['a', '', 'b'])
+})
+
+test('keeps empty selector before other selectors', () => {
+  let rule = new Rule({ selector: ',b' })
+  equal(rule.selectors, ['', 'b'])
+})
+
 test('trims selectors', () => {
   let rule = new Rule({ selector: '.a\n, .b  , .c' })
   equal(rule.selectors, ['.a', '.b', '.c'])


### PR DESCRIPTION
`list.split()` only pushed an item when it had collected some text, so an empty value was dropped unless it happened to be the last one:

```js
list.comma(',,')    // ['']            expected ['', '', '']
list.comma(', b')   // ['b']           expected ['', 'b']
list.comma('a,, b') // ['a', 'b']      expected ['a', '', 'b']
list.comma('a, b,') // ['a', 'b', '']  already correct
```

Whitespace hides it. `'a, ,b'` collects `' '` between the commas, which is not empty, so it survives and is then trimmed to `''`. The result ends up depending on the spacing rather than on the number of commas:

```js
list.comma('a,,b')  // ['a', 'b']
list.comma('a, ,b') // ['a', '', 'b']
```

`Rule#selectors` reads through `list.comma`, so this loses a selector:

```js
let rule = postcss.parse('a,,b{}').first
rule.selectors        // ['a', 'b']
rule.selectors = rule.selectors
rule.toString()       // 'a,b{}'
```

This is the same thing #2129 fixed for `''`, just in the other positions — that PR made the empty value survive when it is the whole string, and the trailing empty was already handled by `last`. The first and middle ones were still being dropped.

## The change

One condition. `last` already marks the separator as significant — `comma()` passes it and `space()` does not — so it is the right thing to check here too:

```diff
 if (split) {
-  if (current !== '') array.push(current.trim())
+  if (last || current !== '') array.push(current.trim())
```

`space()` is unchanged, so runs of whitespace still collapse rather than producing empty items. I added a test pinning that down as well, since it is the behaviour this condition protects.

## Tests

Four cases in `test/list.test.ts` and two in `test/rule.test.ts`, covering the leading and middle positions and the spacing inconsistency. All six fail on `main` and pass with the change. Full suite is 693 passing; the 686 that existed before are untouched, so nothing was relying on the empty values being dropped.

`pnpm test:lint` and `pnpm test:types` are clean.
