### PR TITLE
Put only major.minor in Processor.version

### DIFF
--- a/lib/processor.d.ts
+++ b/lib/processor.d.ts
@@ -37,7 +37,7 @@ declare class Processor_ {
   plugins: (Plugin | TransformCallback | Transformer)[]
 
   /**
-   * Current PostCSS version.
+   * Current PostCSS version as `major.minor`, without the patch component.
    *
    * ```js
    * if (result.processor.version.split('.')[0] !== '6') {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -7,7 +7,7 @@ let Root = require('./root')
 
 class Processor {
   constructor(plugins = []) {
-    this.version = '8.5.26'
+    this.version = '8.5'
     this.plugins = this.normalize(plugins)
   }
 

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -131,7 +131,7 @@ test('has deprecated method to create plugins', () => {
 
   let func1: any = postcss(plugin).plugins[0]
   is(func1.postcssPlugin, 'test')
-  match(func1.postcssVersion, /\d+.\d+.\d+/)
+  match(func1.postcssVersion, /^\d+\.\d+$/)
   equal(warn.callCount, 1)
 
   let func2: any = postcss(plugin()).plugins[0]

--- a/test/processor.test.ts
+++ b/test/processor.test.ts
@@ -487,7 +487,7 @@ test('uses custom syntax', async () => {
 })
 
 test('contains PostCSS version', () => {
-  match(new Processor().version, /\d+.\d+.\d+/)
+  match(new Processor().version, /^\d+\.\d+$/)
 })
 
 test('throws on syntax as plugin', () => {

--- a/test/version.js
+++ b/test/version.js
@@ -4,6 +4,9 @@ let Processor = require('../lib/processor')
 let pkg = require('../package')
 
 let instance = new Processor()
-if (pkg.version !== instance.version) {
-  throw new Error('Version in Processor is not equal to package.json')
+let expected = pkg.version.split('.').slice(0, 2).join('.')
+if (expected !== instance.version) {
+  throw new Error(
+    'Version in Processor is not equal to major.minor of package.json'
+  )
 }


### PR DESCRIPTION
Fixes #2101.

`Processor.version` was a full `major.minor.patch` string hardcoded in `lib/processor.js`, which meant it had to be edited on every patch release to stay in step with `package.json`. This drops the patch component so it only needs touching on a minor bump.

## Why this is safe

The patch component was never read. The only runtime consumer is the plugin-version mismatch warning in `lib/lazy-result.js`:

```js
let a = pluginVer.split('.')
let b = runtimeVer.split('.')

if (a[0] !== b[0] || parseInt(a[1]) > parseInt(b[1])) {
```

It compares `[0]` and `[1]` only, so `'8.5'` behaves identically to `'8.5.26'` here. `postcssVersion`, which `lib/postcss.js` sets from `new Processor().version`, flows into the same comparison and is unaffected. The documented example in `processor.d.ts` uses `version.split('.')[0]`, which also still works.

## Tests

`test/version.js` previously asserted exact equality with `package.json`, which would now always fail. It compares the major and minor components instead, so the guard against the two drifting is kept rather than removed:

```js
let expected = pkg.version.split('.').slice(0, 2).join('.')
```

Two assertions matched `/\d+.\d+.\d+/`. Both are now `/^\d+\.\d+$/` — anchored, and with the dots escaped, which the originals did not do.

I have also noted the format in the `processor.d.ts` doc comment, since it is a visible change for anyone reading `version` directly.

## Checks

- `pnpm unit` — 696 passing, 0 failing
- `node ./test/version.js` — passes
- `pnpm test:types` — clean
- `pnpm test:lint` — one pre-existing warning in `test/visitor.test.ts` (`perfectionist/sort-objects`), present on an unmodified checkout and untouched here
