### PR TITLE
Fix `'source' does not exist in type 'DeclarationProps'` error

### DIFF
--- a/lib/declaration.d.ts
+++ b/lib/declaration.d.ts
@@ -28,7 +28,7 @@ declare namespace Declaration {
     }
   }
 
-  export interface DeclarationProps {
+  export interface DeclarationProps extends NodeProps {
     /** Whether the declaration has an `!important` annotation. */
     important?: boolean
     /** Name of the declaration. */


### PR DESCRIPTION
<img width="767" height="178" alt="Screenshot 2026-08-15 at 17 37 48" src="https://github.com/user-attachments/assets/9dad01e6-67ce-4ce9-b7d2-8f314b9d7564" />

I think it was simply an oversight that this type does not extend `NodeProps`

---

This isn't blocking for me, I've added `@ts-expect-error` comments on my end :)