### PR TITLE
Preserve comments in values and at-rule params

### DIFF
--- a/docs/writing-a-plugin.md
+++ b/docs/writing-a-plugin.md
@@ -141,8 +141,8 @@ PostCSS parses CSS to the tree of nodes (we call it AST). This tree may content:
   or `@media (screen) {}`.
 - [`Rule`]: selector with declaration inside. For instance `input, button {}`.
 - [`Declaration`]: key-value pair like `color: black`;
-- [`Comment`]: stand-alone comment. Comments inside selectors, at-rule
-  parameters and values are stored in node’s `raws` property.
+- [`Comment`]: stand-alone comment. Comments inside at-rule parameters
+  and declaration values remain part of the corresponding string.
 
 You can use [AST Explorer](https://astexplorer.net/#/2uBU1BLuJ1) to learn
 how PostCSS convert different CSS to AST.

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -502,7 +502,7 @@ class Parser {
       type = token[0]
       if (type === 'space' && i === length - 1 && !customProperty) {
         clean = false
-      } else if (type === 'comment') {
+      } else if (type === 'comment' && prop === 'selector') {
         prev = tokens[i - 1] ? tokens[i - 1][0] : 'empty'
         next = tokens[i + 1] ? tokens[i + 1][0] : 'empty'
         if (!SAFE_COMMENT_NEIGHBOR[prev] && !SAFE_COMMENT_NEIGHBOR[next]) {

--- a/test/at-rule.test.ts
+++ b/test/at-rule.test.ts
@@ -54,4 +54,16 @@ test('at-rule without body has no nodes property', () => {
   type(layer.nodes, 'undefined')
 })
 
+test('keeps comments in params after changes', () => {
+  let root = parse('@media screen /* keep */ and (color){}')
+  let media = root.first as AtRule
+
+  is(media.params, 'screen /* keep */ and (color)')
+  media.params += ' and (width > 1px)'
+  is(
+    media.toString(),
+    '@media screen /* keep */ and (color) and (width > 1px){}'
+  )
+})
+
 test.run()

--- a/test/declaration.test.ts
+++ b/test/declaration.test.ts
@@ -45,4 +45,14 @@ test('detects variable declarations', () => {
   is(decl.variable, false)
 })
 
+test('keeps comments in values after changes', () => {
+  let root = parse('a{border:1px /* keep */ solid}')
+  let rule = root.first as Rule
+  let decl = rule.first as Declaration
+
+  is(decl.value, '1px /* keep */ solid')
+  decl.value += ' red'
+  is(decl.toString(), 'border:1px /* keep */ solid red')
+})
+
 test.run()

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -13,6 +13,34 @@ import {
   Rule
 } from '../lib/postcss.js'
 
+function keepCommentsInValues(node: any): void {
+  let prop
+  if (node.type === 'atrule') {
+    prop = 'params'
+  } else if (node.type === 'decl') {
+    prop = 'value'
+  }
+
+  if (prop) {
+    let raw = node.raws?.[prop]
+    if (raw && typeof raw === 'object' && raw.raw.includes('/*')) {
+      let keepTrailing = node.type === 'decl' && node.prop.startsWith('--')
+      let value = keepTrailing ? raw.raw : raw.raw.replace(/\s+$/, '')
+
+      node[prop] = value
+      if (value === raw.raw) {
+        delete node.raws[prop]
+      } else {
+        raw.value = value
+      }
+    }
+  }
+
+  if (node.nodes) {
+    for (let child of node.nodes) keepCommentsInValues(child)
+  }
+}
+
 test('works with file reads', () => {
   let stream = readFileSync(testPath('atrule-empty.css'))
   is(parse(stream) instanceof Root, true)
@@ -21,6 +49,8 @@ test('works with file reads', () => {
 eachTest((name, css, json) => {
   test(`parses ${name}`, () => {
     css = css.replace(/\r\n/g, '\n')
+    // postcss-parser-tests 8 snapshots use the pre-9.0 comment cleaning.
+    keepCommentsInValues(json)
     let parsed = jsonify(parse(css, { from: name }))
     equal(parsed, json)
   })

--- a/test/rule.test.ts
+++ b/test/rule.test.ts
@@ -93,4 +93,13 @@ test('uses different spaces for empty rules', () => {
   is(root.toString(), 'a{}\nb{\n a:1\n}\nem{\n top:0\n}')
 })
 
+test('keeps existing comment cleaning in selectors', () => {
+  let root = parse('a,/**/b{}')
+  let rule = root.first as Rule
+
+  is(rule.selector, 'a,b')
+  rule.selector += ',c'
+  is(rule.toString(), 'a,b,c{}')
+})
+
 test.run()


### PR DESCRIPTION
## Summary

- keep comment tokens directly in `Declaration#value` and `AtRule#params` so changing either property no longer discards embedded comments
- retain the existing selector comment-cleaning behavior
- adapt the shared PostCSS 8 parser fixture expectations to the planned 9.0 semantics
- update the AST documentation and add mutation regressions for declarations, at-rules, and selectors

Fixes #1706

## Validation

- `env -u NO_COLOR pnpm test`
- 702/702 unit tests pass with 100% line coverage
- integration, TypeScript declarations, lint, version, and size checks pass
- bundled size remains below the 16.5 kB limit at 16.37 kB

## AI disclosure

This contribution was made with OpenAI Codex assistance. Codex reproduced comment loss on current `main`, traced it to `Parser#raw`, limited the behavior change to declaration values and at-rule params, added PostCSS 9 fixture adaptation and regression coverage, and ran the complete validation above. The selector path was explicitly kept unchanged after reviewing the shared parser boundary.