### PR TITLE
Drop whitespace-only values from list.space()

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -42,7 +42,8 @@ let list = {
       }
 
       if (split) {
-        if (last || current !== '') array.push(current.trim())
+        let value = current.trim()
+        if (last || value !== '') array.push(value)
         current = ''
         split = false
       } else {
@@ -50,7 +51,8 @@ let list = {
       }
     }
 
-    if (last || current !== '') array.push(current.trim())
+    let value = current.trim()
+    if (last || value !== '') array.push(value)
     return array
   }
 }

--- a/test/list.test.ts
+++ b/test/list.test.ts
@@ -27,6 +27,18 @@ test('space() does not split on escaped spaces', () => {
   equal(list.space('a\\ b'), ['a\\ b'])
 })
 
+test('space() ignores whitespace it does not split on', () => {
+  equal(list.space('\r'), [])
+})
+
+test('space() does not add empty values around CRLF line breaks', () => {
+  equal(list.space('"a b"\r\n\r\n"c d"'), ['"a b"', '"c d"'])
+})
+
+test('space() gives the same result for LF and CRLF', () => {
+  equal(list.space('a\r\n\r\nb'), list.space('a\n\nb'))
+})
+
 test('space() works from variable', () => {
   let space = list.space
   equal(space('a b'), ['a', 'b'])


### PR DESCRIPTION
`list.space()` can return an empty string, which is never a real value.

```js
list.space('\r')                    // ['']                  expected []
list.space('"a b"\r\n\r\n"c d"')    // ['"a b"', '', '"c d"'] expected ['"a b"', '"c d"']
```

`list.split()` checks `current !== ''` before it trims, so the check is looking at a different string from the one it pushes. A chunk made only of whitespace that isn't one of the separators is not empty, so it passes the check, and then `trim()` turns it into `''` on the way into the array.

`space()` splits on `' '`, `'\n'` and `'\t'`, so a `\r` is exactly such a chunk. That makes the result depend on line endings: the same stylesheet gives different values on CRLF than it does on LF.

```css
a {
  grid-template-areas:
    "a b"

    "c d";
}
```

Saved with LF, `list.space(decl.value)` gives two values. Saved with CRLF, it gives three, and the middle one is empty.

This is the other half of #2134. That one was about `comma()` dropping empty values it should keep; the note there was that whitespace hides the problem because `' '` survives the emptiness check and is trimmed afterwards. The same untrimmed check leaks a value here instead of dropping one, so trimming before the check settles both directions.

`comma()` passes `last = true` and short-circuits ahead of the emptiness check, so nothing about it changes, including `list.comma('a,,b')` and `list.comma('a, ,b')` still matching.

Three assertions added; all three fail on `main` and pass here. Full `pnpm unit` is green at 699 tests, plus eslint and check-dts.
