### PR TITLE
Add typed plugin creator helper

### DIFF
--- a/docs/writing-a-plugin.md
+++ b/docs/writing-a-plugin.md
@@ -103,24 +103,23 @@ plugin.postcss = true
 export default plugin
 ```
 
-In TypeScript, type the creator as `PluginCreator` so `postcss = true` is valid:
+In TypeScript, use the `plugin` helper to mark and type the creator:
 
 ```ts
-import type { PluginCreator } from 'postcss'
+import { plugin } from 'postcss'
 
 export interface PluginNameOptions {
   // Types for plugin options
 }
 
-const plugin: PluginCreator<PluginNameOptions> = (opts = {}) => {
+const pluginName = plugin<PluginNameOptions>((opts = {}) => {
   return {
     postcssPlugin: 'PLUGIN NAME'
     // Plugin listeners
   }
-}
-plugin.postcss = true
+})
 
-export default plugin
+export default pluginName
 ```
 
 [PostCSS plugin boilerplate]: https://github.com/postcss/postcss-plugin-boilerplate/

--- a/lib/postcss.d.mts
+++ b/lib/postcss.d.mts
@@ -37,7 +37,6 @@ export {
   OldPlugin,
   parse,
   Parser,
-  // @ts-expect-error This value exists, but it’s untyped.
   plugin,
   Plugin,
   PluginCreator,

--- a/lib/postcss.d.ts
+++ b/lib/postcss.d.ts
@@ -197,10 +197,36 @@ declare namespace postcss {
     prepare?: (result: Result) => Processors
   }
 
-  export interface PluginCreator<PluginOptions> {
-    (opts?: PluginOptions): Plugin | Processor
+  export interface PluginCreator<
+    PluginOptions,
+    PluginResult extends Plugin | Processor = Plugin | Processor
+  > {
+    (opts?: PluginOptions): PluginResult
     postcss: true
   }
+
+  /**
+   * Marks a function as a PostCSS plugin creator.
+   *
+   * @param creator Function that creates a PostCSS plugin.
+   * @return The same function marked as a PostCSS plugin creator.
+   */
+  export function plugin<
+    PluginOptions,
+    PluginResult extends Plugin | Processor = Plugin | Processor
+  >(
+    creator: (opts?: PluginOptions) => PluginResult
+  ): PluginCreator<PluginOptions, PluginResult>
+
+  /**
+   * Creates a PostCSS 7 compatible plugin.
+   *
+   * Deprecated. Use the one-argument plugin creator helper instead.
+   */
+  export function plugin<PluginOptions>(
+    name: string,
+    initializer: (opts?: PluginOptions) => TransformCallback
+  ): OldPlugin<PluginOptions>
 
   export interface Transformer extends TransformCallback {
     postcssPlugin: string

--- a/lib/postcss.js
+++ b/lib/postcss.js
@@ -27,6 +27,11 @@ function postcss(...plugins) {
 }
 
 postcss.plugin = function plugin(name, initializer) {
+  if (typeof name === 'function') {
+    name.postcss = true
+    return name
+  }
+
   let warningPrinted = false
   function creator(...args) {
     // eslint-disable-next-line no-console

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -3,7 +3,11 @@ import { test } from 'uvu'
 import { equal, is, match, throws, type } from 'uvu/assert'
 
 import postcss = require('../lib/postcss.js')
-import postcssDefault, { PluginCreator, Root } from '../lib/postcss.js'
+import postcssDefault, {
+  plugin as createPlugin,
+  PluginCreator,
+  Root
+} from '../lib/postcss.js'
 import Processor from '../lib/processor.js'
 
 test.after.each(() => {
@@ -48,6 +52,14 @@ test('takes plugins from a a plugin returning a processor', () => {
   let meta = (() => other) as PluginCreator<void>
   meta.postcss = true
   equal(postcss([other, c]).plugins, [a, b, c])
+})
+
+test('marks modern plugin creators', () => {
+  let creator = createPlugin(() => ({ postcssPlugin: 'test' }))
+
+  is(createPlugin, postcss.plugin)
+  is(creator.postcss, true)
+  is(creator().postcssPlugin, 'test')
 })
 
 test('contains parser', () => {

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,4 +1,8 @@
-import postcss, { Document, PluginCreator } from '../lib/postcss.js'
+import postcss, {
+  plugin as createPlugin,
+  Document,
+  PluginCreator
+} from '../lib/postcss.js'
 import { RootRaws } from '../lib/root.js'
 
 const plugin: PluginCreator<string> = prop => {
@@ -15,7 +19,16 @@ const plugin: PluginCreator<string> = prop => {
 
 plugin.postcss = true
 
-postcss([plugin])
+const createdPlugin = createPlugin<{ prop?: string }>((opts = {}) => {
+  return {
+    Declaration(decl) {
+      if (decl.prop === opts.prop) decl.remove()
+    },
+    postcssPlugin: 'created-plugin'
+  }
+})
+
+postcss([plugin, createdPlugin])
   .process('h1{color: black;}', {
     from: undefined
   })


### PR DESCRIPTION
## Summary

- add a one-argument `postcss.plugin(creator)` helper that marks and returns the same plugin creator function
- preserve the deprecated two-argument `postcss.plugin(name, initializer)` behavior and add declarations for both overloads
- preserve the creator’s concrete plugin/processor return type in TypeScript
- document the helper and cover its runtime, named-export, and declaration behavior

Fixes #2102

## Validation

- `env -u NO_COLOR pnpm test` — 700/700 unit tests, integration, lint, declarations, version, coverage, and size checks pass
- ESM named-export smoke test using `lib/postcss.mjs`
- bundled size remains below the 16.5 kB limit at 16.44 kB

## AI disclosure

This contribution was made with OpenAI Codex assistance. Codex inspected PostCSS’s current plugin normalization, legacy creator API, TypeScript declarations, ESM exports, documentation, and 9.0 milestone; implemented the backward-compatible overload; and ran the validation above. The API reasoning was to reuse the already-exported `plugin` entry point with a one-argument modern form rather than introduce another public helper name.