### PR TITLE
Fix chinese print not work

### DIFF
--- a/lib/postcss.js
+++ b/lib/postcss.js
@@ -38,7 +38,7 @@ postcss.plugin = function plugin(name, initializer) {
           ': postcss.plugin was deprecated. Migration guide:\n' +
           'https://evilmartians.com/chronicles/postcss-8-plugin-migration'
       )
-      if (process.env.LANG && process.env.LANG.startsWith('cn')) {
+      if (process.env.LANG && process.env.LANG.startsWith('zh')) {
         /* c8 ignore next 7 */
         // eslint-disable-next-line no-console
         console.warn(


### PR DESCRIPTION
The language code for Chinese is `zh`, while `cn` is an ISO country code (referred to as territory in POSIX). According to the [POSIX specification](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html#tag_08_02), the format of the LANG environment variable is `language[_territory][.codeset][@modifier]`. Since LANG starts with language, we should check whether it is `zh`.
<img width="670" height="270" alt="image" src="https://github.com/user-attachments/assets/b451231a-9380-4d86-9eec-1f4f536a657b" />

