### PR TITLE
Replace picocolors with node:util styleText

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,15 @@ export default [
       ],
       'n/no-unsupported-features/node-builtins': [
         'error',
-        { ignores: ['url.fileURLToPath', 'url.pathToFileURL', 'btoa', 'atob'] }
+        {
+          ignores: [
+            'url.fileURLToPath',
+            'url.pathToFileURL',
+            'util.styleText',
+            'btoa',
+            'atob'
+          ]
+        }
       ],
       'n/prefer-node-protocol': 'off',
       'perfectionist/sort-switch-case': 'off'

--- a/lib/colors.d.ts
+++ b/lib/colors.d.ts
@@ -1,0 +1,3 @@
+export function createColor(...formats: string[]): (text: string) => string
+
+export let isColorSupported: boolean

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,0 +1,38 @@
+'use strict'
+
+let { styleText } = require('util')
+
+// util.styleText() was added in Node.js 20.12, but it accepts an array
+// of formats only since 20.13. Detect what we actually use.
+let hasStyleText = typeof styleText === 'function'
+if (hasStyleText) {
+  try {
+    styleText(['bold', 'red'], '', { validateStream: false })
+    /* c8 ignore next 3 */
+  } catch {
+    hasStyleText = false
+  }
+}
+
+// node:util has no isColorSupported, so repeat picocolors' detection here
+let isColorSupported =
+  hasStyleText &&
+  !(process.env.NO_COLOR || process.argv.includes('--no-color')) &&
+  Boolean(
+    process.env.FORCE_COLOR ||
+      process.argv.includes('--color') ||
+      process.platform === 'win32' ||
+      ((process.stdout || {}).isTTY && process.env.TERM !== 'dumb') ||
+      process.env.CI
+  )
+
+// Node.js re-opens the parent style after the nested one only since 22.19
+// and 24.5. To support older versions, styles should be combined
+// in a single call like createColor('bold', 'red') instead of bold(red()).
+function createColor(...formats) {
+  /* c8 ignore next */
+  if (!hasStyleText) return text => String(text)
+  return text => styleText(formats, String(text), { validateStream: false })
+}
+
+module.exports = { createColor, isColorSupported }

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -2,21 +2,8 @@
 
 let { styleText } = require('util')
 
-// util.styleText() was added in Node.js 20.12, but it accepts an array
-// of formats only since 20.13. Detect what we actually use.
-let hasStyleText = typeof styleText === 'function'
-if (hasStyleText) {
-  try {
-    styleText(['bold', 'red'], '', { validateStream: false })
-    /* c8 ignore next 3 */
-  } catch {
-    hasStyleText = false
-  }
-}
-
 // node:util has no isColorSupported, so repeat picocolors' detection here
 let isColorSupported =
