### PR TITLE
Keep non-annotation comments when the processor has no plugins

### DIFF
--- a/lib/map-generator.js
+++ b/lib/map-generator.js
@@ -75,9 +75,10 @@ class MapGenerator {
         }
       }
     } else if (this.css) {
+      let annotation = '/*# sourceMappingURL='
       let startIndex
-      while ((startIndex = this.css.lastIndexOf('/*#')) !== -1) {
-        let endIndex = this.css.indexOf('*/', startIndex + 3)
+      while ((startIndex = this.css.lastIndexOf(annotation)) !== -1) {
+        let endIndex = this.css.indexOf('*/', startIndex + annotation.length)
         if (endIndex === -1) break
         while (startIndex > 0 && this.css[startIndex - 1] === '\n') {
           startIndex--

--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -693,6 +693,20 @@ test('generates correct inline map and multiple comments', () => {
   match(result.css, /a {}\nb {}\n\/\*# sourceMappingURL=/)
 })
 
+test('keeps non-annotation comments with empty processor', () => {
+  let css = '/*#region layout */\na {}\n/*#endregion */\n'
+  let result = postcss().process(css, { from: undefined })
+
+  is(result.css, css)
+})
+
+test('clears the annotation but keeps other comments after it', () => {
+  let css = 'a {}\n/*# sourceMappingURL=a.css.map */\n/*#endregion */\n'
+  let result = postcss().process(css, { from: undefined })
+
+  is(result.css, 'a {}\n/*#endregion */\n')
+})
+
 test('generates correct sources with empty processor', () => {
   let result = postcss().process('a {} /*hello world*/', {
     from: 'a.css',


### PR DESCRIPTION
With no plugins, `process()` deletes every comment beginning with `/*#` — including the `/*#region */` / `/*#endregion */` folding markers editors use.

```js
let css = "/*#region layout */\na{color:red}\n/*#endregion */\n"
postcss([]).process(css, { from: undefined }).css
// "\na{color:red}\n"
postcss([() => {}]).process(css, { from: undefined }).css
// unchanged
```

This happens with `map` unset too: `NoWorkResult` always calls `clearAnnotation()`.

`clearAnnotation()` has two implementations. The AST one removes only comments whose text starts with `# sourceMappingURL=`, and `PreviousMap#loadAnnotation` finds annotations by that marker. The string one — the only path `NoWorkResult` takes — searched for `/*#` alone.

Searching for the whole `/*# sourceMappingURL=` marker keeps the plain string scan, so 497daef7's move off RegExp stands. The old RegExp had the same gap, anchored to end of line.

Two tests added. Reverting `lib/map-generator.js` fails both. A narrower fix keeping the `/*#` needle and stopping at the first non-annotation still fails the second, where the stray comment follows the annotation.

`pnpm test` green: 701/701 unit (699 before), types, size, integration, lint (one pre-existing warning in `visitor.test.ts`).

Unchanged and disclosed: the string path still leaves `/* # sourceMappingURL=… */` (space after `/*`) and appends a second annotation, where the AST path clears it.

Drafted with Claude Opus 5 (`claude-opus-5`); every claim was executed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-map annotation cleanup so regular comments are preserved.
  * Ensured comments following source-map annotations remain intact when no source path is provided.

* **Tests**
  * Added coverage for preserving non-annotation comments and correctly removing source-map annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->