### PR TITLE
Do not emit multiple UTF-8 BOM markers

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -47,7 +47,7 @@ class Input {
 
     if (this.css[0] === '\uFEFF' || this.css[0] === '\uFFFE') {
       this.hasBOM = true
-      this.css = this.css.slice(1)
+      this.css = this.css.replace(/^[\uFEFF\uFFFE]+/, '')
     } else {
       this.hasBOM = false
     }

--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -432,7 +432,9 @@ class Stringifier {
   }
 
   root(node) {
-    if (node.source && node.source.input.hasBOM) {
+    // A document may contain several roots that each had a BOM.
+    if (node.source && node.source.input.hasBOM && !this.emittedBOM) {
+      this.emittedBOM = true
       this.builder('\uFEFF', node, 'start')
     }
     this.body(node)

--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -46,12 +46,23 @@ module.exports = function tokenizer(input, options = {}) {
     throw input.error('Unclosed ' + what, pos)
   }
 
+  // Extra U+FEFF markers appear when BOM-preserving outputs are concatenated.
+  function skipBom() {
+    while (pos < length) {
+      code = css.charCodeAt(pos)
+      if (code !== 0xfeff && code !== 0xfffe) break
+      pos += 1
+    }
+  }
+
   function endOfFile() {
+    if (returned.length === 0) skipBom()
     return returned.length === 0 && pos >= length
   }
 
   function nextToken(opts) {
     if (returned.length) return returned.pop()
+    skipBom()
     if (pos >= length) return
 
     let ignoreUnclosed = opts ? opts.ignoreUnclosed : false

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -41,6 +41,13 @@ test('should has false at hasBOM property', () => {
   is(css.first?.source?.input.hasBOM, false)
 })
 
+test('collapses multiple leading BOMs to a single marker', () => {
+  let css = parse('\uFEFF\uFEFF@host { a {\f} }')
+  equal(css.nodes[0].raws.before, '')
+  is(css.first?.source?.input.hasBOM, true)
+  is(css.toString(), '\uFEFF@host { a {\f} }')
+})
+
 test('parses carrier return', () => {
   throws(() => {
     parse('@font-face{ font:(\r/*);} body { a: "a*/)} a{}"}')

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -2,6 +2,7 @@ import { eachTest } from 'postcss-parser-tests'
 import { test } from 'uvu'
 import { is } from 'uvu/assert'
 
+import Document from '../lib/document.js'
 import { parse, stringify } from '../lib/postcss.js'
 
 eachTest((name, css) => {
@@ -13,6 +14,25 @@ eachTest((name, css) => {
     })
     is(result, css)
   })
+})
+
+test('preserves a single leading BOM', () => {
+  is(parse('\uFEFFa{}').toString(), '\uFEFFa{}')
+})
+
+test('does not emit multiple BOM markers', () => {
+  is(parse('\uFEFF\uFEFFa{}').toString(), '\uFEFFa{}')
+  is(parse('\uFEFFa{}\uFEFFb{}').toString(), '\uFEFFa{}b{}')
+  is(parse('a{}\uFEFFb{}').toString(), 'a{}b{}')
+  is(parse('\uFEFFa{}\uFFFEb{}').toString(), '\uFEFFa{}b{}')
+  is(parse('a{}\uFEFF').toString(), 'a{}')
+})
+
+test('emits a single BOM for a document of BOM roots', () => {
+  let document = new Document()
+  document.append(parse('\uFEFFa{}'))
+  document.append(parse('\uFEFFb{}'))
+  is(document.toString(), '\uFEFFa{}b{}')
 })
 
 test.run()

--- a/test/tokenize.test.js
+++ b/test/tokenize.test.js
@@ -21,6 +21,30 @@ test('tokenizes empty file', () => {
   run('', [])
 })
 
+test('skips stray BOM markers between tokens', () => {
+  run('a{}\uFEFFb{}', [
+    ['word', 'a', 0, 0],
+    ['{', '{', 1],
+    ['}', '}', 2],
+    ['word', 'b', 4, 4],
+    ['{', '{', 5],
+    ['}', '}', 6]
+  ])
+  run('a{}\uFFFEb{}', [
+    ['word', 'a', 0, 0],
+    ['{', '{', 1],
+    ['}', '}', 2],
+    ['word', 'b', 4, 4],
+    ['{', '{', 5],
+    ['}', '}', 6]
+  ])
+  run('a{}\uFEFF', [
+    ['word', 'a', 0, 0],
+    ['{', '{', 1],
+    ['}', '}', 2]
+  ])
+})
+
 test('tokenizes space', () => {
   run('\r\n \f\t', [['space', '\r\n \f\t']])
 })


### PR DESCRIPTION
## Why

v8.5.24 started restoring a leading BOM on stringify (#2119). That is correct for a single file, but `parse`/`stringify` could still produce more than one U+FEFF:

- input with several leading BOMs kept extras after the first
- concatenated CSS (`a{}\uFEFFb{}`) re-emitted the mid-file marker as part of the next selector
- a `Document` of several BOM-tagged roots wrote a BOM before every root

Those extra markers show up in the middle of generated CSS and break the first rule after each one.

## Solution

- Strip every leading U+FEFF / U+FFFE in `Input`, not only the first
- Skip stray BOM markers in the tokenizer so they are not part of the AST
- Emit at most one BOM from `Stringifier#root`

A single leading BOM is still preserved. `parse('\uFEFFa{}').toString()` remains `\uFEFFa{}`.

Fixes #2133