-  hasStyleText &&
   !(process.env.NO_COLOR || process.argv.includes('--no-color')) &&
   Boolean(
     process.env.FORCE_COLOR ||
@@ -30,8 +17,6 @@ let isColorSupported =
 // and 24.5. To support older versions, styles should be combined
 // in a single call like createColor('bold', 'red') instead of bold(red()).
 function createColor(...formats) {
-  /* c8 ignore next */
-  if (!hasStyleText) return text => String(text)
   return text => styleText(formats, String(text), { validateStream: false })
 }
 

--- a/lib/css-syntax-error.js
+++ b/lib/css-syntax-error.js
@@ -1,7 +1,6 @@
 'use strict'
 
-let pico = require('picocolors')
-
+let { createColor, isColorSupported } = require('./colors')
 let terminalHighlight = require('./terminal-highlight')
 
 class CssSyntaxError extends Error {
@@ -51,15 +50,14 @@ class CssSyntaxError extends Error {
     if (!this.source) return ''
 
     let css = this.source
-    if (color == null) color = pico.isColorSupported
+    if (color == null) color = isColorSupported
 
     let aside = text => text
     let mark = text => text
     let highlight = text => text
-    if (color) {
-      let { bold, gray, red } = pico.createColors(true)
-      mark = text => bold(red(text))
-      aside = text => gray(text)
+    if (color && createColor) {
+      mark = createColor('bold', 'red')
+      aside = createColor('gray')
       if (terminalHighlight) {
         highlight = text => terminalHighlight(text)
       }

--- a/lib/terminal-highlight.js
+++ b/lib/terminal-highlight.js
@@ -1,8 +1,10 @@
 'use strict'
 
-let pico = require('picocolors')
-
+let { createColor, isColorSupported } = require('./colors')
 let tokenizer = require('./tokenize')
+
+// Like picocolors' top-level colors, these are no-ops without color support
+let style = isColorSupported ? createColor : () => text => String(text)
 
 let Input
 
@@ -11,21 +13,21 @@ function registerInput(dependant) {
 }
 
 const HIGHLIGHT_THEME = {
-  ';': pico.yellow,
-  ':': pico.yellow,
-  '(': pico.cyan,
-  ')': pico.cyan,
-  '[': pico.yellow,
-  ']': pico.yellow,
-  '{': pico.yellow,
-  '}': pico.yellow,
-  'at-word': pico.cyan,
-  'brackets': pico.cyan,
-  'call': pico.cyan,
-  'class': pico.yellow,
-  'comment': pico.gray,
-  'hash': pico.magenta,
-  'string': pico.green
+  ';': style('yellow'),
+  ':': style('yellow'),
+  '(': style('cyan'),
+  ')': style('cyan'),
+  '[': style('yellow'),
+  ']': style('yellow'),
+  '{': style('yellow'),
+  '}': style('yellow'),
+  'at-word': style('cyan'),
+  'brackets': style('cyan'),
+  'call': style('cyan'),
+  'class': style('yellow'),
+  'comment': style('gray'),
+  'hash': style('magenta'),
+  'string': style('green')
 }
 
 function getTokenType([type, value], processor) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "main": "./lib/postcss.js",
   "browser": {
+    "./lib/colors": false,
     "./lib/terminal-highlight": false,
     "source-map-js": false,
     "path": false,
@@ -90,7 +91,6 @@
   },
   "dependencies": {
     "nanoid": "^3.3.18",
-    "picocolors": "^1.1.1",
     "source-map-js": "^1.2.1"
   },
   "devDependencies": {
@@ -128,7 +128,7 @@
   "size-limit": [
     {
       "path": "lib/postcss.js",
-      "limit": "16.5 KB"
+      "limit": "16.25 KB"
     }
   ],
   "c8": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "reporter": "lcov"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14"
+    "node": ">=22"
   },
   "clean-publish": {
     "cleanDocs": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       nanoid:
         specifier: ^3.3.18
         version: 3.3.18
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       source-map-js:
         specifier: ^1.2.1
         version: 1.2.1

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -1,5 +1,4 @@
 import { join } from 'node:path'
-import * as nodeUtil from 'node:util'
 import { test } from 'uvu'
 import { is } from 'uvu/assert'
 
@@ -10,9 +9,7 @@ interface Colors {
   isColorSupported: boolean
 }
 
-let util: any = nodeUtil
 let colorsPath = join(__dirname, '..', 'lib', 'colors.js')
-let hasStyleText = typeof util.styleText === 'function'
 
 function withEnv<T>(
   env: NodeJS.ProcessEnv,
@@ -47,14 +44,12 @@ function load(env: NodeJS.ProcessEnv, argv: string[] = [], isTTY = false): Color
 }
 
 test('combines formats in a single call', () => {
-  if (!hasStyleText) return
   is(createColor('bold', 'red')('x'), '\x1b[1m\x1b[31mx\x1b[39m\x1b[22m')
   is(createColor('gray')('y'), '\x1b[90my\x1b[39m')
   is(createColor('yellow')('z'), '\x1b[33mz\x1b[39m')
 })
 
 test('forces colors when they are not supported', () => {
-  if (!hasStyleText) return
   let colors = load({})
   is(colors.isColorSupported, process.platform === 'win32')
   is(
@@ -64,24 +59,23 @@ test('forces colors when they are not supported', () => {
 })
 
 test('colors non-string values', () => {
-  if (!hasStyleText) return
   is(createColor('red')(1 as unknown as string), '\x1b[31m1\x1b[39m')
 })
 
 test('enables colors by FORCE_COLOR', () => {
-  is(load({ FORCE_COLOR: '1' }).isColorSupported, hasStyleText)
+  is(load({ FORCE_COLOR: '1' }).isColorSupported, true)
 })
 
 test('enables colors by --color', () => {
-  is(load({}, ['--color']).isColorSupported, hasStyleText)
+  is(load({}, ['--color']).isColorSupported, true)
 })
 
 test('enables colors on CI', () => {
-  is(load({ CI: 'true' }).isColorSupported, hasStyleText)
+  is(load({ CI: 'true' }).isColorSupported, true)
 })
 
 test('enables colors on TTY', () => {
-  is(load({ TERM: 'xterm' }, [], true).isColorSupported, hasStyleText)
+  is(load({ TERM: 'xterm' }, [], true).isColorSupported, true)
 })
 
 test('disables colors by NO_COLOR', () => {
@@ -102,17 +96,5 @@ if (process.platform !== 'win32') {
     is(load({ TERM: 'dumb' }, [], true).isColorSupported, false)
   })
 }
-
-test('degrades to plain text without util.styleText', () => {
-  let styleText = util.styleText
-  delete util.styleText
-  try {
-    let colors = load({ FORCE_COLOR: '1' })
-    is(colors.isColorSupported, false)
-    is(colors.createColor('bold', 'red')('x'), 'x')
-  } finally {
-    util.styleText = styleText
-  }
-})
 
 test.run()

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -1,0 +1,118 @@
+import { join } from 'node:path'
+import * as nodeUtil from 'node:util'
+import { test } from 'uvu'
+import { is } from 'uvu/assert'
+
+import { createColor } from '../lib/colors.js'
+
+interface Colors {
+  createColor(...formats: string[]): (text: string) => string
+  isColorSupported: boolean
+}
+
+let util: any = nodeUtil
+let colorsPath = join(__dirname, '..', 'lib', 'colors.js')
+let hasStyleText = typeof util.styleText === 'function'
+
+function withEnv<T>(
+  env: NodeJS.ProcessEnv,
+  argv: string[],
+  isTTY: boolean,
+  cb: () => T
+): T {
+  let oldEnv = process.env
+  let oldArgv = process.argv
+  let oldTTY = process.stdout.isTTY
+  process.env = env
+  process.argv = ['node', 'colors.test.ts', ...argv]
+  process.stdout.isTTY = isTTY
+  try {
+    return cb()
+  } finally {
+    process.env = oldEnv
+    process.argv = oldArgv
+    process.stdout.isTTY = oldTTY
+  }
+}
+
+function load(env: NodeJS.ProcessEnv, argv: string[] = [], isTTY = false): Colors {
+  return withEnv(env, argv, isTTY, () => {
+    delete require.cache[colorsPath]
+    try {
+      return require(colorsPath)
+    } finally {
+      delete require.cache[colorsPath]
+    }
+  })
+}
+
+test('combines formats in a single call', () => {
+  if (!hasStyleText) return
+  is(createColor('bold', 'red')('x'), '\x1b[1m\x1b[31mx\x1b[39m\x1b[22m')
+  is(createColor('gray')('y'), '\x1b[90my\x1b[39m')
+  is(createColor('yellow')('z'), '\x1b[33mz\x1b[39m')
+})
+
+test('forces colors when they are not supported', () => {
+  if (!hasStyleText) return
+  let colors = load({})
+  is(colors.isColorSupported, process.platform === 'win32')
+  is(
+    withEnv({}, [], false, () => colors.createColor('red')('x')),
+    '\x1b[31mx\x1b[39m'
+  )
+})
+
+test('colors non-string values', () => {
+  if (!hasStyleText) return
+  is(createColor('red')(1 as unknown as string), '\x1b[31m1\x1b[39m')
+})
+
+test('enables colors by FORCE_COLOR', () => {
+  is(load({ FORCE_COLOR: '1' }).isColorSupported, hasStyleText)
+})
+
+test('enables colors by --color', () => {
+  is(load({}, ['--color']).isColorSupported, hasStyleText)
+})
+
+test('enables colors on CI', () => {
+  is(load({ CI: 'true' }).isColorSupported, hasStyleText)
+})
+
+test('enables colors on TTY', () => {
+  is(load({ TERM: 'xterm' }, [], true).isColorSupported, hasStyleText)
+})
+
+test('disables colors by NO_COLOR', () => {
+  is(load({ FORCE_COLOR: '1', NO_COLOR: '1' }).isColorSupported, false)
+})
+
+test('disables colors by --no-color', () => {
+  is(load({ FORCE_COLOR: '1' }, ['--no-color']).isColorSupported, false)
+})
+
+// Windows is always treated as color-capable, like in picocolors
+if (process.platform !== 'win32') {
+  test('disables colors without TTY', () => {
+    is(load({ TERM: 'xterm' }, [], false).isColorSupported, false)
+  })
+
+  test('disables colors on dumb terminal', () => {
+    is(load({ TERM: 'dumb' }, [], true).isColorSupported, false)
+  })
+}
+
+test('degrades to plain text without util.styleText', () => {
+  let styleText = util.styleText
+  delete util.styleText
+  try {
+    let colors = load({ FORCE_COLOR: '1' })
+    is(colors.isColorSupported, false)
+    is(colors.createColor('bold', 'red')('x'), 'x')
+  } finally {
+    util.styleText = styleText
+  }
+})
+
+test.run()

--- a/test/css-syntax-error.test.ts
+++ b/test/css-syntax-error.test.ts
@@ -1,17 +1,23 @@
 import Concat from 'concat-with-sourcemaps'
 import { join, resolve as pathResolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import * as pico from 'picocolors'
 import stripAnsi = require('strip-ansi')
 import { test } from 'uvu'
 import { equal, is, match, type } from 'uvu/assert'
 
+import { createColor } from '../lib/colors.js'
 import postcss, {
   CssSyntaxError,
   Plugin,
   ProcessOptions,
   Rule
 } from '../lib/postcss.js'
+
+let cyan = createColor('cyan')
+let gray = createColor('gray')
+let magenta = createColor('magenta')
+let mark = createColor('bold', 'red')
+let yellow = createColor('yellow')
 
 function isSyntaxError(e: unknown): e is CssSyntaxError {
   return e instanceof Error && e.name === 'CssSyntaxError'
@@ -149,19 +155,19 @@ test('saves source with ranges', () => {
 test('highlights broken line with colors', () => {
   is(
     parseError('#a .b c() {').showSourceCode(true),
-    pico.bold(pico.red('>')) +
-      pico.gray(' 1 | ') +
-      pico.magenta('#a') +
+    mark('>') +
+      gray(' 1 | ') +
+      magenta('#a') +
       ' ' +
-      pico.yellow('.b') +
+      yellow('.b') +
       ' ' +
-      pico.cyan('c') +
-      pico.cyan('()') +
+      cyan('c') +
+      cyan('()') +
       ' ' +
-      pico.yellow('{') +
+      yellow('{') +
       '\n ' +
-      pico.gray('   | ') +
-      pico.bold(pico.red('^'))
+      gray('   | ') +
+      mark('^')
   )
 })
 
@@ -232,27 +238,27 @@ test('highlight cut minified css with colors', () => {
     '.d{position:absolute!important;clip:rect(1px,1px,1px,1px);}'
   is(
     parseError(css).showSourceCode(true),
-    pico.bold(pico.red('>')) +
-      pico.gray(' 1 | ') +
+    mark('>') +
+      gray(' 1 | ') +
       ',1px' +
-      pico.cyan(')') +
-      pico.yellow(';') +
-      pico.yellow('}') +
-      pico.yellow('.b') +
-      pico.yellow('{') +
+      cyan(')') +
+      yellow(';') +
+      yellow('}') +
+      yellow('.b') +
+      yellow('{') +
       'border' +
-      pico.yellow(':') +
+      yellow(':') +
       '0' +
-      pico.yellow(';') +
+      yellow(';') +
       'background' +
-      pico.yellow(';') +
+      yellow(';') +
       'text-decoration' +
-      pico.yellow(':') +
+      yellow(':') +
       'none' +
       '\n ' +
-      pico.gray('   | ') +
+      gray('   | ') +
       '                   ' +
-      pico.bold(pico.red('^'))
+      mark('^')
   )
 })
 


### PR DESCRIPTION
Fixes #2116

`picocolors` was only there to color terminal output, and `node:util` does the
same job, so this drops it from `dependencies`. New `lib/colors.js` exports a
`createColor(...formats)` factory plus an `isColorSupported` flag, modelled on
the `colors.js` in size-limit; the three call sites keep their `text => string`
shape, so `HIGHLIGHT_THEME` and `showSourceCode()` are unchanged in structure.

Rather than eyeball the output, I diffed it against picocolors byte for byte —
old and new `showSourceCode()` and `showSourceCode(true)` are identical across
9 environments (piped, `FORCE_COLOR`, `NO_COLOR`, `CI`, `TERM=dumb`, `--color`,
and the empty-string variants of each). The empty-string cases are why the
detector uses truthiness rather than presence: `NO_COLOR=""` must not disable
color, per no-color.org and picocolors.

Two details worth flagging, both of which changed the code:

- `styleText` accepts an **array** of formats only since **20.13**, not 20.12.
  On 20.12.x, `createColor('bold', 'red')` throws `ERR_INVALID_ARG_VALUE` —
  while formatting a syntax error, which is the worst possible moment. So the
  guard is a feature detect, not a version check.
- `./lib/terminal-highlight` is a published entry in `exports`, and its old
  `pico.yellow` values were no-ops when color was unsupported. The theme is
  gated on `isColorSupported` so direct importers keep that contract.

`size-limit` drops 16.38 kB → 16.18 kB, so I lowered the budget to 16.25 kB.
New `test/colors.test.ts` covers the detection signals and the degrade path;
I checked it is not vacuous by breaking the code four ways and confirming a
specific test goes red each time.

### One thing I need you to decide

This is the conservative version: on Node < 20.13 the module degrades to plain
text, the color assertions degrade with it, every CI leg stays green, and
`engines` is untouched. The cost is a real regression — **error output loses
its color on Node 14, 16, 18 and 20.0–20.12**, where picocolors colored fine.
It degrades silently rather than throwing.

If 9.0 is bumping the Node floor anyway, the other version is smaller and
cleaner: `engines` → `>=20.13`, prune the `old` matrix to 20, and delete the
fallback branch entirely. I did not want to make that call on your behalf.
Say which you prefer and I will rewrite this.
